### PR TITLE
Keep classes to the right

### DIFF
--- a/R/gg_rfsrc.R
+++ b/R/gg_rfsrc.R
@@ -299,7 +299,7 @@ gg_rfsrc.rfsrc <- function(object,
     stop(paste("Plotting for ", object$family, " randomForestSRC is not yet implemented.", sep=""))
   }
   
-  class(gg_dta) <- c("gg_rfsrc", class(gg_dta), object$family)
+  class(gg_dta) <- c("gg_rfsrc", object$family, class(gg_dta))
   invisible(gg_dta)
 }
 
@@ -444,7 +444,7 @@ gg_rfsrc.randomForest <- function(object,
     stop(paste("Plotting for ", object$family, " randomForest is not yet implemented.", sep=""))
   }
   
-  class(gg_dta) <- c("gg_rfsrc", class(gg_dta), object$type)
+  class(gg_dta) <- c("gg_rfsrc", object$type, class(gg_dta))
   invisible(gg_dta)
 }
 


### PR DESCRIPTION
related to #33 

This does not fix all issues we see of this package against `dplyr` 1.0.0, but it's a start. The idea is that the `data.frame` class should be the last class, otherwise some things in `vctrs` won't work. 

There might be other places, but those are the ones that were identified by the test cases. 