### PR TITLE
fix: map randomForest 'classification' type to 'class' in gg_variable class attr

### DIFF
--- a/R/gg_variable.R
+++ b/R/gg_variable.R
@@ -313,7 +313,12 @@ gg_variable.randomForest <- function(object,
     gg_dta$yvar <- response
   }
 
-  class(gg_dta) <- c("gg_variable", object$type, class(gg_dta))
+  # randomForest uses object$type ("classification" / "regression"); the
+  # plot.gg_variable dispatcher and the rfsrc path both use "class" for
+  # classification forests.  Map here so the class attribute is consistent
+  # and callers never need to special-case "classification".
+  family_lbl <- if (object$type == "classification") "class" else object$type
+  class(gg_dta) <- c("gg_variable", family_lbl, class(gg_dta))
   gg_dta <- .set_provenance(gg_dta, object)
   invisible(gg_dta)
 }

--- a/tests/testthat/test_gg_variable.R
+++ b/tests/testthat/test_gg_variable.R
@@ -355,3 +355,16 @@ test_that("plot.gg_variable: missing xvar returns list for all predictors", {
   # Returns a single plottable object (patchwork composite for multiple predictors)
   expect_true(inherits(gg_plt, "patchwork") || inherits(gg_plt, "ggplot"))
 })
+
+test_that("gg_variable.randomForest classification: class attr uses 'class' not 'classification'", {
+  # randomForest stores the family in $type as "classification", but
+  # plot.gg_variable and the rfsrc path both dispatch on "class".
+  # Verify the mapping is applied so callers see a consistent class attribute.
+  set.seed(42)
+  rf_iris <- randomForest::randomForest(Species ~ ., data = iris, ntree = 50L)
+  gg_dta  <- gg_variable(rf_iris)
+
+  expect_true("class"          %in% class(gg_dta))
+  expect_false("classification" %in% class(gg_dta))
+  expect_s3_class(gg_dta, "gg_variable")
+})


### PR DESCRIPTION
## Summary

- `gg_variable.randomForest()` appended `object$type` (`"classification"`) to the class vector of the result, but `plot.gg_variable`'s dispatcher and the rfsrc path both use `"class"` to identify classification forests
- This was accidentally correct (the dispatcher fell through to the `"class"` default), but fragile — any `inherits(gg_dta, "class")` check would silently fail
- Maps `"classification"` → `"class"` at the point of assignment with an explanatory comment; all other `object$type` values pass through unchanged

## Test plan

- [ ] New test: `"class" %in% class(gg_variable(rf_iris))` is `TRUE`
- [ ] New test: `"classification" %in% class(gg_variable(rf_iris))` is `FALSE`
- [ ] Full `test_gg_variable.R` suite passes (42 tests)

## Notes

Depends on nothing; safe to merge before or after PR #87/#88.  The real-world impact is minimal today (dispatcher falls through to the same default) but the explicit mapping removes a latent surprise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)