### PR TITLE
docs: voice audit — rewrite AI-written documentation in John's voice

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,7 +13,7 @@ ggRandomForests v2.8.0 (development) — continued
     `"facet"` gives each class its own panel.
   - `summary.gg_roc()` prints the named per-class AUC values when a `class`
     column is present.
-  - On a binary forest, `per_class = TRUE` does nothing — the usual
+  - On a binary forest, `per_class = TRUE` does nothing, the usual
     single-curve result comes back unchanged.
   - ROC confidence intervals are still to come, in v2.9.0 (issue #7 / #72-CIs).
 * New `gg_udependent()`: varPro cross-variable dependency (Phase 3).
@@ -35,7 +35,7 @@ ggRandomForests v2.8.0 (development) — continued
     z above `cutoff` (default 0.79) are colour-highlighted.
   - With `faithful = TRUE`, the individual per-tree z-scores are jittered
     over the box as semi-transparent points, with a white-outlined dot at
-    the mean — the same view as varPro's internal `bxp` output.
+    the mean, the same view as varPro's internal `bxp` output.
   - With `conditional = TRUE` (classification forests only), `gg_varpro()`
     reads `$conditional.z` and draws class-conditional importance as a
     `facet_wrap(~class, nrow=1)` bar chart.
@@ -47,7 +47,7 @@ ggRandomForests v2.8.0 (development)
 * `gg_variable.randomForest`: classification fix (#87).
   - For a classification forest, `gg_variable.randomForest()` now stores
     per-class OOB vote fractions as `yhat.<classname>` columns, read from
-    `object$votes` — the same layout the `rfsrc` path produces. It used to
+    `object$votes`, the same layout the `rfsrc` path produces. It used to
     store a single `yhat` factor column of class labels (from
     `object$predicted`), and that column shape stopped the multi-class
     pivot in `plot.gg_variable` from ever running. The vote fractions are
@@ -61,7 +61,7 @@ ggRandomForests v2.8.0 (development)
 * New `gg_partial_varpro()`: varPro partial dependence (#84).
   - `gg_partial_varpro()` takes over from `gg_partialpro()` as the entry
     point for varPro partial dependence plots. It accepts an optional
-    `object` argument — the originating `varpro` fit — which it uses for
+    `object` argument (the originating `varpro` fit) which it uses for
     provenance-aware axis labels, and a `scale` argument
     (`"auto"`, `"mortality"`, `"rmst"`, `"surv"`, `"chf"`).
   - Ensemble mortality labelling (Ishwaran et al. 2008): with
@@ -86,7 +86,7 @@ ggRandomForests v2.8.0 (development)
     `xvar`, which broke `patchwork` / `autoplot()` / `layer_data()`
     composition (#80).
   - `gg_roc()` and `calc_roc()` for `randomForest` now build the ROC from
-    class probabilities — OOB votes by default, honouring `oob` — rather
+    class probabilities (OOB votes by default, honouring `oob`) rather
     than the degenerate three-point curve they produced before. With
     `which_outcome = "all"` (the default for `gg_roc(rf)`) the result is a
     macro-averaged one-vs-rest ROC, and no warning. The shared
@@ -100,7 +100,7 @@ ggRandomForests v2.8.0 (development)
   `randomForest` on the search path. A script that called `rfsrc()` or
   `randomForest()` unqualified after only `library(ggRandomForests)` now
   needs its own `library(randomForestSRC)` / `library(randomForest)`, or
-  must qualify the calls. ggRandomForests itself is unaffected — it
+  must qualify the calls. ggRandomForests itself is unaffected. It
   qualifies every call into its dependencies.
 
 ggRandomForests v2.7.3

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,104 +3,105 @@ Version: 2.7.3.9006
 
 ggRandomForests v2.8.0 (development) — continued
 =================================================
-* **`gg_roc`: per-class one-vs-rest ROC curves (#88, closes #72).**
-  - `gg_roc()` gains a `per_class = FALSE` argument.  When `per_class = TRUE`
-    and the forest has more than two classes, returns a long-format `gg_roc`
-    data frame with a `class` factor column and a named AUC vector attribute
-    (one entry per class, ordered by descending AUC).
-  - `plot.gg_roc()` gains a `panel = c("overlay", "facet")` argument.  When the
-    `gg_roc` object contains a `class` column, the overlay path colours curves
-    by class; the facet path wraps each class into its own panel.
-  - `summary.gg_roc()` now prints named per-class AUC values when the `class`
+* `gg_roc()`: per-class one-vs-rest ROC curves (#88, closes #72).
+  - New `per_class` argument, default `FALSE`. With `per_class = TRUE` on a
+    forest of more than two classes, `gg_roc()` returns a long-format
+    `gg_roc` data frame with a `class` factor column, plus a named AUC
+    vector attribute with one entry per class, ordered by descending AUC.
+  - `plot.gg_roc()` gains `panel = c("overlay", "facet")`. When the object
+    has a `class` column, `"overlay"` colours the curves by class and
+    `"facet"` gives each class its own panel.
+  - `summary.gg_roc()` prints the named per-class AUC values when a `class`
     column is present.
-  - Binary forests: `per_class = TRUE` is a silent no-op (single-curve result
-    returned unchanged).
-  - ROC confidence intervals are deferred to v2.9.0 (issue #7 / #72-CIs).
-* **varPro variable dependency: `gg_udependent()` (Phase 3).**
-  - `gg_udependent()` extracts cross-variable dependency scores from a
-    `uvarpro` fit using `varPro::get.beta.entropy()` +
-    `varPro::sdependent()`, and returns a tidy list with `$edges`
-    (variable_from, variable_to, weight), `$nodes` (variable, degree,
-    selected), and `$graph` (igraph object).
-  - `plot.gg_udependent()` renders the dependency network using ggraph
-    with edge width/opacity scaled by dependency strength and node colour
-    by signal-variable status.  Layout is configurable (`"fr"`, `"kk"`,
-    `"stress"`, etc.).
+  - On a binary forest, `per_class = TRUE` does nothing — the usual
+    single-curve result comes back unchanged.
+  - ROC confidence intervals are still to come, in v2.9.0 (issue #7 / #72-CIs).
+* New `gg_udependent()`: varPro cross-variable dependency (Phase 3).
+  - `gg_udependent()` reads cross-variable dependency scores off a `uvarpro`
+    fit, via `varPro::get.beta.entropy()` and `varPro::sdependent()`. It
+    returns a tidy list: `$edges` (variable_from, variable_to, weight),
+    `$nodes` (variable, degree, selected), and `$graph`, an igraph object.
+  - `plot.gg_udependent()` draws the dependency network with ggraph. Edge
+    width and opacity scale with dependency strength; node colour marks the
+    signal variables. The layout is configurable (`"fr"`, `"kk"`,
+    `"stress"`, and so on).
   - `ggraph` added to `Suggests:`.
-* **varPro variable importance: `gg_varpro()` (#85).**
-  - `gg_varpro()` extracts per-tree importance scores from a fitted
-    `varpro` object and renders an honest boxplot — hinges at the
-    15th/85th percentile, whiskers at the 5th/95th — of the per-tree
-    z-score distribution per variable.  Variables whose aggregate
-    z > `cutoff` (default 0.79) are colour-highlighted.
-  - `faithful = TRUE` overlays individual per-tree z-scores as jittered
-    semi-transparent points with a white-outlined mean dot, reproducing
-    the distributional view from varPro's internal `bxp` output.
-  - `conditional = TRUE` (classification forests only) extracts
-    `$conditional.z` and renders class-conditional importance as a
+* New `gg_varpro()`: varPro variable importance (#85).
+  - `gg_varpro()` pulls per-tree importance scores from a fitted `varpro`
+    object and draws a boxplot of the per-tree z-score distribution for each
+    variable. The hinges sit at the 15th and 85th percentiles and the
+    whiskers at the 5th and 95th, so the box is not the usual Tukey one —
+    it reports the percentiles it actually shows. Variables with aggregate
+    z above `cutoff` (default 0.79) are colour-highlighted.
+  - With `faithful = TRUE`, the individual per-tree z-scores are jittered
+    over the box as semi-transparent points, with a white-outlined dot at
+    the mean — the same view as varPro's internal `bxp` output.
+  - With `conditional = TRUE` (classification forests only), `gg_varpro()`
+    reads `$conditional.z` and draws class-conditional importance as a
     `facet_wrap(~class, nrow=1)` bar chart.
-  - `local.std = FALSE` enables `plot(..., type = "raw")` to display
-    raw per-tree importance instead of z-normalised values.
+  - Set `local.std = FALSE` to allow `plot(..., type = "raw")`, which shows
+    raw per-tree importance instead of the z-normalised values.
 
 ggRandomForests v2.8.0 (development)
 ====================================
-* **`gg_variable.randomForest` classification fix (#87).**
-  - `gg_variable.randomForest()` for classification forests now stores
-    per-class OOB vote fractions as `yhat.<classname>` columns (from
-    `object$votes`), matching the `rfsrc` path.  Previously a single
-    `yhat` factor column (class labels from `object$predicted`) was
-    stored, which prevented the multi-class pivot in `plot.gg_variable`
-    from firing.  Vote fractions are row-normalised to `[0, 1]` even
-    when the forest was fit with `norm.votes = FALSE`.
-  - `plot.gg_variable` binary classification: `smooth = TRUE` now
-    correctly maps x/y aesthetics onto the smooth layer.
-  - `plot.gg_variable` multi-class numeric path: `smooth = TRUE` now
-    adds a smooth layer (was silently skipped).
+* `gg_variable.randomForest`: classification fix (#87).
+  - For a classification forest, `gg_variable.randomForest()` now stores
+    per-class OOB vote fractions as `yhat.<classname>` columns, read from
+    `object$votes` — the same layout the `rfsrc` path produces. It used to
+    store a single `yhat` factor column of class labels (from
+    `object$predicted`), and that column shape stopped the multi-class
+    pivot in `plot.gg_variable` from ever running. The vote fractions are
+    row-normalised to `[0, 1]`, even when the forest was fit with
+    `norm.votes = FALSE`.
+  - `plot.gg_variable`, binary classification: with `smooth = TRUE` the
+    x and y aesthetics are now mapped onto the smooth layer correctly.
+  - `plot.gg_variable`, multi-class numeric path: `smooth = TRUE` now adds
+    the smooth layer instead of skipping it silently.
   - Closes stale issues #81 (fixed in PR #83) and #82.
-* **varPro partial dependence: `gg_partial_varpro()` (#84).**
-  - `gg_partial_varpro()` replaces `gg_partialpro()` as the primary entry
-    point for varPro partial dependence plots.  The new extractor accepts
-    an optional `object` argument (the originating `varpro` fit) for
-    provenance-aware axis labeling and a `scale` argument
+* New `gg_partial_varpro()`: varPro partial dependence (#84).
+  - `gg_partial_varpro()` takes over from `gg_partialpro()` as the entry
+    point for varPro partial dependence plots. It accepts an optional
+    `object` argument — the originating `varpro` fit — which it uses for
+    provenance-aware axis labels, and a `scale` argument
     (`"auto"`, `"mortality"`, `"rmst"`, `"surv"`, `"chf"`).
-  - **Ensemble mortality labeling** (Ishwaran et al. 2008): when
-    `scale = "mortality"` (or `scale = "auto"` with a survival forest),
-    the y-axis is labeled "Ensemble mortality (expected events)" — an
-    unbounded relative-risk score, not a survival probability.  The
-    documentation explicitly warns against misinterpretation.
-  - **Survival path C:** `scale = "surv"` or `scale = "chf"` extracts
-    `object$rf` (the embedded rfsrc forest) and returns true S(t)/CHF
-    partial curves via `gg_partial_rfsrc` infrastructure.
+  - Ensemble mortality labelling (Ishwaran et al. 2008): with
+    `scale = "mortality"`, or `scale = "auto"` on a survival forest, the
+    y-axis reads "Ensemble mortality (expected events)". That is an
+    unbounded relative-risk score, not a survival probability, and the
+    documentation says so plainly so it is not misread.
+  - Survival path C: with `scale = "surv"` or `scale = "chf"`,
+    `gg_partial_varpro()` pulls the embedded rfsrc forest from `object$rf`
+    and returns true S(t) or CHF partial curves through the existing
+    `gg_partial_rfsrc` machinery.
   - `varPro` is now a hard dependency (`Imports:`).
-  - `gg_partialpro()` is soft-deprecated: it emits a deprecation warning
-    and delegates to `gg_partial_varpro()`.  Removal is planned for the
-    release after v2.8.0.
-* **randomForest engine validation & repair (#82).** Fixes #80, #81
-  and a `plot.gg_error` label wart; adds full randomForest regression
-  coverage. See sub-items below.
+  - `gg_partialpro()` is soft-deprecated: it warns, then hands off to
+    `gg_partial_varpro()`. It will be removed in the release after v2.8.0.
+* randomForest engine validation and repair (#82). Fixes #80, #81, and a
+  `plot.gg_error` label wart, and adds full randomForest regression test
+  coverage. Details below.
   - `plot.gg_variable()` now always returns a single `ggplot` (one
-    variable) or a `patchwork` composite (multiple variables / default),
-    never a bare list — consistent with the v2.7.3 `plot.gg_partial*`
-    change. Previously a list was returned for multiple `xvar`, which
-    broke `patchwork` / `autoplot()` / `layer_data()` composition (#80).
-  - `gg_roc()` / `calc_roc()` for `randomForest` now compute a correct
-    ROC from class probabilities (OOB votes by default, honoring `oob`)
-    instead of a degenerate ~3-point curve; `which_outcome = "all"` (the
-    default for `gg_roc(rf)`) returns a macro-averaged one-vs-rest ROC
-    with no warning. The shared `.validate_which_outcome` helper and
-    `calc_roc.rfsrc` are byte-unchanged — rfsrc behavior is preserved
-    (#81).
-* **Dependency modernization (breaking for scripts that relied on
-  attachment).** `randomForestSRC` and `randomForest` moved from
-  `Depends:` to `Imports:`; `igraph`, `callr`, and `varPro` added to
-  `Suggests:` (`varPro` graduates to `Imports:` later in the v2.8.0
-  development series, with the first varPro-integration component).
-  `library(ggRandomForests)` no longer attaches
-  `randomForestSRC`/`randomForest` to the search path. User scripts
-  that called `rfsrc()`/`randomForest()` unqualified after only
-  `library(ggRandomForests)` must now also `library(randomForestSRC)`
-  / `library(randomForest)` (or qualify the calls). All ggRandomForests
-  functions are unaffected — they fully qualify their dependencies.
+    variable) or a `patchwork` composite (several variables, or the
+    default) — never a bare list. This matches the v2.7.3
+    `plot.gg_partial*` change. A list used to come back for multiple
+    `xvar`, which broke `patchwork` / `autoplot()` / `layer_data()`
+    composition (#80).
+  - `gg_roc()` and `calc_roc()` for `randomForest` now build the ROC from
+    class probabilities — OOB votes by default, honouring `oob` — rather
+    than the degenerate three-point curve they produced before. With
+    `which_outcome = "all"` (the default for `gg_roc(rf)`) the result is a
+    macro-averaged one-vs-rest ROC, and no warning. The shared
+    `.validate_which_outcome` helper and `calc_roc.rfsrc` are
+    byte-for-byte unchanged, so rfsrc behaviour is untouched (#81).
+* Dependency modernization. This breaks scripts that relied on attachment.
+  `randomForestSRC` and `randomForest` move from `Depends:` to `Imports:`;
+  `igraph`, `callr`, and `varPro` are added to `Suggests:` (`varPro` later
+  moves up to `Imports:`, with the first varPro-integration component).
+  `library(ggRandomForests)` no longer puts `randomForestSRC` or
+  `randomForest` on the search path. A script that called `rfsrc()` or
+  `randomForest()` unqualified after only `library(ggRandomForests)` now
+  needs its own `library(randomForestSRC)` / `library(randomForest)`, or
+  must qualify the calls. ggRandomForests itself is unaffected — it
+  qualifies every call into its dependencies.
 
 ggRandomForests v2.7.3
 ======================

--- a/R/autoplot_methods.R
+++ b/R/autoplot_methods.R
@@ -14,13 +14,13 @@ NULL
 
 #' \code{autoplot} methods for \pkg{ggRandomForests} data objects
 #'
-#' These methods let you use \code{ggplot2::autoplot()} on any \code{gg_*}
-#' object returned by \pkg{ggRandomForests}.  They are thin wrappers around
-#' the corresponding \code{plot.gg_*()} S3 methods, so all arguments
-#' accepted by those methods are forwarded via \code{...}.
+#' These let you call \code{ggplot2::autoplot()} on any \code{gg_*} object
+#' \pkg{ggRandomForests} returns. Each is a thin wrapper around the matching
+#' \code{plot.gg_*()} S3 method, and \code{...} passes straight through, so
+#' every argument those plot methods take is still available here.
 #'
 #' @param object A \code{gg_*} data object (see Details).
-#' @param ... Additional arguments forwarded to the underlying
+#' @param ... Additional arguments passed to the underlying
 #'   \code{plot.gg_*()} method.
 #'
 #' @return A \code{ggplot} object.

--- a/R/gg_brier.R
+++ b/R/gg_brier.R
@@ -14,18 +14,24 @@
 #'
 #' Brier score and CRPS for survival forests
 #'
-#' Extract the time-resolved Brier score and continuous ranked probability
-#' score (CRPS) for a survival forest grown with \code{randomForestSRC}. The
-#' Brier score is computed at each time on \code{object$time.interest}, both
-#' overall and stratified by mortality-risk quartile. CRPS is the running
-#' trapezoidal integral of the Brier score, normalised by elapsed time, and
-#' is computed within each quartile and overall.
+#' The Brier score asks a familiar question of any probabilistic forecast:
+#' how far did the predicted probability sit from what actually happened?
+#' For a survival forest the forecast is the predicted survival probability,
+#' and the score is computed at each event time, so the result is a curve
+#' rather than a single number -- lower is better, at every time.
 #'
-#' @details Wraps \code{\link[randomForestSRC]{get.brier.survival}} and
-#' rebuilds the quartile decomposition + running CRPS from the returned
-#' \code{brier.matx} and \code{mort} components, mirroring the computation
-#' in the internal \code{plot.survival} function of \pkg{randomForestSRC}. The Brier score uses
-#' inverse-probability-of-censoring weighting; the censoring distribution
+#' This function extracts that time-resolved Brier score for a survival
+#' forest grown with \code{randomForestSRC}, both overall and split by
+#' mortality-risk quartile. It also returns the continuous ranked
+#' probability score (CRPS), which is the Brier score integrated over time
+#' and divided by elapsed time -- a running average of the curve so far.
+#'
+#' @details This wraps \code{\link[randomForestSRC]{get.brier.survival}} and
+#' rebuilds the quartile decomposition and running CRPS from the returned
+#' \code{brier.matx} and \code{mort} components, following the computation
+#' in the internal \code{plot.survival} function of \pkg{randomForestSRC}.
+#' Right-censored data make a plain Brier score biased, so the score uses
+#' inverse-probability-of-censoring weighting. The censoring distribution
 #' is estimated either by Kaplan-Meier (\code{cens.model = "km"}, the
 #' default) or by a separate censoring forest (\code{cens.model = "rfsrc"}).
 #'

--- a/R/gg_partial_rfsrc.R
+++ b/R/gg_partial_rfsrc.R
@@ -1,24 +1,29 @@
 ##=============================================================================
 #' Partial dependence data from an rfsrc model
 #'
-#' Computes partial dependence for one or more predictors by calling
-#' \code{\link[randomForestSRC]{partial.rfsrc}} internally, then splits the
-#' results into separate data frames for continuous and categorical variables.
-#' Unlike \code{\link{gg_partial}}, no separate \code{plot.variable} call is
-#' required — supply the fitted \code{rfsrc} object directly.
+#' A partial dependence curve answers a what-if question: hold the rest of
+#' the predictors as they are, sweep one of them across its range, and watch
+#' how the forest's prediction moves.  This function builds those curves for
+#' one or more predictors by calling
+#' \code{\link[randomForestSRC]{partial.rfsrc}} for you, then splits the
+#' result into separate data frames for continuous and categorical
+#' variables.  Unlike \code{\link{gg_partial}}, there is no separate
+#' \code{plot.variable} step -- pass the fitted \code{rfsrc} object straight
+#' in.
 #'
 #' @section Survival forests and \code{partial.time}:
-#' \code{\link[randomForestSRC]{partial.rfsrc}} requires that every value in
-#' \code{partial.time} be an exact member of the model's \code{time.interest}
-#' vector (the unique observed event times stored in the fitted object).
-#' Passing arbitrary time values — even plausible ones such as \code{c(1, 3)}
-#' for a study measured in years — causes a C-level prediction error inside
-#' \code{partial.rfsrc}.
+#' \code{\link[randomForestSRC]{partial.rfsrc}} expects every value in
+#' \code{partial.time} to be an exact member of the model's
+#' \code{time.interest} vector, the unique observed event times stored in the
+#' fitted object.  Pass an arbitrary time, even a plausible one such as
+#' \code{c(1, 3)} for a study measured in years, and you get a C-level
+#' prediction error from inside \code{partial.rfsrc}.
 #'
-#' \code{gg_partial_rfsrc} handles this automatically: every element of
-#' \code{partial.time} is silently snapped to its nearest \code{time.interest}
-#' value before the call is made.  To target a specific follow-up horizon,
-#' find the closest grid point yourself and pass it explicitly:
+#' \code{gg_partial_rfsrc} takes care of this: every element of
+#' \code{partial.time} is silently snapped to its nearest
+#' \code{time.interest} value before the call.  To target a specific
+#' follow-up horizon, find the closest grid point yourself and pass it
+#' explicitly:
 #'
 #' \preformatted{
 #' ti  <- rf_model$time.interest

--- a/R/gg_partial_varpro.R
+++ b/R/gg_partial_varpro.R
@@ -1,10 +1,10 @@
 ##=============================================================================
 #' Partial dependence data from a varPro model
 #'
-#' \code{varpro::partialpro} hands back one list, with continuous and
+#' \code{varpro::partialpro} returns one list, with continuous and
 #' categorical predictors mixed together. This function splits that list into
-#' two tidy data frames, one for each kind, and works out an honest y-axis
-#' label for the plot method to use later.
+#' two tidy data frames, one for each kind, and resolves the y-axis label the
+#' plot method will use.
 #'
 #' @param part_dta Partial plot data from \code{varpro::partialpro}.  Each
 #'   element must contain \code{xvirtual}, \code{xorg}, \code{yhat.par},

--- a/R/gg_partial_varpro.R
+++ b/R/gg_partial_varpro.R
@@ -1,19 +1,21 @@
 ##=============================================================================
 #' Partial dependence data from a varPro model
 #'
-#' Splits the list returned by \code{varpro::partialpro} into separate
-#' data frames for continuous and categorical predictors, with provenance-
-#' aware y-axis labeling for downstream plot methods.
+#' \code{varpro::partialpro} hands back one list, with continuous and
+#' categorical predictors mixed together. This function splits that list into
+#' two tidy data frames, one for each kind, and works out an honest y-axis
+#' label for the plot method to use later.
 #'
 #' @param part_dta Partial plot data from \code{varpro::partialpro}.  Each
 #'   element must contain \code{xvirtual}, \code{xorg}, \code{yhat.par},
-#'   \code{yhat.nonpar}, and \code{yhat.causal}.  At least one of
-#'   \code{part_dta} or \code{object} must be supplied.
-#' @param object A fitted \code{varpro} object (the originating forest).
-#'   When supplied, used for provenance metadata and — when \code{part_dta}
-#'   is \code{NULL} — \code{varpro::partialpro(object)} is called
-#'   internally.  Required when \code{scale \%in\% c("surv","chf")}.
-#' @param scale Character; controls y-axis labeling and (for survival)
+#'   \code{yhat.nonpar}, and \code{yhat.causal}.  Supply at least one of
+#'   \code{part_dta} or \code{object}.
+#' @param object A fitted \code{varpro} object, the forest the partial data
+#'   came from.  When supplied it provides the provenance metadata, and when
+#'   \code{part_dta} is \code{NULL} it is passed to
+#'   \code{varpro::partialpro(object)} for you.  Required when
+#'   \code{scale \%in\% c("surv","chf")}.
+#' @param scale Character; sets the y-axis label and, for survival forests,
 #'   the output type.  One of \code{"auto"} (default), \code{"mortality"},
 #'   \code{"rmst"}, \code{"surv"}, or \code{"chf"}.
 #' @param time Numeric; the evaluation time point.  Required when
@@ -23,29 +25,30 @@
 #'   computation and axis labeling; if \code{NULL}, three quartile time
 #'   points from \code{time.interest} are used (see
 #'   \code{\link{gg_partial_rfsrc}}).
-#' @param nvars Integer; number of variables (list elements) to process.
-#'   Defaults to all variables in \code{part_dta}.
-#' @param cat_limit Integer; variables with
-#'   \code{length(xvirtual) <= cat_limit} are treated as categorical.
+#' @param nvars Integer; how many variables (list elements) to process.
+#'   Defaults to every variable in \code{part_dta}.
+#' @param cat_limit Integer; a variable with
+#'   \code{length(xvirtual) <= cat_limit} is treated as categorical.
 #'   Default \code{10}.
-#' @param model Character; label appended to all rows (useful when
-#'   combining results from multiple models in a single figure).
+#' @param model Character; a label tacked onto every row, handy when you are
+#'   combining results from several models in one figure.
 #'
 #' @details
-#' **Scale detection:** \code{scale = "auto"} with a supplied \code{object}
-#' resolves to \code{"mortality"} for survival forests and \code{"generic"}
-#' for regression/classification forests.  The RMST horizon \eqn{\tau} is
-#' \emph{not} stored in the \code{varpro} object (varPro 3.1.0); pass
-#' \code{scale = "rmst", time = tau} explicitly for RMST-labeled output.
+#' **Scale detection:** with \code{scale = "auto"} and an \code{object} in
+#' hand, the scale resolves to \code{"mortality"} for a survival forest and
+#' \code{"generic"} for a regression or classification forest.  The RMST
+#' horizon \eqn{\tau} is \emph{not} stored in the \code{varpro} object
+#' (varPro 3.1.0), so for RMST-labeled output you have to pass
+#' \code{scale = "rmst", time = tau} yourself.
 #'
-#' **Ensemble mortality (scale = "mortality"):** The y-axis represents
-#' \emph{ensemble mortality}: the expected number of events if the subject
-#' experienced the study-average cumulative hazard, equivalent to the
-#' \code{rfsrc} \code{predicted} value for survival forests (Ishwaran,
-#' Kogalur, Blackstone & Lauer, 2008 <doi:10.1214/08-AOAS169>).  This is
-#' an \strong{unbounded relative-risk score}---\emph{not} a survival
-#' probability or \eqn{1 - S(t)}---and must not be interpreted as one.
-#' For probability-scale output refit with
+#' **Ensemble mortality (scale = "mortality"):** here the y-axis is
+#' \emph{ensemble mortality}, the expected number of events a subject would
+#' see if they were exposed to the study-average cumulative hazard.  It is
+#' the same quantity as the \code{rfsrc} \code{predicted} value for survival
+#' forests (Ishwaran, Kogalur, Blackstone & Lauer, 2008
+#' <doi:10.1214/08-AOAS169>).  This is an \strong{unbounded relative-risk
+#' score}, \emph{not} a survival probability and not \eqn{1 - S(t)}; don't
+#' read it as one.  If you want output on the probability scale, refit with
 #' \code{varpro(..., rmst = tau)} and use \code{scale = "rmst"}.
 #'
 #' @return A named list of class \code{"gg_partial_varpro"} with elements:
@@ -53,7 +56,7 @@
 #'   \item{continuous}{data.frame with columns \code{variable},
 #'     \code{parametric}, \code{nonparametric}, \code{causal}, \code{name}
 #'     (and optionally \code{model}).}
-#'   \item{categorical}{data.frame with the same columns but one row per
+#'   \item{categorical}{data.frame with the same columns, one row per
 #'     observation per category level.}
 #' }
 #' A \code{"provenance"} attribute carries \code{source}, \code{family},

--- a/R/gg_partialpro.R
+++ b/R/gg_partialpro.R
@@ -2,9 +2,10 @@
 #' Split varpro partial dependence data into continuous or categorical datasets
 #' (deprecated)
 #'
-#' \emph{Deprecated.} \code{gg_partialpro()} has been renamed to
-#' \code{\link{gg_partial_varpro}()}.  This function is a thin alias that
-#' will be removed in the release after \pkg{ggRandomForests} v2.8.0.
+#' \emph{Deprecated.} \code{gg_partialpro()} has been superseded by
+#' \code{\link{gg_partial_varpro}()} and is now a thin alias for it.  It will
+#' be removed in the release after \pkg{ggRandomForests} v2.8.0; use
+#' \code{\link{gg_partial_varpro}()} directly.
 #'
 #' @param part_dta Passed to \code{\link{gg_partial_varpro}}.
 #' @param object Passed to \code{\link{gg_partial_varpro}}.

--- a/R/gg_roc.R
+++ b/R/gg_roc.R
@@ -14,48 +14,51 @@
 #'
 #' ROC (Receiver Operating Characteristic) curve data from a classification forest.
 #'
-#' Computes sensitivity (true positive rate) and specificity (1 - false positive
-#' rate) across all prediction thresholds for one class of a classification
+#' A classifier does not hand you a class; it hands you a predicted probability,
+#' and you pick a threshold. Slide that threshold from 0 to 1 and the trade-off
+#' between catching the positives and crying wolf shifts the whole way. The ROC
+#' curve traces that trade-off. For one class of a classification
 #' \code{\link[randomForestSRC]{rfsrc}} or
-#' \code{\link[randomForest]{randomForest}} object.
+#' \code{\link[randomForest]{randomForest}} forest, \code{gg_roc} walks every
+#' threshold and records sensitivity (the true positive rate) against
+#' specificity (1 minus the false positive rate).
 #'
 #' @param object A classification \code{\link[randomForestSRC]{rfsrc}} or
 #'   \code{\link[randomForest]{randomForest}} object. Only forests with
 #'   \code{family == "class"} (rfsrc) or \code{type == "classification"}
 #'   (randomForest) are supported.
-#' @param which_outcome Integer index or character name of the class for
-#'   which the ROC curve is computed. For binary forests this is typically
-#'   \code{1} or \code{2}; for multi-class forests any valid class index or
-#'   level name. The behaviour of \code{which_outcome = "all"} or \code{0}
-#'   is engine-specific:
+#' @param which_outcome Integer index or character name of the class to score.
+#'   For binary forests this is usually \code{1} or \code{2}; for multi-class
+#'   forests, any valid class index or level name. \code{which_outcome = "all"}
+#'   or \code{0} behaves differently by engine:
 #'   \describe{
 #'     \item{\code{randomForest} method}{Returns a macro-averaged
 #'       one-vs-rest ROC computed over the per-class probabilities.}
-#'     \item{\code{rfsrc} method}{Currently warns and falls back to
-#'       class 1 (the macro-average / per-class faceting work for the
-#'       \code{rfsrc} path is tracked separately under issue #72).}
+#'     \item{\code{rfsrc} method}{Warns and falls back to class 1. The
+#'       macro-average and per-class faceting for the \code{rfsrc} path
+#'       are tracked separately under issue #72.}
 #'   }
-#' @param oob Logical; if \code{TRUE} (default) use out-of-bag predicted
-#'   probabilities for the curve. Set to \code{FALSE} to use full in-bag
-#'   predictions. For \code{randomForest}, \code{oob = TRUE} uses out-of-bag
-#'   vote probabilities (\code{object$votes}); \code{FALSE} uses in-bag
+#' @param oob Logical; if \code{TRUE} (default), build the curve from
+#'   out-of-bag predicted probabilities, otherwise from full in-bag
+#'   predictions. For \code{randomForest}, \code{TRUE} uses the out-of-bag
+#'   vote probabilities in \code{object$votes}; \code{FALSE} uses in-bag
 #'   \code{predict(type = "prob")}.
 #' @param per_class Logical; if \code{TRUE} and the forest has more than two
-#'   classes, return per-class one-vs-rest ROC curves in a long-format
-#'   \code{data.frame} with a \code{class} factor column and a named AUC
-#'   vector attribute (ordered by descending AUC). Binary forests treat
-#'   \code{per_class = TRUE} as a no-op. Currently honoured by the
-#'   \code{randomForest} method only.
+#'   classes, return one ROC curve per class, each class scored against all
+#'   the others. The result is a long-format \code{data.frame} with a
+#'   \code{class} factor column and a named AUC vector attribute, ordered by
+#'   descending AUC. Binary forests treat \code{per_class = TRUE} as a no-op.
+#'   Honoured by the \code{randomForest} method only.
 #' @param ... Extra arguments (currently unused).
 #'
-#' @return A \code{gg_roc} \code{data.frame} with one row per unique prediction
-#'   threshold and columns:
+#' @return A \code{gg_roc} \code{data.frame}, one row per unique prediction
+#'   threshold, with columns:
 #'   \describe{
-#'     \item{sens}{Sensitivity (true positive rate) at each threshold.}
-#'     \item{spec}{Specificity (true negative rate) at each threshold.}
+#'     \item{sens}{Sensitivity (true positive rate) at the threshold.}
+#'     \item{spec}{Specificity (true negative rate) at the threshold.}
 #'     \item{yvar}{The observed class label for each observation.}
 #'   }
-#'   Pass to \code{\link{calc_auc}} for the area under the curve.
+#'   Pass it to \code{\link{calc_auc}} for the area under the curve.
 #'
 #' @seealso \code{\link{plot.gg_roc}}, \code{\link{calc_roc}},
 #'   \code{\link{calc_auc}},

--- a/R/gg_udependent.R
+++ b/R/gg_udependent.R
@@ -1,9 +1,9 @@
 ##=============================================================================
 #' Variable dependency graph from a uvarpro model
 #'
-#' A \code{uvarpro} fit knows which variables lean on which others.  This
-#' function reads those cross-variable dependency scores off the fit with
-#' \code{\link[varPro]{get.beta.entropy}} and
+#' A \code{uvarpro} fit records how strongly each variable depends on the
+#' others.  This function pulls those cross-variable dependency scores from
+#' the fit with \code{\link[varPro]{get.beta.entropy}} and
 #' \code{\link[varPro]{sdependent}}, and returns them as a tidy list that
 #' \code{plot.gg_udependent} can draw as a network.
 #'

--- a/R/gg_udependent.R
+++ b/R/gg_udependent.R
@@ -1,20 +1,21 @@
 ##=============================================================================
 #' Variable dependency graph from a uvarpro model
 #'
-#' Extracts cross-variable dependency scores from a fitted \code{uvarpro}
-#' object using \code{\link[varPro]{get.beta.entropy}} and
-#' \code{\link[varPro]{sdependent}}, and returns a tidy list suitable for
-#' \code{plot.gg_udependent}.
+#' A \code{uvarpro} fit knows which variables lean on which others.  This
+#' function reads those cross-variable dependency scores off the fit with
+#' \code{\link[varPro]{get.beta.entropy}} and
+#' \code{\link[varPro]{sdependent}}, and returns them as a tidy list that
+#' \code{plot.gg_udependent} can draw as a network.
 #'
 #' @param object A fitted \code{uvarpro} object (required).
-#' @param threshold Numeric; positive dependency threshold passed to
-#'   \code{sdependent()}. An edge \eqn{i \to j} is drawn when
-#'   \code{I[i, j] >= threshold}. Default \code{0.25}.
-#' @param q.signal Quantile threshold (0--1) for signal variable selection;
-#'   passed to \code{sdependent()}. Default \code{0.75}.
+#' @param threshold Numeric; the positive dependency threshold passed on to
+#'   \code{sdependent()}.  An edge \eqn{i \to j} is drawn when
+#'   \code{I[i, j] >= threshold}.  Default \code{0.25}.
+#' @param q.signal Quantile threshold (0--1) for picking out the signal
+#'   variables; passed on to \code{sdependent()}.  Default \code{0.75}.
 #' @param directed Logical; \code{TRUE} (default) builds a directed igraph.
-#' @param min.degree Integer or \code{NULL}. When non-\code{NULL}, only nodes
-#'   with degree \eqn{\ge} \code{min.degree} are retained in \code{$nodes},
+#' @param min.degree Integer or \code{NULL}.  When set, only nodes with
+#'   degree \eqn{\ge} \code{min.degree} are kept in \code{$nodes},
 #'   \code{$edges}, and \code{$graph}.
 #' @param ... Additional arguments forwarded to \code{varPro::sdependent()}.
 #'

--- a/R/gg_variable.R
+++ b/R/gg_variable.R
@@ -28,27 +28,27 @@
 #' variables) and the predicted response for each observation. Marginal
 #' dependence figures are created using the \code{\link{plot.gg_variable}}
 #' function.
-#' For \code{randomForest} fits the original model frame is rebuilt
-#' from the stored call so that the same predictors can be paired with the
-#' in-sample predictions.
+#' A \code{randomForest} fit does not keep the model frame, so for those
+#' objects \code{gg_variable} rebuilds it from the stored call. That lets the
+#' same predictors be paired with the in-sample predictions.
 #'
-#' Optional arguments include \code{time} (scalar or vector of survival times
-#' of interest), \code{time_labels} (labels for multiple survival horizons) and
-#' \code{oob} which toggles between out-of-bag and in-bag predictions when the
-#' forest stores both.
+#' A few optional arguments tune the extraction: \code{time} (one survival
+#' time, or a vector of them), \code{time_labels} (labels for multiple
+#' survival horizons), and \code{oob}, which switches between out-of-bag and
+#' in-bag predictions when the forest carries both.
 #'
 #' @param object A \code{\link[randomForestSRC]{rfsrc}} or
 #'   \code{\link[randomForest]{randomForest}} object, or a
 #'   \code{\link[randomForestSRC]{plot.variable}} result.
-#' @param ... Optional arguments such as \code{time}, \code{time_labels}, and
-#'   \code{oob} that tailor the marginal dependence extraction.
+#' @param ... Optional arguments \code{time}, \code{time_labels}, and
+#'   \code{oob} that tune the marginal dependence extraction.
 #'
-#' @return A \code{gg_variable} object: a \code{data.frame} of all predictor
-#'   columns from the training data paired with the OOB (or in-bag) predicted
-#'   response. For survival forests each requested time horizon produces an
-#'   additional column named by \code{time_labels}. The object carries a
-#'   \code{"family"} class attribute (\code{"regr"}, \code{"class"}, or
-#'   \code{"surv"}) used by \code{\link{plot.gg_variable}} for dispatch.
+#' @return A \code{gg_variable} object: a \code{data.frame} pairing every
+#'   training predictor column with the OOB (or in-bag) predicted response.
+#'   For survival forests, each requested time horizon adds a column named by
+#'   \code{time_labels}. The object carries a \code{"family"} class attribute
+#'   (\code{"regr"}, \code{"class"}, or \code{"surv"}) that
+#'   \code{\link{plot.gg_variable}} uses for dispatch.
 #'
 #' @seealso \code{\link{plot.gg_variable}},
 #'   \code{\link[randomForestSRC]{plot.variable}}

--- a/R/gg_varpro.R
+++ b/R/gg_varpro.R
@@ -1,27 +1,30 @@
 ##=============================================================================
 #' Variable importance data from a varPro model
 #'
-#' Extracts per-tree importance scores from a fitted \code{varpro} object,
-#' summarises them into an honest boxplot-ready data structure (hinges at
-#' 15th/85th percentile, whiskers at 5th/95th), and optionally retains
-#' class-conditional importance for classification forests.
+#' Pulls the per-tree importance scores out of a fitted \code{varpro} object
+#' and summarises them into a data structure the plot method can draw as a
+#' boxplot.  The box is an honest one: hinges at the 15th and 85th
+#' percentiles, whiskers at the 5th and 95th, no Tukey rule hiding in the
+#' middle.  For a classification forest you can also keep the
+#' class-conditional importances.
 #'
 #' @param object A fitted \code{varpro} object (required).
 #' @param local.std Logical; default \code{TRUE}.  When \code{TRUE} the
-#'   per-tree importances are normalised to z-scale before computing box
-#'   statistics.  Set to \code{FALSE} to retain the raw importance scale
-#'   (required for \code{type = "raw"} in \code{plot.gg_varpro}).
-#' @param cutoff Numeric z-score threshold for variable selection; default
-#'   \code{0.79}.  Variables with aggregate z > cutoff are flagged
-#'   \code{selected = TRUE} in \code{$imp}.
+#'   per-tree importances are put on the z-scale before the box statistics
+#'   are computed.  Set it \code{FALSE} to keep the raw importance scale,
+#'   which is what \code{type = "raw"} in \code{plot.gg_varpro} needs.
+#' @param cutoff Numeric; the z-score above which a variable is treated as
+#'   selected.  Default \code{0.79}.  A variable with aggregate z above the
+#'   cutoff is flagged \code{selected = TRUE} in \code{$imp}.
 #' @param faithful Logical; default \code{FALSE}.  When \code{TRUE},
-#'   \code{$imp.tree} is retained so \code{plot.gg_varpro} can
-#'   overlay per-tree jitter points in \code{plot.gg_varpro}.
-#' @param conditional Logical; default \code{FALSE}.  When \code{TRUE}
-#'   (classification forests only) extracts the \code{$conditional.z}
-#'   matrix and stores it as \code{$conditional}.
-#' @param nvar Integer; retain only the top \code{nvar} variables (by
-#'   median per-tree z) after applying the cutoff filter.  \code{NULL} keeps all.
+#'   \code{$imp.tree} is kept so \code{plot.gg_varpro} can scatter the
+#'   per-tree points over the box.
+#' @param conditional Logical; default \code{FALSE}.  When \code{TRUE}, and
+#'   only for a classification forest, the \code{$conditional.z} matrix is
+#'   extracted and stored as \code{$conditional}.
+#' @param nvar Integer; keep only the top \code{nvar} variables, ranked by
+#'   median per-tree z, after the cutoff filter has been applied.
+#'   \code{NULL} keeps all of them.
 #' @param ... Additional arguments passed to \code{varPro::importance()}.
 #'
 #' @return A named list of class \code{"gg_varpro"} with elements:

--- a/R/gg_varpro.R
+++ b/R/gg_varpro.R
@@ -3,10 +3,10 @@
 #'
 #' Pulls the per-tree importance scores out of a fitted \code{varpro} object
 #' and summarises them into a data structure the plot method can draw as a
-#' boxplot.  The box is an honest one: hinges at the 15th and 85th
-#' percentiles, whiskers at the 5th and 95th, no Tukey rule hiding in the
-#' middle.  For a classification forest you can also keep the
-#' class-conditional importances.
+#' boxplot.  The box hinges are the 15th and 85th percentiles and the
+#' whiskers run to the 5th and 95th -- not the usual Tukey 1.5 IQR whiskers.
+#' For a classification forest you can also keep the class-conditional
+#' importances.
 #'
 #' @param object A fitted \code{varpro} object (required).
 #' @param local.std Logical; default \code{TRUE}.  When \code{TRUE} the

--- a/R/plot.gg_brier.R
+++ b/R/plot.gg_brier.R
@@ -14,7 +14,7 @@
 #' Plot a \code{\link{gg_brier}} object
 #'
 #' Draws the time-resolved Brier score (the default) or the running CRPS as
-#' a curve against time.  A lower curve means a better-calibrated forecast.
+#' a curve against time.  Lower means more accurate probabilistic predictions.
 #' Turn \code{envelope = TRUE} on and the overall line picks up a ribbon
 #' spanning the 15th to 85th percentile of the per-subject contributions,
 #' which shows how much the score varies across subjects at each time.

--- a/R/plot.gg_brier.R
+++ b/R/plot.gg_brier.R
@@ -13,9 +13,11 @@
 ####**********************************************************************
 #' Plot a \code{\link{gg_brier}} object
 #'
-#' Plot the time-resolved Brier score (default) or running CRPS for a
-#' survival forest, optionally overlaid with a 15-85 percent per-subject
-#' envelope.
+#' Draws the time-resolved Brier score (the default) or the running CRPS as
+#' a curve against time.  A lower curve means a better-calibrated forecast.
+#' Turn \code{envelope = TRUE} on and the overall line picks up a ribbon
+#' spanning the 15th to 85th percentile of the per-subject contributions,
+#' which shows how much the score varies across subjects at each time.
 #'
 #' @param x A \code{\link{gg_brier}} object.
 #' @param type Which series to plot: \code{"brier"} (default) or

--- a/R/plot.gg_partial_varpro.R
+++ b/R/plot.gg_partial_varpro.R
@@ -6,8 +6,7 @@
 #' overlaid line curves, one per effect type; categorical predictors get
 #' side-by-side boxplots.  Survival path-C objects (the ones you get when
 #' \code{scale \%in\% c("surv","chf")} was passed to the extractor) are
-#' handed off to \code{\link{plot.gg_partial_rfsrc}}, which already knows
-#' how to draw them.
+#' handed off to \code{\link{plot.gg_partial_rfsrc}} for drawing.
 #'
 #' @param x A \code{\link{gg_partial_varpro}} object.
 #' @param type Character vector; one or more of \code{"parametric"},

--- a/R/plot.gg_partial_varpro.R
+++ b/R/plot.gg_partial_varpro.R
@@ -1,27 +1,28 @@
 ##=============================================================================
 #' Plot a \code{\link{gg_partial_varpro}} object
 #'
-#' Produces ggplot2 partial dependence curves from the named list returned
-#' by \code{\link{gg_partial_varpro}}.  Continuous predictors are shown as
-#' overlaid line curves (one per effect type); categorical predictors as
-#' side-by-side boxplots.  For survival path-C objects (produced when
-#' \code{scale \%in\% c("surv","chf")} is passed to the extractor) the plot
-#' is delegated to \code{\link{plot.gg_partial_rfsrc}}.
+#' Draws the partial dependence curves from the list that
+#' \code{\link{gg_partial_varpro}} returns.  Continuous predictors get
+#' overlaid line curves, one per effect type; categorical predictors get
+#' side-by-side boxplots.  Survival path-C objects (the ones you get when
+#' \code{scale \%in\% c("surv","chf")} was passed to the extractor) are
+#' handed off to \code{\link{plot.gg_partial_rfsrc}}, which already knows
+#' how to draw them.
 #'
 #' @param x A \code{\link{gg_partial_varpro}} object.
 #' @param type Character vector; one or more of \code{"parametric"},
 #'   \code{"nonparametric"}, \code{"causal"}.  Defaults to all three.
 #'   Ignored for path-C objects.
-#' @param ... Not currently used for path-A objects; forwarded to
+#' @param ... Unused for path-A objects; forwarded to
 #'   \code{plot.gg_partial_rfsrc} for path-C objects.
 #'
 #' @details
-#' **Ensemble mortality (scale = "mortality"):** When the provenance scale
-#' is \code{"mortality"}, the y-axis label reads
-#' \emph{"Ensemble mortality (expected events)"} to make clear that this
-#' is an \strong{unbounded relative-risk score}, not a survival probability
-#' or \eqn{1 - S(t)} (Ishwaran, Kogalur, Blackstone & Lauer, 2008
-#' <doi:10.1214/08-AOAS169>).
+#' **Ensemble mortality (scale = "mortality"):** when the provenance scale
+#' is \code{"mortality"}, the y-axis is labelled
+#' \emph{"Ensemble mortality (expected events)"}.  The wording is
+#' deliberate: this is an \strong{unbounded relative-risk score}, not a
+#' survival probability and not \eqn{1 - S(t)} (Ishwaran, Kogalur,
+#' Blackstone & Lauer, 2008 <doi:10.1214/08-AOAS169>).
 #'
 #' @return A \code{ggplot} (or \code{patchwork}) object.
 #'

--- a/R/plot.gg_roc.R
+++ b/R/plot.gg_roc.R
@@ -16,26 +16,25 @@
 #' ROC plot generic function for a \code{\link{gg_roc}} object.
 #'
 #' @param x A \code{\link{gg_roc}} object, or a raw
-#'   \code{\link[randomForestSRC]{rfsrc}} classification forest or
-#'   \code{\link[randomForest]{randomForest}} classification object.  When a
-#'   forest is supplied, \code{\link{gg_roc}} is called automatically.
+#'   \code{\link[randomForestSRC]{rfsrc}} or
+#'   \code{\link[randomForest]{randomForest}} classification forest. Hand it a
+#'   forest and \code{\link{gg_roc}} is called for you.
 #' @param which_outcome Integer; for multi-class problems, the index of the
-#'   class whose ROC curve should be plotted.  When \code{NULL} (default) and
-#'   the forest has more than two classes, ROC curves for all classes are
-#'   overlaid in a single plot.  For binary forests \code{NULL} defaults to
-#'   class index 2.
-#' @param panel Character; layout for per-class ROC objects (those produced by
-#'   \code{gg_roc(..., per_class = TRUE)}). \code{"overlay"} (default) draws all
-#'   class curves in one panel coloured by class; \code{"facet"} wraps each
-#'   class into its own panel. Ignored for single-class \code{gg_roc} objects.
-#' @param ... Additional arguments forwarded to \code{\link{gg_roc}} when
-#'   \code{x} is a raw forest object (e.g. \code{oob = FALSE}).
+#'   class to plot. When \code{NULL} (default) and the forest has more than two
+#'   classes, the curves for all classes are overlaid in one plot. For binary
+#'   forests, \code{NULL} defaults to class index 2.
+#' @param panel Character; layout for per-class ROC objects, the ones from
+#'   \code{gg_roc(..., per_class = TRUE)}. \code{"overlay"} (default) draws
+#'   every class curve in one panel, coloured by class; \code{"facet"} gives
+#'   each class its own panel. Ignored for single-class \code{gg_roc} objects.
+#' @param ... Additional arguments passed to \code{\link{gg_roc}} when
+#'   \code{x} is a raw forest (e.g. \code{oob = FALSE}).
 #'
-#' @return A \code{ggplot} object.  The x-axis shows 1 - Specificity (FPR)
-#'   and the y-axis shows Sensitivity (TPR).  A dashed red diagonal reference
-#'   line marks the random-classifier baseline.  The AUC value is annotated
-#'   on the plot for single-class curves.  Multi-class plots colour and style
-#'   each class curve distinctly.
+#' @return A \code{ggplot} object. The x-axis is 1 - Specificity (FPR), the
+#'   y-axis is Sensitivity (TPR), and a dashed red diagonal marks the
+#'   random-classifier baseline. Single-class curves carry the AUC as an
+#'   annotation; multi-class plots colour and style each class curve
+#'   distinctly.
 #'
 #' @seealso \code{\link{gg_roc}} \code{\link{calc_roc}} \code{\link{calc_auc}}
 #'   \code{\link[randomForestSRC]{rfsrc}}

--- a/R/plot.gg_udependent.R
+++ b/R/plot.gg_udependent.R
@@ -1,24 +1,27 @@
 ##=============================================================================
 #' Plot a \code{gg_udependent} variable dependency graph
 #'
-#' Renders the variable dependency graph from a \code{gg_udependent} object
-#' as a ggraph network plot. Nodes are coloured by selection status; edge
-#' width and opacity reflect dependency strength.
+#' Draws the dependency graph held in a \code{gg_udependent} object as a
+#' ggraph network.  Node colour marks whether a variable made the signal
+#' set, and the width and opacity of an edge tell you how strong the
+#' dependency between its two variables is.
 #'
 #' @param x A \code{gg_udependent} object from \code{\link{gg_udependent}}.
-#' @param layout Character; igraph/ggraph layout algorithm.  Common choices:
-#'   \code{"fr"} (Fruchterman-Reingold, default), \code{"kk"}
-#'   (Kamada-Kawai), \code{"stress"}, \code{"circle"}, \code{"grid"}.
+#' @param layout Character; the igraph/ggraph layout algorithm.  Common
+#'   choices are \code{"fr"} (Fruchterman-Reingold, the default),
+#'   \code{"kk"} (Kamada-Kawai), \code{"stress"}, \code{"circle"}, and
+#'   \code{"grid"}.
 #' @param ... Not currently used.
 #'
 #' @details
-#' Requires the \pkg{ggraph} package (\code{Suggests}).  Install it with
+#' This plot needs the \pkg{ggraph} package, which is in \code{Suggests}
+#' rather than installed for you.  If it is missing, run
 #' \code{install.packages("ggraph")}.
 #'
-#' Node colour: blue (\code{#4e8fcd}) for signal variables
-#' (\code{selected = TRUE}), grey (\code{#888888}) otherwise.
-#' Node size scales with degree.  Edge width and opacity scale with raw
-#' dependency weight (\code{I[i,j]}).
+#' A signal variable (\code{selected = TRUE}) gets a blue node
+#' (\code{#4e8fcd}); the rest are grey (\code{#888888}).  Node size grows
+#' with degree.  Edge width and opacity both grow with the raw dependency
+#' weight \code{I[i,j]}.
 #'
 #' @return A \code{ggplot} object (built via ggraph).
 #'

--- a/R/plot.gg_variable.R
+++ b/R/plot.gg_variable.R
@@ -27,13 +27,13 @@
 #' @param ... arguments passed to the \code{ggplot2} functions.
 #'
 #' @return A single \code{ggplot} object when \code{length(xvar) == 1} or
-#'   \code{panel = TRUE}; otherwise a \code{patchwork} composite stacking
-#'   one panel per variable in \code{xvar}. Always a single plottable
-#'   object (never a bare list) so it composes naturally with
+#'   \code{panel = TRUE}; otherwise a \code{patchwork} composite that stacks
+#'   one panel per variable in \code{xvar}. Either way the result is one
+#'   plottable object, never a bare list, so it composes with
 #'   \code{patchwork} and dispatches through \code{ggplot2::autoplot()}.
-#'   For the patchwork case, callers wanting to inspect a specific
-#'   panel with \code{ggplot2::layer_data()} should extract that panel
-#'   first (e.g. \code{ggplot2::layer_data(p[[1]])}).
+#'   For the patchwork case, to inspect one panel with
+#'   \code{ggplot2::layer_data()} pull that panel out first
+#'   (e.g. \code{ggplot2::layer_data(p[[1]])}).
 #'
 #' @seealso \code{\link{gg_variable}}, \code{\link{gg_partial}},
 #'   \code{\link[randomForestSRC]{plot.variable}}

--- a/R/plot.gg_varpro.R
+++ b/R/plot.gg_varpro.R
@@ -4,8 +4,8 @@
 #' Draws a horizontal boxplot of the per-tree importance z-scores, or of the
 #' raw importances if you asked for those.  Set \code{faithful = TRUE} at
 #' extract time and the per-tree points are scattered over the box; for a
-#' classification forest, \code{conditional = TRUE} splits the picture into
-#' one facet per class.
+#' classification forest, \code{conditional = TRUE} splits the plot into one
+#' facet per class.
 #'
 #' @param x A \code{gg_varpro} object from \code{\link{gg_varpro}}.
 #' @param type Character; the display scale.  Leave it off and it is read
@@ -16,10 +16,10 @@
 #' @param ... Not currently used.
 #'
 #' @details
-#' **Honest boxplot geometry:** the hinges are the 15th and 85th percentiles
-#' of the per-tree z-distribution, and the whiskers run to the 5th and 95th.
-#' This is \strong{not} a Tukey boxplot, and the plot carries a caption that
-#' says so.
+#' **Boxplot geometry:** the hinges are the 15th and 85th percentiles of the
+#' per-tree z-distribution, and the whiskers run to the 5th and 95th.  This
+#' is \strong{not} a Tukey boxplot, and the plot carries a caption that says
+#' so.
 #'
 #' **\code{faithful = TRUE}:** the per-tree values are jittered over the box
 #' as semi-transparent points, on the same scale as the box itself (z when

--- a/R/plot.gg_varpro.R
+++ b/R/plot.gg_varpro.R
@@ -1,34 +1,36 @@
 ##=============================================================================
 #' Plot a \code{gg_varpro} variable importance object
 #'
-#' Renders a horizontal boxplot of per-tree importance z-scores (or raw
-#' importances) with optional per-tree jitter overlay (\code{faithful=TRUE})
-#' or class-conditional facets (\code{conditional=TRUE}).
+#' Draws a horizontal boxplot of the per-tree importance z-scores, or of the
+#' raw importances if you asked for those.  Set \code{faithful = TRUE} at
+#' extract time and the per-tree points are scattered over the box; for a
+#' classification forest, \code{conditional = TRUE} splits the picture into
+#' one facet per class.
 #'
 #' @param x A \code{gg_varpro} object from \code{\link{gg_varpro}}.
-#' @param type Character; controls the display scale.  When omitted,
-#'   auto-detected from \code{provenance$local.std}: \code{"z"} if
-#'   \code{local.std = TRUE} (the default), \code{"raw"} if
-#'   \code{local.std = FALSE}.  Explicitly supplying a value that conflicts
-#'   with the extract-time setting raises an error.
+#' @param type Character; the display scale.  Leave it off and it is read
+#'   from \code{provenance$local.std}: \code{"z"} when \code{local.std =
+#'   TRUE} (the default), \code{"raw"} when \code{local.std = FALSE}.
+#'   Asking for a scale that the extract step did not prepare raises an
+#'   error.
 #' @param ... Not currently used.
 #'
 #' @details
-#' **Honest boxplot geometry:** Hinges are the 15th and 85th percentiles of
-#' the per-tree z-distribution; whiskers extend to the 5th and 95th
-#' percentiles.  This is \strong{not} a Tukey boxplot.  A mandatory plot
-#' caption states this explicitly.
+#' **Honest boxplot geometry:** the hinges are the 15th and 85th percentiles
+#' of the per-tree z-distribution, and the whiskers run to the 5th and 95th.
+#' This is \strong{not} a Tukey boxplot, and the plot carries a caption that
+#' says so.
 #'
-#' **\code{faithful = TRUE}:** Per-tree values are overlaid as jittered
-#' semi-transparent points on the same scale as the boxplot (z-scale when
-#' \code{local.std = TRUE}, raw-scale when \code{local.std = FALSE}); the
-#' box is drawn at reduced opacity; a white-outlined filled dot marks the
-#' mean.
+#' **\code{faithful = TRUE}:** the per-tree values are jittered over the box
+#' as semi-transparent points, on the same scale as the box itself (z when
+#' \code{local.std = TRUE}, raw when \code{local.std = FALSE}).  The box is
+#' drawn faint to let the points show through, and a white-outlined dot
+#' marks the mean.
 #'
-#' **\code{conditional = TRUE}:** The conditional class-importance scores
+#' **\code{conditional = TRUE}:** the class-conditional importances
 #' (\code{$conditional}) are shown as a faceted bar chart
-#' (\code{facet_wrap(~class, nrow = 1)}); variable sort order follows the
-#' unconditional median z from \code{$stats}.
+#' (\code{facet_wrap(~class, nrow = 1)}).  Variables keep the sort order set
+#' by the unconditional median z in \code{$stats}, so the facets line up.
 #'
 #' @return A \code{ggplot} object.
 #'

--- a/R/print_methods.R
+++ b/R/print_methods.R
@@ -9,13 +9,13 @@
 
 #' Print methods for gg_* data objects
 #'
-#' Each \code{print.gg_*()} method emits a single-line header containing the
-#' class label and, when available, forest provenance metadata (source package,
-#' family, ntree, n). The object is returned invisibly so \code{print()} calls
-#' chain cleanly in pipes.
+#' Each \code{print.gg_*()} method prints a one-line header: the class label
+#' and, where the forest recorded it, provenance (source package, family,
+#' ntree, n). It returns the object invisibly, so \code{print()} sits cleanly
+#' in a pipe.
 #'
-#' To inspect rows use \code{head()}.  To retrieve per-class diagnostics use
-#' \code{\link{summary.gg}}.
+#' To see the rows themselves, use \code{head()}; for per-class diagnostics,
+#' use \code{\link{summary.gg}}.
 #'
 #' @param x A \code{gg_*} data object.
 #' @param ... Not currently used.

--- a/R/summary_methods.R
+++ b/R/summary_methods.R
@@ -18,18 +18,20 @@
 
 #' Summary methods for gg_* data objects
 #'
-#' Each \code{summary.gg_*()} method returns a \code{summary.gg} object
-#' containing a header line and per-class diagnostic statistics (OOB error
-#' curve, top VIMP variables, time range, integrated CRPS, etc.).
-#' \code{print.summary.gg()} renders the object to the console.
+#' Where \code{print} gives you a one-line header, \code{summary} digs a level
+#' deeper. Each \code{summary.gg_*()} method returns a \code{summary.gg}
+#' object: a header line plus a few diagnostic statistics for that object
+#' type (the OOB error curve, the top VIMP variables, a time range, the
+#' integrated CRPS, and so on). \code{print.summary.gg()} renders it to the
+#' console.
 #'
 #' @param object A \code{gg_*} data object.
 #' @param x A \code{summary.gg} object (for \code{print.summary.gg}).
 #' @param ... Not currently used.
 #'
-#' @return A \code{summary.gg} object (a list with \code{header} and
-#'   \code{body} character vectors), returned invisibly from
-#'   \code{print.summary.gg}.
+#' @return A \code{summary.gg} object: a list with \code{header} and
+#'   \code{body} character vectors. \code{print.summary.gg} returns it
+#'   invisibly.
 #'
 #' @seealso \code{\link{print.gg}}, \code{\link{autoplot.gg}}
 #'

--- a/R/surv_partial.rfsrc.R
+++ b/R/surv_partial.rfsrc.R
@@ -5,9 +5,9 @@
 #' \code{plot()} method.
 #'
 #' Computes partial dependence curves for a survival or competing-risk
-#' \code{\link[randomForestSRC]{rfsrc}} forest by calling
+#' \code{\link[randomForestSRC]{rfsrc}} forest.  For each predictor it calls
 #' \code{\link[randomForestSRC]{partial.rfsrc}} at \code{npts} evenly-spaced
-#' unique values of each predictor across all stored event times.
+#' unique values, across every stored event time.
 #'
 #' @param rforest A fitted \code{\link[randomForestSRC]{rfsrc}} survival or
 #'   competing-risk forest object.

--- a/R/varpro_feature_names.R
+++ b/R/varpro_feature_names.R
@@ -3,9 +3,9 @@
 #' Recover original variable names from varpro one-hot encoded feature names
 #'
 #' \code{varpro} one-hot encodes factor variables, appending a numeric suffix
-#' for each level (e.g., \code{sex} becomes \code{sex0} and \code{sex1}).
-#' This function strips those suffixes iteratively until every name in
-#' \code{varpro_names} can be matched back to a column in \code{dataset}.
+#' for each level -- \code{sex} becomes \code{sex0} and \code{sex1}.  To map
+#' those back, this function strips the suffix one character at a time until
+#' every name in \code{varpro_names} matches a column in \code{dataset}.
 #'
 #' @param varpro_names character vector of names as output by varpro (may
 #'   include one-hot encoded suffixed names such as \code{"sex0"}, \code{"sex1"})

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
 [randomForest](https://cran.r-project.org/package=randomForest).
 It separates data extraction from plotting so the intermediate tidy objects can be inspected, saved, or used
 for custom analyses.
+Listed in the [ggplot2 extensions gallery](https://exts.ggplot2.tidyverse.org/).
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -95,9 +95,10 @@ First, the data object stands on its own. It carries everything its plot needs, 
 inspect it, or come back to it later without keeping the original forest — which can be large —
 in memory.
 
-Second, you are never locked into the default figure. Because a `plot()` method returns a plain
-`ggplot` object, you can add layers, swap scales, or apply a theme; and if the default is not what
-you want, you can ignore it entirely and build the figure from the tidy data yourself.
+Second, you are never locked into the default figure. Because a `plot()` method returns a single
+plottable object (a `ggplot`, or a `patchwork` composite for the multi-panel methods), you can add
+layers, swap scales, or apply a theme; and if the default is not what you want, you can ignore it
+entirely and build the figure from the tidy data yourself.
 
 ## Recent changes
 

--- a/README.md
+++ b/README.md
@@ -80,19 +80,24 @@ vignette("ggRandomForests")
 | `gg_roc()` | `rfsrc` / `randomForest` (class) | ROC curve data |
 | `gg_brier()` | `rfsrc` (survival) | Time-resolved Brier score and CRPS |
 
-Each `gg_*` function has a corresponding `plot()` S3 method that returns a `ggplot2` object, making it easy
-to apply additional `ggplot2` layers or themes. Every `gg_*` object also implements `print()` (header-only
-summary at the REPL — use `head()` for rows) and `summary()` (printable diagnostics object).
+Each `gg_*` function has a matching `plot()` S3 method that hands back a `ggplot2` object, so you can keep
+adding layers, scales, or a theme. Every `gg_*` object also has `print()` and `summary()` methods: `print()`
+shows a short header at the REPL rather than dumping every row (use `head()` when you want the rows), and
+`summary()` gives you a diagnostics object you can print or keep.
 
 ## Why ggRandomForests?
 
-- **Separation of data and figures.** `gg_*` functions extract tidy data objects from the forest.
-  `plot()` methods turn those into `ggplot2` figures. You can inspect, save, or transform the data
-  before plotting.
-- **Self-contained objects.** Each data object holds everything needed for its plot, so figures are
-  reproducible without the original forest in memory.
-- **Full `ggplot2` composability.** Every `plot()` method returns a `ggplot` object that accepts
-  additional layers, scales, and themes.
+The package is built on one decision: keep the data step and the figure step apart. The `gg_*`
+functions pull a tidy data object out of the forest; the `plot()` methods turn that object into a
+`ggplot2` figure. Two things follow from that split.
+
+First, the data object stands on its own. It carries everything its plot needs, so you can save it,
+inspect it, or come back to it later without keeping the original forest --- which can be large ---
+in memory.
+
+Second, you are never locked into the default figure. Because a `plot()` method returns a plain
+`ggplot` object, you can add layers, swap scales, or apply a theme; and if the default is not what
+you want, you can ignore it entirely and build the figure from the tidy data yourself.
 
 ## Recent changes
 

--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ vignette("ggRandomForests")
 | `gg_roc()` | `rfsrc` / `randomForest` (class) | ROC curve data |
 | `gg_brier()` | `rfsrc` (survival) | Time-resolved Brier score and CRPS |
 
-Each `gg_*` function has a matching `plot()` S3 method that hands back a `ggplot2` object, so you can keep
-adding layers, scales, or a theme. Every `gg_*` object also has `print()` and `summary()` methods: `print()`
+Each `gg_*` function has a matching `plot()` S3 method that hands back a single plottable object — a `ggplot`,
+or a `patchwork` composite when the method lays out multiple panels — so you can keep adding layers, scales, or a theme. Every `gg_*` object also has `print()` and `summary()` methods: `print()`
 shows a short header at the REPL rather than dumping every row (use `head()` when you want the rows), and
 `summary()` gives you a diagnostics object you can print or keep.
 
@@ -92,7 +92,7 @@ functions pull a tidy data object out of the forest; the `plot()` methods turn t
 `ggplot2` figure. Two things follow from that split.
 
 First, the data object stands on its own. It carries everything its plot needs, so you can save it,
-inspect it, or come back to it later without keeping the original forest --- which can be large ---
+inspect it, or come back to it later without keeping the original forest — which can be large —
 in memory.
 
 Second, you are never locked into the default figure. Because a `plot()` method returns a plain

--- a/dev/plans/2026-05-22-doc-voice-audit-design.md
+++ b/dev/plans/2026-05-22-doc-voice-audit-design.md
@@ -63,10 +63,23 @@ Observed voice characteristics (from the samples):
   package docs: **use sparingly** — keep where the em-dash earns the pause,
   otherwise prefer a comma, parentheses, or a full stop. Do not strip them
   entirely (un-John); do not sprinkle them.
+- **Ellipses** — an informal-register habit (text, email). Keep them out of
+  package docs; do not flag them as an AI tell either.
+- **Don't overstate** — no overselling. Cut "enhanced", "powerful",
+  "seamlessly", "robust" (as a brag), "comprehensive". State what the thing
+  does, at its actual size.
+- **Repetition that teaches is voice, not defect** — deliberately restating a
+  concept, or a callback structure (e.g. the VarPro sample states five
+  problems up front and answers each in the Epilog), is kept. Repeat a
+  concept when the repetition makes it clearer; cut repetition that only
+  fills space.
 
-AI tells to hunt (these are NOT John): relentless parallelism, flavorlessness,
-absence of analogy, absence of "we"/"you", sterile hedge-free balance, forced
-tricolons, "it is worth noting". Punctuation density is not itself a tell.
+AI tells to hunt (these are NOT John): *mechanical* parallelism (same-shaped
+sentences with no teaching purpose, lists padded to equal length),
+flavorlessness, absence of analogy, absence of "we"/"you", sterile hedge-free
+balance, forced tricolons, "it is worth noting", overstatement. Punctuation
+density is not itself a tell, and pedagogical repetition is not parallelism —
+preserve it.
 
 ### Step 2 — Two registers
 

--- a/dev/plans/2026-05-22-doc-voice-audit-design.md
+++ b/dev/plans/2026-05-22-doc-voice-audit-design.md
@@ -1,0 +1,132 @@
+# ggRandomForests Documentation Voice Audit — Design Spec
+
+**Date:** 2026-05-22
+**Author:** John Ehrlinger (design via Claude brainstorming)
+**Status:** Approved — ready for implementation planning
+
+---
+
+## Goal
+
+Audit all ggRandomForests documentation and rewrite the AI-written portions in
+John Ehrlinger's own voice, so the package reads as one consistent human author
+rather than a mix of human prose and AI-generated text.
+
+## Scope
+
+All four documentation surfaces:
+
+- **Roxygen / man pages** — 39 R files → 40 `.Rd` pages.
+- **Vignettes** — 3 Quarto files (`ggRandomForests.qmd`, `-regression.qmd`,
+  `-survival.qmd`).
+- **README** — `README.md`.
+- **NEWS** — `NEWS.md`.
+
+## Delivery
+
+A single PR folded into the v2.8.0 development cycle, opened **after PR #91
+merges** and **before the v2.8.0 release candidate**. It is the last
+substantive change in the v2.8.0 cycle.
+
+---
+
+## Approach
+
+Approach A of three considered (A: fingerprint → classify → targeted rewrite;
+B: wholesale rewrite; C: mechanical checklist scan). A was chosen because it
+preserves prose that is already John's, concentrates effort on the genuine AI
+surface, and produces an objective yardstick for review.
+
+### Step 1 — Voice fingerprint
+
+Build a written voice reference before touching any doc. Corpus:
+
+- The oldest git versions of the three vignettes (JSS-era prose, predating any
+  AI involvement).
+- The oldest `NEWS.md` entries.
+- Two external writing samples supplied by John (CORR boilerplates):
+  `VarPro Modeling in Plain English`, `supp_SIDclustering_methods`.
+
+Observed voice characteristics (from the samples):
+
+- **Pedagogical openers** — start from the familiar, build to the new.
+- **Extended analogies** — homely concrete pictures for abstract methods
+  (fruit basket, blind men and the elephant, "noise-reduction filter").
+- **Question-headed sections** — "Why Cluster?", "Where Do We Stop?".
+- **First-person plural** — "in our practice", "we proceed", direct "you".
+- **Parenthetical glosses** — terms defined inline in parentheses.
+- **Scare-quotes on jargon at first use** — "rules", "regions", "elbow".
+- **Sentence-initial conjunctions** — "But…", "Yet…", "Thus…".
+- **Deliberate imperfection** — mild redundancy, an occasional dropped
+  article, a sentence that runs long. First-draft human texture is kept.
+- **Em-dashes** — native to the voice, acknowledged as overused. Rule for
+  package docs: **use sparingly** — keep where the em-dash earns the pause,
+  otherwise prefer a comma, parentheses, or a full stop. Do not strip them
+  entirely (un-John); do not sprinkle them.
+
+AI tells to hunt (these are NOT John): relentless parallelism, flavorlessness,
+absence of analogy, absence of "we"/"you", sterile hedge-free balance, forced
+tricolons, "it is worth noting". Punctuation density is not itself a tell.
+
+### Step 2 — Two registers
+
+The fingerprint defines two registers of the one voice:
+
+- **Narrative register** — vignettes, README narrative, roxygen
+  `@description` / `@details`. Full pedagogical voice: analogies, question
+  framing, "we"/"you", builds from the familiar.
+- **Terse register** — roxygen `@param` / `@return`, NEWS bullets. Compressed
+  but still John: plain, concrete, no AI parallelism or hedging.
+  ("Terse in conversation, complete in deliverables.")
+
+### Step 3 — Classify
+
+Tag every doc surface — *original-voice / AI-written / mixed* — using git
+blame and commit dates, and assign each its register. Expected: vignette
+narrative is mostly pre-AI (original); the ~5 newest functions' roxygen
+(`gg_brier`, `gg_partial_varpro`, `gg_varpro`, `gg_udependent`, the ROC work)
+and recent `NEWS.md` entries are the AI surface. The classification table is
+committed as part of the spec/plan so rewrite scope is auditable.
+
+### Step 4 — Targeted rewrite
+
+Rewrite only AI-written and mixed docs, each against its register's
+fingerprint. Genuinely original-voice prose is left untouched.
+
+---
+
+## Critical guardrail — voice, not content
+
+This rewrite changes *how* things are said, never *what*. Technical claims,
+`@param` names, function signatures, return-value facts, example code, version
+numbers, and issue references stay identical in meaning. If a rewrite would
+change a factual statement, that is out of scope: flag it separately, do not
+silently edit. This keeps the large diff safe to review and keeps it from
+colliding with the v2.8.0 RC.
+
+## Verification
+
+- `R CMD check --as-cran` → 0 errors / 0 warnings / 0 notes (roxygen rewrites
+  must still produce valid `.Rd`; examples must still run).
+- All 3 vignettes render.
+- Re-audit pass: each rewritten doc re-scored against its register fingerprint.
+- Em-dash density check — confirm "sparingly" held.
+
+## Acceptance criteria
+
+- Every doc surface classified.
+- Every AI-written and mixed doc rewritten; every original-voice doc untouched.
+- Rewritten docs pass the fingerprint re-audit.
+- Zero functional or factual changes to documentation content.
+- One PR, opened after PR #91 merges, before the v2.8.0 release candidate.
+
+## Artifacts
+
+The voice fingerprint has two homes:
+
+- **Canonical:** `~/Documents/ObsidianVault/memory/writing-voice.md` — portable,
+  reusable across all of John's writing (manuscripts, boilerplates, email,
+  other R packages). Source of truth; leads when refined from other work.
+- **Repo copy:** `dev/voice-fingerprint.md` in ggRandomForests — a synced copy
+  committed so the PR is self-contained for CI and reviewers. Header line notes
+  the Vault file is canonical.

--- a/dev/plans/2026-05-22-doc-voice-audit-plan.md
+++ b/dev/plans/2026-05-22-doc-voice-audit-plan.md
@@ -1,0 +1,577 @@
+# Documentation Voice Audit Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Audit every ggRandomForests documentation surface and rewrite the AI-written portions in John Ehrlinger's own voice, changing how things are said but never what they say.
+
+**Architecture:** Build a written two-register voice fingerprint, classify every doc surface as original / AI / mixed, then rewrite only the AI and mixed surfaces against the fingerprint. Voice-only: no factual or content changes. Ships as one PR in the v2.8.0 cycle, before the release candidate.
+
+**Tech Stack:** R, roxygen2, Quarto vignettes, R CMD check, git.
+
+**Gating:** Execution starts only after PR #91 (`feat/rf-88-multiclass-roc`) merges to `main`. The plan is written now; do not branch until #91 is merged.
+
+**Note on "tests":** This is a prose task, not a code task. There is no failing-test-first cycle. The verification for each task is: `R CMD check` stays clean, roxygen still generates valid `.Rd`, vignettes still render, and the rewritten text passes a re-read against the fingerprint. Each task ends with that verification and a commit.
+
+---
+
+## Reference: the voice fingerprint (full text)
+
+This is the exact content Task 1 writes to both the Vault and the repo. It is the yardstick every rewrite task uses.
+
+```markdown
+# John Ehrlinger — Writing Voice Fingerprint
+
+Reference for keeping documentation and prose in a consistent human voice.
+Canonical copy lives in the Obsidian vault; package repos hold a synced copy.
+
+## The voice in one line
+
+Pedagogical and conversational: start from something the reader already knows,
+build to the new idea with a concrete analogy, and don't be afraid of a little
+personality or a slightly imperfect sentence.
+
+## Two registers
+
+**Narrative** (vignettes, README, roxygen @description/@details, methods prose)
+- Open from the familiar: "Most readers are familiar with simple linear regression..."
+- Carry one concrete analogy through a hard idea (a fruit basket, the blind men
+  and the elephant, a "noise-reduction filter").
+- Question-headed sections: "Why Cluster?", "Where Do We Stop?".
+- First person plural: "in our practice", "we proceed". Address the reader as "you".
+- Gloss terms inline in parentheses; scare-quote a piece of jargon the first
+  time it appears ("rules", "elbow", "eyeballing").
+- Start sentences with But / Yet / Thus / Now when it helps the flow.
+- Vary sentence length. A short flat statement after a long one lands well.
+
+**Terse** (roxygen @param/@return, NEWS bullets)
+- Compressed, but still plain and concrete, not sterile.
+- State the thing; skip the preamble. "Logical; if TRUE, ..." not "This
+  argument controls whether...".
+- No analogies, no question headers here; the voice shows in word choice.
+
+## Rules
+
+- Em-dashes: use sparingly. Native to the voice and honestly overused. Keep one
+  where it earns the pause; otherwise a comma, parentheses, or a full stop.
+- Ellipses: an informal-register habit (text, email). Keep them out of package docs.
+- Don't overstate. No overselling. Cut "enhanced", "powerful", "seamlessly",
+  "robust" (as a brag), "comprehensive". State what the thing does, at its size.
+- Imperfection is allowed. Mild redundancy, an occasional long sentence: human
+  texture, not an error to scrub. Don't polish to a glassy finish.
+- Repetition that teaches is voice, not defect. Restating a concept, or a
+  callback structure (state the problems up front, answer each later), is kept.
+  Repeat when it clarifies; cut repetition that only fills space.
+
+## AI tells to hunt and kill
+
+- Mechanical parallelism: same-shaped sentences with no teaching purpose, lists
+  padded to equal length. (Pedagogical repetition is NOT this; preserve it.)
+- Flavorlessness: correct but with no analogy, no picture, nothing a person
+  would actually say.
+- Missing "we"/"you": abstract, authorless prose.
+- Forced tricolons: "fast, simple, and reliable".
+- Hedge-free sterile balance: "X. However, Y. It is worth noting Z."
+- Overstatement (see Rules).
+- "in order to", "it is important to note", "leverage", "utilize".
+
+Punctuation density is NOT a tell. The tells are structural.
+
+## Before / after
+
+AI:   "Set per_class = TRUE to enable the computation of per-class one-vs-rest
+       ROC curves, providing enhanced flexibility for multi-class analysis."
+John: "Set per_class = TRUE and a multi-class forest gives you one ROC curve
+       per class, each class scored against all the others."
+```
+
+---
+
+## Task 1: Branch, build the fingerprint, sync both copies
+
+**Files:**
+- Create: `~/Documents/ObsidianVault/memory/writing-voice.md` (canonical)
+- Create: `dev/voice-fingerprint.md` (repo copy)
+
+- [ ] **Step 1: Confirm PR #91 is merged, then branch from main**
+
+```bash
+git fetch origin
+git log origin/main --oneline -5   # confirm the #91 merge commit is present
+git checkout -b docs/voice-audit origin/main
+```
+
+Expected: `Switched to a new branch 'docs/voice-audit'`. If the #91 merge is not in `origin/main`, stop — execution is gated on it.
+
+- [ ] **Step 2: Write the canonical fingerprint to the Vault**
+
+Write the full fingerprint text from the "Reference: the voice fingerprint" section above to `~/Documents/ObsidianVault/memory/writing-voice.md`, verbatim.
+
+- [ ] **Step 3: Write the repo copy**
+
+Write the same content to `dev/voice-fingerprint.md`, with this header line prepended:
+
+```markdown
+<!-- Synced copy. Canonical: ~/Documents/ObsidianVault/memory/writing-voice.md -->
+```
+
+- [ ] **Step 4: Commit the Vault copy**
+
+```bash
+cd ~/Documents/ObsidianVault && git add memory/writing-voice.md && \
+  git commit -m "memory: add writing voice fingerprint"
+```
+
+- [ ] **Step 5: Commit the repo copy**
+
+```bash
+cd /Users/ehrlinj/Documents/GitHub/ggRandomForests
+git add dev/voice-fingerprint.md
+git commit -m "docs: add voice fingerprint (synced from vault)"
+```
+
+---
+
+## Task 2: Classification audit
+
+**Files:**
+- Create: `dev/voice-audit-classification.md`
+
+- [ ] **Step 1: Gather first-commit dates for every R file**
+
+```bash
+for f in R/*.R; do echo "$f: $(git log --reverse --format='%ad' --date=short -- "$f" | head -1)"; done
+```
+
+Files first committed in 2026-05 are AI-era; files dating to 2014-2016 are
+original-voice. Known AI-era function files: `gg_brier.R`, `gg_partial_varpro.R`,
+`gg_varpro.R`, `gg_udependent.R`, and their `plot.*` counterparts;
+`print_methods.R`, `summary_methods.R`, `autoplot_methods.R` (PR #75, 2026-05).
+Known AI-*modified* (mixed): `gg_roc.R`, `plot.gg_roc.R`, `calc_roc.R`,
+`gg_variable.R`, `plot.gg_variable.R` (RF work, 2026-05).
+
+- [ ] **Step 2: Classify the vignettes and top-level docs**
+
+```bash
+for f in vignettes/*.qmd README.md NEWS.md; do \
+  echo "=== $f ==="; git log --format='%ad %s' --date=short -- "$f" | tail -3; done
+```
+
+Vignette narrative bodies are original-voice (JSS-era); only sections that
+document AI-era functions are mixed. `NEWS.md` entries under the two
+`v2.8.0 (development)` headers are AI-written; older entries are original.
+`README.md` body is mostly original; the feature paragraph(s) touched in
+2026-05 commits are mixed.
+
+- [ ] **Step 3: Write the classification table**
+
+Create `dev/voice-audit-classification.md` with a table: one row per doc
+surface, columns `Surface | Register | Verdict (original/AI/mixed) | Rewrite?`.
+"Rewrite? = yes" only for AI and mixed rows. Original rows are recorded as
+out-of-scope so the decision is auditable.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add dev/voice-audit-classification.md
+git commit -m "docs: voice-audit classification table"
+```
+
+---
+
+## Task 3: Rewrite roxygen — varPro function family
+
+**Files:**
+- Modify: `R/gg_partial_varpro.R`, `R/plot.gg_partial_varpro.R`,
+  `R/gg_varpro.R`, `R/plot.gg_varpro.R`, `R/gg_udependent.R`,
+  `R/plot.gg_udependent.R` (roxygen blocks only)
+
+- [ ] **Step 1: Audit each file's roxygen against the fingerprint**
+
+For each file, read the roxygen block (`#'` lines only). Mark every sentence
+that hits an AI tell from `dev/voice-fingerprint.md`: mechanical parallelism,
+flavorlessness, missing "we"/"you", forced tricolons, overstatement,
+"in order to" / "leverage" / "utilize".
+
+- [ ] **Step 2: Rewrite the flagged `@description` and `@details` text (narrative register)**
+
+Rewrite flagged narrative-register blocks. Example transformation:
+
+```
+# BEFORE (AI):
+#' This function provides a comprehensive interface for extracting variable
+#' importance, leveraging the varpro framework to deliver robust results.
+
+# AFTER (John):
+#' gg_varpro() pulls the per-tree importance scores out of a varpro fit so you
+#' can plot them. Think of varpro as a filter: it scores how much each variable
+#' actually moves the prediction, and the noise variables fall out near zero.
+```
+
+Keep every factual claim, every cross-reference, every `\code{}` and
+`\link{}` intact. Voice only.
+
+- [ ] **Step 3: Rewrite flagged `@param`/`@return` text (terse register)**
+
+Terse register: compressed, plain, no preamble. Example:
+
+```
+# BEFORE (AI):
+#' @param conditional Logical flag that, when set to TRUE, enables the
+#'   computation and rendering of class-conditional importance values.
+
+# AFTER (John):
+#' @param conditional Logical; if TRUE, show class-conditional importance
+#'   (classification forests only).
+```
+
+- [ ] **Step 4: Regenerate Rd and check**
+
+```bash
+Rscript -e "devtools::document(quiet = TRUE)"
+Rscript -e "devtools::check(args = '--as-cran', quiet = TRUE)" 2>&1 | tail -5
+```
+
+Expected: `0 errors | 0 warnings | 0 notes`. Roxygen must still produce valid
+`.Rd`. If `@examples` were touched, they must still run.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add R/gg_partial_varpro.R R/plot.gg_partial_varpro.R R/gg_varpro.R \
+  R/plot.gg_varpro.R R/gg_udependent.R R/plot.gg_udependent.R man/
+git commit -m "docs: rewrite varPro family roxygen in John's voice"
+```
+
+---
+
+## Task 4: Rewrite roxygen — gg_brier
+
+**Files:**
+- Modify: `R/gg_brier.R`, `R/plot.gg_brier.R` (roxygen blocks only)
+
+- [ ] **Step 1: Audit the roxygen in both files against the fingerprint**
+
+Same procedure as Task 3 Step 1. Read `#'` lines, flag AI tells.
+
+- [ ] **Step 2: Rewrite flagged `@description`/`@details` (narrative register)**
+
+Rewrite flagged narrative blocks against the fingerprint. Open from the
+familiar where it helps (the Brier score is a forecasting-accuracy idea most
+readers have met). Keep all references — Graf et al., the CRPS definition,
+`cens.model` options — factually unchanged.
+
+- [ ] **Step 3: Rewrite flagged `@param`/`@return` (terse register)**
+
+Same terse-register procedure as Task 3 Step 3.
+
+- [ ] **Step 4: Regenerate Rd and check**
+
+```bash
+Rscript -e "devtools::document(quiet = TRUE)"
+Rscript -e "devtools::check(args = '--as-cran', quiet = TRUE)" 2>&1 | tail -5
+```
+
+Expected: `0 errors | 0 warnings | 0 notes`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add R/gg_brier.R R/plot.gg_brier.R man/
+git commit -m "docs: rewrite gg_brier roxygen in John's voice"
+```
+
+---
+
+## Task 5: Rewrite roxygen — ROC and randomForest surface
+
+**Files:**
+- Modify: `R/gg_roc.R`, `R/plot.gg_roc.R`, `R/calc_roc.R`,
+  `R/gg_variable.R`, `R/plot.gg_variable.R` (roxygen blocks only)
+
+- [ ] **Step 1: Audit the roxygen in all five files against the fingerprint**
+
+Same procedure as Task 3 Step 1. These files are *mixed* — they have older
+original-voice prose plus 2026-05 AI additions (the `per_class`, `panel`,
+`oob`, randomForest-classification text). Rewrite only the AI additions; leave
+the original prose alone. Use `git blame` on a `#'` line if origin is unclear:
+
+```bash
+git blame -L '/^#'"'"'/,/^[^#]/' R/gg_roc.R | head -60
+```
+
+- [ ] **Step 2: Rewrite flagged `@description`/`@details` (narrative register)**
+
+Rewrite flagged narrative blocks against the fingerprint.
+
+- [ ] **Step 3: Rewrite flagged `@param`/`@return` (terse register)**
+
+Rewrite flagged terse-register blocks. The `per_class`, `panel`, and `oob`
+param text added in PR #88/#91 is the main AI surface here.
+
+- [ ] **Step 4: Regenerate Rd and check**
+
+```bash
+Rscript -e "devtools::document(quiet = TRUE)"
+Rscript -e "devtools::check(args = '--as-cran', quiet = TRUE)" 2>&1 | tail -5
+```
+
+Expected: `0 errors | 0 warnings | 0 notes`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add R/gg_roc.R R/plot.gg_roc.R R/calc_roc.R R/gg_variable.R \
+  R/plot.gg_variable.R man/
+git commit -m "docs: rewrite ROC and randomForest roxygen in John's voice"
+```
+
+---
+
+## Task 6: Rewrite roxygen — print/summary/autoplot S3 methods
+
+**Files:**
+- Modify: `R/print_methods.R`, `R/summary_methods.R`, `R/autoplot_methods.R`
+  (roxygen blocks only)
+
+- [ ] **Step 1: Audit the roxygen against the fingerprint**
+
+Same procedure as Task 3 Step 1. These three files are AI-era (PR #75). The
+roxygen is largely shared `@rdname` blocks, so the surface is small.
+
+- [ ] **Step 2: Rewrite flagged blocks**
+
+Rewrite flagged narrative and terse blocks against the fingerprint. These
+methods are simple; resist padding the description. State what `print()`,
+`summary()`, `autoplot()` do for a `gg_*` object and stop.
+
+- [ ] **Step 3: Regenerate Rd and check**
+
+```bash
+Rscript -e "devtools::document(quiet = TRUE)"
+Rscript -e "devtools::check(args = '--as-cran', quiet = TRUE)" 2>&1 | tail -5
+```
+
+Expected: `0 errors | 0 warnings | 0 notes`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add R/print_methods.R R/summary_methods.R R/autoplot_methods.R man/
+git commit -m "docs: rewrite S3 method roxygen in John's voice"
+```
+
+---
+
+## Task 7: Rewrite vignette AI-touched sections
+
+**Files:**
+- Modify: `vignettes/ggRandomForests.qmd`, `vignettes/ggRandomForests-regression.qmd`,
+  `vignettes/ggRandomForests-survival.qmd` (AI-touched prose only)
+
+- [ ] **Step 1: Identify AI-touched vignette prose**
+
+For each vignette, find prose added in 2026-05 commits (the sections
+documenting `gg_brier` and the refactored `gg_partial`/`gg_survival`):
+
+```bash
+git log --format='%H %ad %s' --date=short -- vignettes/ggRandomForests-survival.qmd
+git show <2026-05-commit-hash> -- vignettes/ggRandomForests-survival.qmd
+```
+
+The original JSS-era narrative is out of scope and stays untouched.
+
+- [ ] **Step 2: Rewrite the AI-touched sections (narrative register)**
+
+Rewrite only the flagged sections against the narrative-register fingerprint.
+Vignettes are the highest-visibility narrative surface: this is where the
+pedagogical openers, analogies, and question-headed sections matter most.
+Match the surrounding original prose so the seam is invisible. Do not touch
+code chunks, only the prose between them.
+
+- [ ] **Step 3: Render every vignette**
+
+```bash
+Rscript -e "quarto::quarto_render('vignettes/ggRandomForests.qmd')"
+Rscript -e "quarto::quarto_render('vignettes/ggRandomForests-regression.qmd')"
+Rscript -e "quarto::quarto_render('vignettes/ggRandomForests-survival.qmd')"
+```
+
+Expected: each renders with no error.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add vignettes/*.qmd
+git commit -m "docs: rewrite AI-touched vignette prose in John's voice"
+```
+
+---
+
+## Task 8: Rewrite README AI-touched sections
+
+**Files:**
+- Modify: `README.md` (AI-touched prose only)
+
+- [ ] **Step 1: Identify AI-touched README prose**
+
+```bash
+git log --format='%H %ad %s' --date=short -- README.md
+git show <2026-05-commit-hash> -- README.md
+```
+
+Badges, install instructions, and the original overview stay untouched. The
+feature paragraphs added/edited in 2026-05 are the rewrite surface.
+
+- [ ] **Step 2: Rewrite the flagged paragraphs (narrative register)**
+
+Rewrite against the narrative-register fingerprint. The README opener is the
+first impression: it should sound like John explaining the package to a
+colleague, not a feature list.
+
+- [ ] **Step 3: Verify README still renders on pkgdown build**
+
+```bash
+Rscript -e "pkgdown::build_home_index(pkgdown::as_pkgdown('.'))" 2>&1 | tail -3
+```
+
+Expected: builds with no error.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: rewrite README feature prose in John's voice"
+```
+
+---
+
+## Task 9: Rewrite NEWS v2.8.0 entries
+
+**Files:**
+- Modify: `NEWS.md` (the two `v2.8.0 (development)` sections only)
+
+- [ ] **Step 1: Audit the v2.8.0 bullets against the terse-register fingerprint**
+
+All bullets under `ggRandomForests v2.8.0 (development) — continued` and
+`ggRandomForests v2.8.0 (development)` are AI-written. Entries for v2.7.3 and
+earlier are out of scope and stay untouched.
+
+- [ ] **Step 2: Rewrite the v2.8.0 bullets (terse register)**
+
+Rewrite against the terse-register fingerprint: plain, concrete, no
+overstatement, no mechanical parallelism. Keep every issue/PR number, every
+function name, every factual claim. A NEWS bullet says what changed and why a
+user would care, in as few words as that takes.
+
+- [ ] **Step 3: Verify NEWS still parses**
+
+```bash
+Rscript -e "devtools::test(filter = 'ggrandomforests_news')" 2>&1 | tail -5
+```
+
+Expected: `0 failures` (the NEWS-version test still finds `2.7.3.9006`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add NEWS.md
+git commit -m "docs: rewrite v2.8.0 NEWS entries in John's voice"
+```
+
+---
+
+## Task 10: Verification gate and PR
+
+**Files:** none (verification + PR)
+
+- [ ] **Step 1: Full R CMD check**
+
+```bash
+Rscript -e "devtools::check(args = '--as-cran', quiet = TRUE)" 2>&1 | tail -8
+```
+
+Expected: `0 errors | 0 warnings | 0 notes`.
+
+- [ ] **Step 2: Render all vignettes**
+
+```bash
+for v in vignettes/*.qmd; do Rscript -e "quarto::quarto_render('$v')" || echo "FAIL: $v"; done
+```
+
+Expected: no `FAIL` lines.
+
+- [ ] **Step 3: Re-audit each rewritten doc against the fingerprint**
+
+Re-read every file touched in Tasks 3-9. For each, confirm: no AI tell from
+`dev/voice-fingerprint.md` remains, and no factual claim changed versus the
+pre-rewrite text. Spot-check with `git diff origin/main -- <file>` that diffs
+are voice-only.
+
+- [ ] **Step 4: Em-dash density check**
+
+```bash
+git diff origin/main -- R/ vignettes/ README.md NEWS.md | grep '^+' | grep -c '—'
+git diff origin/main -- R/ vignettes/ README.md NEWS.md | grep '^-' | grep -c '—'
+```
+
+The added-em-dash count should not exceed the removed count. If it does,
+revisit the rewrites and apply the "use sparingly" rule.
+
+- [ ] **Step 5: Push and open the PR**
+
+```bash
+git push -u origin docs/voice-audit
+gh pr create --title "docs: voice audit — rewrite AI-written docs in John's voice" \
+  --body "$(cat <<'EOF'
+## Summary
+
+- Rewrites all AI-written documentation (roxygen, vignettes, README, NEWS) in
+  John's own voice, per the approved spec
+  (dev/plans/2026-05-22-doc-voice-audit-design.md).
+- Voice-only: no factual or content changes. Function signatures, param names,
+  return-value facts, example code, version numbers, and issue references are
+  unchanged.
+- Adds dev/voice-fingerprint.md (synced from the vault) as the yardstick, and
+  dev/voice-audit-classification.md recording what was and was not in scope.
+
+## Test plan
+- [x] devtools::check(args = "--as-cran") — 0 errors, 0 warnings, 0 notes
+- [x] All 3 vignettes render
+- [x] Re-audit pass: no AI tells remain; diffs are voice-only
+- [x] Em-dash density check: added <= removed
+EOF
+)"
+```
+
+- [ ] **Step 6: Verify CI is green**
+
+```bash
+gh pr checks <PR-NUMBER>
+```
+
+Expected: all checks pass.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Scope (4 surfaces): roxygen → Tasks 3-6; vignettes → Task 7; README → Task 8;
+  NEWS → Task 9. Covered.
+- Fingerprint, two registers → Task 1 (full text embedded). Covered.
+- Classification → Task 2. Covered.
+- Voice-not-content guardrail → stated in every rewrite task; verified Task 10
+  Step 3. Covered.
+- Verification (R CMD check, vignette render, re-audit, em-dash check) →
+  Task 10. Covered.
+- Two fingerprint homes (Vault + repo) → Task 1 Steps 2-5. Covered.
+- One PR, after #91, before RC → gating note + Task 10. Covered.
+
+**Placeholder scan:** `<2026-05-commit-hash>` and `<PR-NUMBER>` are runtime
+values the worker fills from the commands immediately above them, not
+plan-authoring gaps. No "TBD"/"add error handling"/"similar to Task N".
+
+**Consistency:** File paths consistent throughout. Fingerprint filename
+`dev/voice-fingerprint.md` and Vault path `memory/writing-voice.md` consistent
+between Task 1 and later references. Register names ("narrative", "terse")
+consistent.

--- a/dev/plans/2026-05-22-doc-voice-audit-plan.md
+++ b/dev/plans/2026-05-22-doc-voice-audit-plan.md
@@ -362,6 +362,57 @@ git commit -m "docs: rewrite S3 method roxygen in John's voice"
 
 ---
 
+## Task 6b: Rewrite roxygen — gg_partial family + varpro helper
+
+**Files:**
+- Modify: `R/gg_partial_rfsrc.R`, `R/gg_partialpro.R`, `R/surv_partial.rfsrc.R`,
+  `R/varpro_feature_names.R` (roxygen blocks only)
+
+This task was added after the Task 2 classification audit found these four
+files carry AI-written roxygen (2026-03 onward) — they were missing from the
+original Task 3-6 file lists. `gg_partial_rfsrc.R` and `surv_partial.rfsrc.R`
+are *mixed* (substantive 2025 `@examples` prose plus 2026 AI edits);
+`gg_partialpro.R` and `varpro_feature_names.R` are *AI*.
+
+- [ ] **Step 1: Audit each file's roxygen against the fingerprint**
+
+For each file read the `#'` lines and flag AI tells per `dev/voice-fingerprint.md`.
+For the two mixed files, use `git blame` to separate 2025 original prose (leave
+it) from 2026 AI prose (rewrite it):
+
+```bash
+git blame -- R/gg_partial_rfsrc.R | grep "#'" | head -100
+```
+
+- [ ] **Step 2: Rewrite flagged `@description`/`@details` (narrative register)**
+
+Rewrite flagged narrative blocks against the fingerprint. `gg_partialpro()` is
+the soft-deprecated shim — its roxygen should plainly say it is superseded by
+`gg_partial_varpro()` and stop; do not oversell either function.
+
+- [ ] **Step 3: Rewrite flagged `@param`/`@return` (terse register)**
+
+Same terse-register procedure as Task 3 Step 3.
+
+- [ ] **Step 4: Regenerate Rd and check**
+
+```bash
+Rscript -e "devtools::document(quiet = TRUE)"
+Rscript -e "devtools::check(args = '--as-cran', quiet = TRUE)" 2>&1 | tail -5
+```
+
+Expected: `0 errors | 0 warnings | 0 notes`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add R/gg_partial_rfsrc.R R/gg_partialpro.R R/surv_partial.rfsrc.R \
+  R/varpro_feature_names.R man/
+git commit -m "docs: rewrite gg_partial family roxygen in John's voice"
+```
+
+---
+
 ## Task 7: Rewrite vignette AI-touched sections
 
 **Files:**

--- a/dev/voice-audit-classification.md
+++ b/dev/voice-audit-classification.md
@@ -26,10 +26,10 @@ decision is auditable. Rewrite happens in a later task — this table changes no
 | R/gg_udependent.R (roxygen) | both | AI | yes |
 | R/plot.gg_udependent.R (roxygen) | both | AI | yes |
 | R/print_methods.R (roxygen) | both | AI | yes |
-| R/print_helpers.R (roxygen) | both | AI | yes |
+| R/print_helpers.R | n/a | no doc surface (0 roxygen lines) | no |
 | R/summary_methods.R (roxygen) | both | AI | yes |
-| R/ribbon_style.R (roxygen) | both | AI | yes |
-| R/utils.R (roxygen) | both | AI | yes |
+| R/ribbon_style.R | n/a | no doc surface (0 roxygen lines) | no |
+| R/utils.R | n/a | no doc surface (0 roxygen lines) | no |
 | R/gg_roc.R (roxygen) | both | mixed | yes |
 | R/plot.gg_roc.R (roxygen) | both | mixed | yes |
 | R/calc_roc.R (roxygen) | both | mixed | yes |

--- a/dev/voice-audit-classification.md
+++ b/dev/voice-audit-classification.md
@@ -1,0 +1,52 @@
+# Voice-Audit Classification Table
+
+This table records the documentation voice classification for every documentation
+surface in ggRandomForests, as part of the documentation voice-audit (Task 2). The
+package's prose is a mix of John Ehrlinger's original JSS-era writing (2014-2016) and
+AI-written prose added during 2026-05 development. Classification is based on the
+first-commit date of each R source file and the commit history of vignettes and
+top-level docs.
+
+- **original** — written by John Ehrlinger, 2014-2016 JSS-era; out of scope for rewrite.
+- **AI** — file first committed in 2026-05; AI-written throughout.
+- **mixed** — original file with substantive 2026-05 AI edits.
+
+Original-voice rows are listed explicitly (Rewrite? = no) so the out-of-scope
+decision is auditable. Rewrite happens in a later task — this table changes nothing.
+
+| Surface | Register | Verdict | Rewrite? |
+|---|---|---|---|
+| R/autoplot_methods.R (roxygen) | both | AI | yes |
+| R/gg_brier.R (roxygen) | both | AI | yes |
+| R/plot.gg_brier.R (roxygen) | both | AI | yes |
+| R/gg_partial_varpro.R (roxygen) | both | AI | yes |
+| R/plot.gg_partial_varpro.R (roxygen) | both | AI | yes |
+| R/gg_varpro.R (roxygen) | both | AI | yes |
+| R/plot.gg_varpro.R (roxygen) | both | AI | yes |
+| R/gg_udependent.R (roxygen) | both | AI | yes |
+| R/plot.gg_udependent.R (roxygen) | both | AI | yes |
+| R/print_methods.R (roxygen) | both | AI | yes |
+| R/print_helpers.R (roxygen) | both | AI | yes |
+| R/summary_methods.R (roxygen) | both | AI | yes |
+| R/ribbon_style.R (roxygen) | both | AI | yes |
+| R/utils.R (roxygen) | both | AI | yes |
+| R/gg_roc.R (roxygen) | both | mixed | yes |
+| R/plot.gg_roc.R (roxygen) | both | mixed | yes |
+| R/calc_roc.R (roxygen) | both | mixed | yes |
+| R/gg_variable.R (roxygen) | both | mixed | yes |
+| R/plot.gg_variable.R (roxygen) | both | mixed | yes |
+| R/gg_error.R, R/plot.gg_error.R (roxygen) | both | original | no |
+| R/gg_partial.R, R/plot.gg_partial.R (roxygen) | both | original | no |
+| R/gg_rfsrc.R, R/plot.gg_rfsrc.R (roxygen) | both | original | no |
+| R/gg_survival.R, R/plot.gg_survival.R (roxygen) | both | original | no |
+| R/gg_vimp.R, R/plot.gg_vimp.R (roxygen) | both | original | no |
+| R/calc_roc.R helper (kaplan.R, nelson.R) (roxygen) | both | original | no |
+| R/quantile_pts.R (roxygen) | both | original | no |
+| R/help.R, R/ggrandomforests.news.R, R/zzz.R (roxygen) | both | original | no |
+| R/gg_partial_rfsrc.R, R/gg_partialpro.R (roxygen) | both | original | no |
+| R/surv_partial.rfsrc.R, R/varpro_feature_names.R (roxygen) | both | original | no |
+| vignettes/ggRandomForests.qmd | narrative | original | no |
+| vignettes/ggRandomForests-regression.qmd | narrative | original | no |
+| vignettes/ggRandomForests-survival.qmd | both | mixed | yes |
+| README.md | both | mixed | yes |
+| NEWS.md | terse | mixed | yes |

--- a/dev/voice-audit-classification.md
+++ b/dev/voice-audit-classification.md
@@ -43,8 +43,10 @@ decision is auditable. Rewrite happens in a later task — this table changes no
 | R/calc_roc.R helper (kaplan.R, nelson.R) (roxygen) | both | original | no |
 | R/quantile_pts.R (roxygen) | both | original | no |
 | R/help.R, R/ggrandomforests.news.R, R/zzz.R (roxygen) | both | original | no |
-| R/gg_partial_rfsrc.R, R/gg_partialpro.R (roxygen) | both | original | no |
-| R/surv_partial.rfsrc.R, R/varpro_feature_names.R (roxygen) | both | original | no |
+| R/gg_partial_rfsrc.R (roxygen) | both | mixed | yes |
+| R/gg_partialpro.R (roxygen) | both | AI | yes |
+| R/surv_partial.rfsrc.R (roxygen) | both | mixed | yes |
+| R/varpro_feature_names.R (roxygen) | both | AI | yes |
 | vignettes/ggRandomForests.qmd | narrative | original | no |
 | vignettes/ggRandomForests-regression.qmd | narrative | original | no |
 | vignettes/ggRandomForests-survival.qmd | both | mixed | yes |

--- a/dev/voice-fingerprint.md
+++ b/dev/voice-fingerprint.md
@@ -22,6 +22,11 @@ personality or a slightly imperfect sentence.
   time it appears ("rules", "elbow", "eyeballing").
 - Start sentences with But / Yet / Thus / Now when it helps the flow.
 - Vary sentence length. A short flat statement after a long one lands well.
+- **Conversational, not chatty.** A colleague explaining the method at a
+  whiteboard, not a blog post. Keep an analogy when it teaches; cut winking
+  asides and cute phrasing. "no Tukey rule hiding in the middle" is too cute;
+  "not the usual Tukey 1.5 IQR whiskers" is right. Plain and direct beats
+  folksy. The reader is a peer, so don't perform for them.
 
 **Terse** (roxygen @param/@return, NEWS bullets)
 - Compressed, but still plain and concrete, not sterile.

--- a/dev/voice-fingerprint.md
+++ b/dev/voice-fingerprint.md
@@ -1,0 +1,64 @@
+<!-- Synced copy. Canonical: ~/Documents/ObsidianVault/memory/writing-voice.md -->
+# John Ehrlinger — Writing Voice Fingerprint
+
+Reference for keeping documentation and prose in a consistent human voice.
+Canonical copy lives in the Obsidian vault; package repos hold a synced copy.
+
+## The voice in one line
+
+Pedagogical and conversational: start from something the reader already knows,
+build to the new idea with a concrete analogy, and don't be afraid of a little
+personality or a slightly imperfect sentence.
+
+## Two registers
+
+**Narrative** (vignettes, README, roxygen @description/@details, methods prose)
+- Open from the familiar: "Most readers are familiar with simple linear regression..."
+- Carry one concrete analogy through a hard idea (a fruit basket, the blind men
+  and the elephant, a "noise-reduction filter").
+- Question-headed sections: "Why Cluster?", "Where Do We Stop?".
+- First person plural: "in our practice", "we proceed". Address the reader as "you".
+- Gloss terms inline in parentheses; scare-quote a piece of jargon the first
+  time it appears ("rules", "elbow", "eyeballing").
+- Start sentences with But / Yet / Thus / Now when it helps the flow.
+- Vary sentence length. A short flat statement after a long one lands well.
+
+**Terse** (roxygen @param/@return, NEWS bullets)
+- Compressed, but still plain and concrete, not sterile.
+- State the thing; skip the preamble. "Logical; if TRUE, ..." not "This
+  argument controls whether...".
+- No analogies, no question headers here; the voice shows in word choice.
+
+## Rules
+
+- Em-dashes: use sparingly. Native to the voice and honestly overused. Keep one
+  where it earns the pause; otherwise a comma, parentheses, or a full stop.
+- Ellipses: an informal-register habit (text, email). Keep them out of package docs.
+- Don't overstate. No overselling. Cut "enhanced", "powerful", "seamlessly",
+  "robust" (as a brag), "comprehensive". State what the thing does, at its size.
+- Imperfection is allowed. Mild redundancy, an occasional long sentence: human
+  texture, not an error to scrub. Don't polish to a glassy finish.
+- Repetition that teaches is voice, not defect. Restating a concept, or a
+  callback structure (state the problems up front, answer each later), is kept.
+  Repeat when it clarifies; cut repetition that only fills space.
+
+## AI tells to hunt and kill
+
+- Mechanical parallelism: same-shaped sentences with no teaching purpose, lists
+  padded to equal length. (Pedagogical repetition is NOT this; preserve it.)
+- Flavorlessness: correct but with no analogy, no picture, nothing a person
+  would actually say.
+- Missing "we"/"you": abstract, authorless prose.
+- Forced tricolons: "fast, simple, and reliable".
+- Hedge-free sterile balance: "X. However, Y. It is worth noting Z."
+- Overstatement (see Rules).
+- "in order to", "it is important to note", "leverage", "utilize".
+
+Punctuation density is NOT a tell. The tells are structural.
+
+## Before / after
+
+AI:   "Set per_class = TRUE to enable the computation of per-class one-vs-rest
+       ROC curves, providing enhanced flexibility for multi-class analysis."
+John: "Set per_class = TRUE and a multi-class forest gives you one ROC curve
+       per class, each class scored against all the others."

--- a/man/autoplot.gg.Rd
+++ b/man/autoplot.gg.Rd
@@ -46,17 +46,17 @@
 \arguments{
 \item{object}{A \code{gg_*} data object (see Details).}
 
-\item{...}{Additional arguments forwarded to the underlying
+\item{...}{Additional arguments passed to the underlying
 \code{plot.gg_*()} method.}
 }
 \value{
 A \code{ggplot} object.
 }
 \description{
-These methods let you use \code{ggplot2::autoplot()} on any \code{gg_*}
-object returned by \pkg{ggRandomForests}.  They are thin wrappers around
-the corresponding \code{plot.gg_*()} S3 methods, so all arguments
-accepted by those methods are forwarded via \code{...}.
+These let you call \code{ggplot2::autoplot()} on any \code{gg_*} object
+\pkg{ggRandomForests} returns. Each is a thin wrapper around the matching
+\code{plot.gg_*()} S3 method, and \code{...} passes straight through, so
+every argument those plot methods take is still available here.
 }
 \details{
 The following \code{gg_*} classes are supported:

--- a/man/gg_brier.Rd
+++ b/man/gg_brier.Rd
@@ -35,19 +35,25 @@ A \code{gg_brier} \code{data.frame} with columns
   \code{attr(., "crps_integrated")}.
 }
 \description{
-Extract the time-resolved Brier score and continuous ranked probability
-score (CRPS) for a survival forest grown with \code{randomForestSRC}. The
-Brier score is computed at each time on \code{object$time.interest}, both
-overall and stratified by mortality-risk quartile. CRPS is the running
-trapezoidal integral of the Brier score, normalised by elapsed time, and
-is computed within each quartile and overall.
+The Brier score asks a familiar question of any probabilistic forecast:
+how far did the predicted probability sit from what actually happened?
+For a survival forest the forecast is the predicted survival probability,
+and the score is computed at each event time, so the result is a curve
+rather than a single number -- lower is better, at every time.
 }
 \details{
-Wraps \code{\link[randomForestSRC]{get.brier.survival}} and
-rebuilds the quartile decomposition + running CRPS from the returned
-\code{brier.matx} and \code{mort} components, mirroring the computation
-in the internal \code{plot.survival} function of \pkg{randomForestSRC}. The Brier score uses
-inverse-probability-of-censoring weighting; the censoring distribution
+This function extracts that time-resolved Brier score for a survival
+forest grown with \code{randomForestSRC}, both overall and split by
+mortality-risk quartile. It also returns the continuous ranked
+probability score (CRPS), which is the Brier score integrated over time
+and divided by elapsed time -- a running average of the curve so far.
+
+This wraps \code{\link[randomForestSRC]{get.brier.survival}} and
+rebuilds the quartile decomposition and running CRPS from the returned
+\code{brier.matx} and \code{mort} components, following the computation
+in the internal \code{plot.survival} function of \pkg{randomForestSRC}.
+Right-censored data make a plain Brier score biased, so the score uses
+inverse-probability-of-censoring weighting. The censoring distribution
 is estimated either by Kaplan-Meier (\code{cens.model = "km"}, the
 default) or by a separate censoring forest (\code{cens.model = "rfsrc"}).
 }

--- a/man/gg_partial_rfsrc.Rd
+++ b/man/gg_partial_rfsrc.Rd
@@ -64,25 +64,30 @@ A named list with two elements:
   }
 }
 \description{
-Computes partial dependence for one or more predictors by calling
-\code{\link[randomForestSRC]{partial.rfsrc}} internally, then splits the
-results into separate data frames for continuous and categorical variables.
-Unlike \code{\link{gg_partial}}, no separate \code{plot.variable} call is
-required — supply the fitted \code{rfsrc} object directly.
+A partial dependence curve answers a what-if question: hold the rest of
+the predictors as they are, sweep one of them across its range, and watch
+how the forest's prediction moves.  This function builds those curves for
+one or more predictors by calling
+\code{\link[randomForestSRC]{partial.rfsrc}} for you, then splits the
+result into separate data frames for continuous and categorical
+variables.  Unlike \code{\link{gg_partial}}, there is no separate
+\code{plot.variable} step -- pass the fitted \code{rfsrc} object straight
+in.
 }
 \section{Survival forests and \code{partial.time}}{
 
-\code{\link[randomForestSRC]{partial.rfsrc}} requires that every value in
-\code{partial.time} be an exact member of the model's \code{time.interest}
-vector (the unique observed event times stored in the fitted object).
-Passing arbitrary time values — even plausible ones such as \code{c(1, 3)}
-for a study measured in years — causes a C-level prediction error inside
-\code{partial.rfsrc}.
+\code{\link[randomForestSRC]{partial.rfsrc}} expects every value in
+\code{partial.time} to be an exact member of the model's
+\code{time.interest} vector, the unique observed event times stored in the
+fitted object.  Pass an arbitrary time, even a plausible one such as
+\code{c(1, 3)} for a study measured in years, and you get a C-level
+prediction error from inside \code{partial.rfsrc}.
 
-\code{gg_partial_rfsrc} handles this automatically: every element of
-\code{partial.time} is silently snapped to its nearest \code{time.interest}
-value before the call is made.  To target a specific follow-up horizon,
-find the closest grid point yourself and pass it explicitly:
+\code{gg_partial_rfsrc} takes care of this: every element of
+\code{partial.time} is silently snapped to its nearest
+\code{time.interest} value before the call.  To target a specific
+follow-up horizon, find the closest grid point yourself and pass it
+explicitly:
 
 \preformatted{
 ti  <- rf_model$time.interest

--- a/man/gg_partial_varpro.Rd
+++ b/man/gg_partial_varpro.Rd
@@ -62,9 +62,10 @@ categorical predictors mixed together. This function splits that list into
 two tidy data frames, one for each kind, and resolves the y-axis label the
 plot method will use.
 
-\emph{Deprecated.} \code{gg_partialpro()} has been renamed to
-\code{\link{gg_partial_varpro}()}.  This function is a thin alias that
-will be removed in the release after \pkg{ggRandomForests} v2.8.0.
+\emph{Deprecated.} \code{gg_partialpro()} has been superseded by
+\code{\link{gg_partial_varpro}()} and is now a thin alias for it.  It will
+be removed in the release after \pkg{ggRandomForests} v2.8.0; use
+\code{\link{gg_partial_varpro}()} directly.
 }
 \details{
 **Scale detection:** with \code{scale = "auto"} and an \code{object} in

--- a/man/gg_partial_varpro.Rd
+++ b/man/gg_partial_varpro.Rd
@@ -46,7 +46,7 @@ A named list of class \code{"gg_partial_varpro"} with elements:
   \item{continuous}{data.frame with columns \code{variable},
     \code{parametric}, \code{nonparametric}, \code{causal}, \code{name}
     (and optionally \code{model}).}
-  \item{categorical}{data.frame with the same columns but one row per
+  \item{categorical}{data.frame with the same columns, one row per
     observation per category level.}
 }
 A \code{"provenance"} attribute carries \code{source}, \code{family},
@@ -57,29 +57,31 @@ A \code{gg_partial_varpro} object (see
   \code{\link{gg_partial_varpro}}).
 }
 \description{
-Splits the list returned by \code{varpro::partialpro} into separate
-data frames for continuous and categorical predictors, with provenance-
-aware y-axis labeling for downstream plot methods.
+\code{varpro::partialpro} hands back one list, with continuous and
+categorical predictors mixed together. This function splits that list into
+two tidy data frames, one for each kind, and works out an honest y-axis
+label for the plot method to use later.
 
 \emph{Deprecated.} \code{gg_partialpro()} has been renamed to
 \code{\link{gg_partial_varpro}()}.  This function is a thin alias that
 will be removed in the release after \pkg{ggRandomForests} v2.8.0.
 }
 \details{
-**Scale detection:** \code{scale = "auto"} with a supplied \code{object}
-resolves to \code{"mortality"} for survival forests and \code{"generic"}
-for regression/classification forests.  The RMST horizon \eqn{\tau} is
-\emph{not} stored in the \code{varpro} object (varPro 3.1.0); pass
-\code{scale = "rmst", time = tau} explicitly for RMST-labeled output.
+**Scale detection:** with \code{scale = "auto"} and an \code{object} in
+hand, the scale resolves to \code{"mortality"} for a survival forest and
+\code{"generic"} for a regression or classification forest.  The RMST
+horizon \eqn{\tau} is \emph{not} stored in the \code{varpro} object
+(varPro 3.1.0), so for RMST-labeled output you have to pass
+\code{scale = "rmst", time = tau} yourself.
 
-**Ensemble mortality (scale = "mortality"):** The y-axis represents
-\emph{ensemble mortality}: the expected number of events if the subject
-experienced the study-average cumulative hazard, equivalent to the
-\code{rfsrc} \code{predicted} value for survival forests (Ishwaran,
-Kogalur, Blackstone & Lauer, 2008 <doi:10.1214/08-AOAS169>).  This is
-an \strong{unbounded relative-risk score}---\emph{not} a survival
-probability or \eqn{1 - S(t)}---and must not be interpreted as one.
-For probability-scale output refit with
+**Ensemble mortality (scale = "mortality"):** here the y-axis is
+\emph{ensemble mortality}, the expected number of events a subject would
+see if they were exposed to the study-average cumulative hazard.  It is
+the same quantity as the \code{rfsrc} \code{predicted} value for survival
+forests (Ishwaran, Kogalur, Blackstone & Lauer, 2008
+<doi:10.1214/08-AOAS169>).  This is an \strong{unbounded relative-risk
+score}, \emph{not} a survival probability and not \eqn{1 - S(t)}; don't
+read it as one.  If you want output on the probability scale, refit with
 \code{varpro(..., rmst = tau)} and use \code{scale = "rmst"}.
 }
 \examples{

--- a/man/gg_partial_varpro.Rd
+++ b/man/gg_partial_varpro.Rd
@@ -57,10 +57,10 @@ A \code{gg_partial_varpro} object (see
   \code{\link{gg_partial_varpro}}).
 }
 \description{
-\code{varpro::partialpro} hands back one list, with continuous and
+\code{varpro::partialpro} returns one list, with continuous and
 categorical predictors mixed together. This function splits that list into
-two tidy data frames, one for each kind, and works out an honest y-axis
-label for the plot method to use later.
+two tidy data frames, one for each kind, and resolves the y-axis label the
+plot method will use.
 
 \emph{Deprecated.} \code{gg_partialpro()} has been renamed to
 \code{\link{gg_partial_varpro}()}.  This function is a thin alias that

--- a/man/gg_roc.rfsrc.Rd
+++ b/man/gg_roc.rfsrc.Rd
@@ -14,49 +14,52 @@
 \code{family == "class"} (rfsrc) or \code{type == "classification"}
 (randomForest) are supported.}
 
-\item{which_outcome}{Integer index or character name of the class for
-which the ROC curve is computed. For binary forests this is typically
-\code{1} or \code{2}; for multi-class forests any valid class index or
-level name. The behaviour of \code{which_outcome = "all"} or \code{0}
-is engine-specific:
+\item{which_outcome}{Integer index or character name of the class to score.
+For binary forests this is usually \code{1} or \code{2}; for multi-class
+forests, any valid class index or level name. \code{which_outcome = "all"}
+or \code{0} behaves differently by engine:
 \describe{
   \item{\code{randomForest} method}{Returns a macro-averaged
     one-vs-rest ROC computed over the per-class probabilities.}
-  \item{\code{rfsrc} method}{Currently warns and falls back to
-    class 1 (the macro-average / per-class faceting work for the
-    \code{rfsrc} path is tracked separately under issue #72).}
+  \item{\code{rfsrc} method}{Warns and falls back to class 1. The
+    macro-average and per-class faceting for the \code{rfsrc} path
+    are tracked separately under issue #72.}
 }}
 
-\item{oob}{Logical; if \code{TRUE} (default) use out-of-bag predicted
-probabilities for the curve. Set to \code{FALSE} to use full in-bag
-predictions. For \code{randomForest}, \code{oob = TRUE} uses out-of-bag
-vote probabilities (\code{object$votes}); \code{FALSE} uses in-bag
+\item{oob}{Logical; if \code{TRUE} (default), build the curve from
+out-of-bag predicted probabilities, otherwise from full in-bag
+predictions. For \code{randomForest}, \code{TRUE} uses the out-of-bag
+vote probabilities in \code{object$votes}; \code{FALSE} uses in-bag
 \code{predict(type = "prob")}.}
 
 \item{per_class}{Logical; if \code{TRUE} and the forest has more than two
-classes, return per-class one-vs-rest ROC curves in a long-format
-\code{data.frame} with a \code{class} factor column and a named AUC
-vector attribute (ordered by descending AUC). Binary forests treat
-\code{per_class = TRUE} as a no-op. Currently honoured by the
-\code{randomForest} method only.}
+classes, return one ROC curve per class, each class scored against all
+the others. The result is a long-format \code{data.frame} with a
+\code{class} factor column and a named AUC vector attribute, ordered by
+descending AUC. Binary forests treat \code{per_class = TRUE} as a no-op.
+Honoured by the \code{randomForest} method only.}
 
 \item{...}{Extra arguments (currently unused).}
 }
 \value{
-A \code{gg_roc} \code{data.frame} with one row per unique prediction
-  threshold and columns:
+A \code{gg_roc} \code{data.frame}, one row per unique prediction
+  threshold, with columns:
   \describe{
-    \item{sens}{Sensitivity (true positive rate) at each threshold.}
-    \item{spec}{Specificity (true negative rate) at each threshold.}
+    \item{sens}{Sensitivity (true positive rate) at the threshold.}
+    \item{spec}{Specificity (true negative rate) at the threshold.}
     \item{yvar}{The observed class label for each observation.}
   }
-  Pass to \code{\link{calc_auc}} for the area under the curve.
+  Pass it to \code{\link{calc_auc}} for the area under the curve.
 }
 \description{
-Computes sensitivity (true positive rate) and specificity (1 - false positive
-rate) across all prediction thresholds for one class of a classification
+A classifier does not hand you a class; it hands you a predicted probability,
+and you pick a threshold. Slide that threshold from 0 to 1 and the trade-off
+between catching the positives and crying wolf shifts the whole way. The ROC
+curve traces that trade-off. For one class of a classification
 \code{\link[randomForestSRC]{rfsrc}} or
-\code{\link[randomForest]{randomForest}} object.
+\code{\link[randomForest]{randomForest}} forest, \code{gg_roc} walks every
+threshold and records sensitivity (the true positive rate) against
+specificity (1 minus the false positive rate).
 }
 \examples{
 ## ------------------------------------------------------------

--- a/man/gg_udependent.Rd
+++ b/man/gg_udependent.Rd
@@ -48,9 +48,9 @@ A \code{"provenance"} attribute carries \code{threshold}, \code{q.signal},
 \code{directed}, \code{min.degree}, \code{xvar.names}, and \code{n}.
 }
 \description{
-A \code{uvarpro} fit knows which variables lean on which others.  This
-function reads those cross-variable dependency scores off the fit with
-\code{\link[varPro]{get.beta.entropy}} and
+A \code{uvarpro} fit records how strongly each variable depends on the
+others.  This function pulls those cross-variable dependency scores from
+the fit with \code{\link[varPro]{get.beta.entropy}} and
 \code{\link[varPro]{sdependent}}, and returns them as a tidy list that
 \code{plot.gg_udependent} can draw as a network.
 }

--- a/man/gg_udependent.Rd
+++ b/man/gg_udependent.Rd
@@ -16,17 +16,17 @@ gg_udependent(
 \arguments{
 \item{object}{A fitted \code{uvarpro} object (required).}
 
-\item{threshold}{Numeric; positive dependency threshold passed to
-\code{sdependent()}. An edge \eqn{i \to j} is drawn when
-\code{I[i, j] >= threshold}. Default \code{0.25}.}
+\item{threshold}{Numeric; the positive dependency threshold passed on to
+\code{sdependent()}.  An edge \eqn{i \to j} is drawn when
+\code{I[i, j] >= threshold}.  Default \code{0.25}.}
 
-\item{q.signal}{Quantile threshold (0--1) for signal variable selection;
-passed to \code{sdependent()}. Default \code{0.75}.}
+\item{q.signal}{Quantile threshold (0--1) for picking out the signal
+variables; passed on to \code{sdependent()}.  Default \code{0.75}.}
 
 \item{directed}{Logical; \code{TRUE} (default) builds a directed igraph.}
 
-\item{min.degree}{Integer or \code{NULL}. When non-\code{NULL}, only nodes
-with degree \eqn{\ge} \code{min.degree} are retained in \code{$nodes},
+\item{min.degree}{Integer or \code{NULL}.  When set, only nodes with
+degree \eqn{\ge} \code{min.degree} are kept in \code{$nodes},
 \code{$edges}, and \code{$graph}.}
 
 \item{...}{Additional arguments forwarded to \code{varPro::sdependent()}.}
@@ -48,10 +48,11 @@ A \code{"provenance"} attribute carries \code{threshold}, \code{q.signal},
 \code{directed}, \code{min.degree}, \code{xvar.names}, and \code{n}.
 }
 \description{
-Extracts cross-variable dependency scores from a fitted \code{uvarpro}
-object using \code{\link[varPro]{get.beta.entropy}} and
-\code{\link[varPro]{sdependent}}, and returns a tidy list suitable for
-\code{plot.gg_udependent}.
+A \code{uvarpro} fit knows which variables lean on which others.  This
+function reads those cross-variable dependency scores off the fit with
+\code{\link[varPro]{get.beta.entropy}} and
+\code{\link[varPro]{sdependent}}, and returns them as a tidy list that
+\code{plot.gg_udependent} can draw as a network.
 }
 \examples{
 \donttest{

--- a/man/gg_variable.Rd
+++ b/man/gg_variable.Rd
@@ -14,16 +14,16 @@ gg_variable(object, ...)
 \code{\link[randomForest]{randomForest}} object, or a
 \code{\link[randomForestSRC]{plot.variable}} result.}
 
-\item{...}{Optional arguments such as \code{time}, \code{time_labels}, and
-\code{oob} that tailor the marginal dependence extraction.}
+\item{...}{Optional arguments \code{time}, \code{time_labels}, and
+\code{oob} that tune the marginal dependence extraction.}
 }
 \value{
-A \code{gg_variable} object: a \code{data.frame} of all predictor
-  columns from the training data paired with the OOB (or in-bag) predicted
-  response. For survival forests each requested time horizon produces an
-  additional column named by \code{time_labels}. The object carries a
-  \code{"family"} class attribute (\code{"regr"}, \code{"class"}, or
-  \code{"surv"}) used by \code{\link{plot.gg_variable}} for dispatch.
+A \code{gg_variable} object: a \code{data.frame} pairing every
+  training predictor column with the OOB (or in-bag) predicted response.
+  For survival forests, each requested time horizon adds a column named by
+  \code{time_labels}. The object carries a \code{"family"} class attribute
+  (\code{"regr"}, \code{"class"}, or \code{"surv"}) that
+  \code{\link{plot.gg_variable}} uses for dispatch.
 }
 \description{
 \code{\link[randomForestSRC]{plot.variable}} generates a
@@ -33,14 +33,14 @@ partial variable dependence. The \code{gg_variable} function creates a
 variables) and the predicted response for each observation. Marginal
 dependence figures are created using the \code{\link{plot.gg_variable}}
 function.
-For \code{randomForest} fits the original model frame is rebuilt
-from the stored call so that the same predictors can be paired with the
-in-sample predictions.
+A \code{randomForest} fit does not keep the model frame, so for those
+objects \code{gg_variable} rebuilds it from the stored call. That lets the
+same predictors be paired with the in-sample predictions.
 
-Optional arguments include \code{time} (scalar or vector of survival times
-of interest), \code{time_labels} (labels for multiple survival horizons) and
-\code{oob} which toggles between out-of-bag and in-bag predictions when the
-forest stores both.
+A few optional arguments tune the extraction: \code{time} (one survival
+time, or a vector of them), \code{time_labels} (labels for multiple
+survival horizons), and \code{oob}, which switches between out-of-bag and
+in-bag predictions when the forest carries both.
 }
 \details{
 The marginal variable dependence is determined by comparing

--- a/man/gg_varpro.Rd
+++ b/man/gg_varpro.Rd
@@ -64,10 +64,10 @@ and \code{n}.
 \description{
 Pulls the per-tree importance scores out of a fitted \code{varpro} object
 and summarises them into a data structure the plot method can draw as a
-boxplot.  The box is an honest one: hinges at the 15th and 85th
-percentiles, whiskers at the 5th and 95th, no Tukey rule hiding in the
-middle.  For a classification forest you can also keep the
-class-conditional importances.
+boxplot.  The box hinges are the 15th and 85th percentiles and the
+whiskers run to the 5th and 95th -- not the usual Tukey 1.5 IQR whiskers.
+For a classification forest you can also keep the class-conditional
+importances.
 }
 \examples{
 \donttest{

--- a/man/gg_varpro.Rd
+++ b/man/gg_varpro.Rd
@@ -18,24 +18,25 @@ gg_varpro(
 \item{object}{A fitted \code{varpro} object (required).}
 
 \item{local.std}{Logical; default \code{TRUE}.  When \code{TRUE} the
-per-tree importances are normalised to z-scale before computing box
-statistics.  Set to \code{FALSE} to retain the raw importance scale
-(required for \code{type = "raw"} in \code{plot.gg_varpro}).}
+per-tree importances are put on the z-scale before the box statistics
+are computed.  Set it \code{FALSE} to keep the raw importance scale,
+which is what \code{type = "raw"} in \code{plot.gg_varpro} needs.}
 
-\item{cutoff}{Numeric z-score threshold for variable selection; default
-\code{0.79}.  Variables with aggregate z > cutoff are flagged
-\code{selected = TRUE} in \code{$imp}.}
+\item{cutoff}{Numeric; the z-score above which a variable is treated as
+selected.  Default \code{0.79}.  A variable with aggregate z above the
+cutoff is flagged \code{selected = TRUE} in \code{$imp}.}
 
 \item{faithful}{Logical; default \code{FALSE}.  When \code{TRUE},
-\code{$imp.tree} is retained so \code{plot.gg_varpro} can
-overlay per-tree jitter points in \code{plot.gg_varpro}.}
+\code{$imp.tree} is kept so \code{plot.gg_varpro} can scatter the
+per-tree points over the box.}
 
-\item{conditional}{Logical; default \code{FALSE}.  When \code{TRUE}
-(classification forests only) extracts the \code{$conditional.z}
-matrix and stores it as \code{$conditional}.}
+\item{conditional}{Logical; default \code{FALSE}.  When \code{TRUE}, and
+only for a classification forest, the \code{$conditional.z} matrix is
+extracted and stored as \code{$conditional}.}
 
-\item{nvar}{Integer; retain only the top \code{nvar} variables (by
-median per-tree z) after applying the cutoff filter.  \code{NULL} keeps all.}
+\item{nvar}{Integer; keep only the top \code{nvar} variables, ranked by
+median per-tree z, after the cutoff filter has been applied.
+\code{NULL} keeps all of them.}
 
 \item{...}{Additional arguments passed to \code{varPro::importance()}.}
 }
@@ -61,10 +62,12 @@ A \code{"provenance"} attribute carries \code{family}, \code{local.std},
 and \code{n}.
 }
 \description{
-Extracts per-tree importance scores from a fitted \code{varpro} object,
-summarises them into an honest boxplot-ready data structure (hinges at
-15th/85th percentile, whiskers at 5th/95th), and optionally retains
-class-conditional importance for classification forests.
+Pulls the per-tree importance scores out of a fitted \code{varpro} object
+and summarises them into a data structure the plot method can draw as a
+boxplot.  The box is an honest one: hinges at the 15th and 85th
+percentiles, whiskers at the 5th and 95th, no Tukey rule hiding in the
+middle.  For a classification forest you can also keep the
+class-conditional importances.
 }
 \examples{
 \donttest{

--- a/man/plot.gg_brier.Rd
+++ b/man/plot.gg_brier.Rd
@@ -23,9 +23,11 @@ contributions at each time, around the overall line. When \code{FALSE}
 A \code{ggplot} object.
 }
 \description{
-Plot the time-resolved Brier score (default) or running CRPS for a
-survival forest, optionally overlaid with a 15-85 percent per-subject
-envelope.
+Draws the time-resolved Brier score (the default) or the running CRPS as
+a curve against time.  A lower curve means a better-calibrated forecast.
+Turn \code{envelope = TRUE} on and the overall line picks up a ribbon
+spanning the 15th to 85th percentile of the per-subject contributions,
+which shows how much the score varies across subjects at each time.
 }
 \examples{
 \dontrun{

--- a/man/plot.gg_brier.Rd
+++ b/man/plot.gg_brier.Rd
@@ -24,7 +24,7 @@ A \code{ggplot} object.
 }
 \description{
 Draws the time-resolved Brier score (the default) or the running CRPS as
-a curve against time.  A lower curve means a better-calibrated forecast.
+a curve against time.  Lower means more accurate probabilistic predictions.
 Turn \code{envelope = TRUE} on and the overall line picks up a ribbon
 spanning the 15th to 85th percentile of the per-subject contributions,
 which shows how much the score varies across subjects at each time.

--- a/man/plot.gg_partial_varpro.Rd
+++ b/man/plot.gg_partial_varpro.Rd
@@ -16,27 +16,28 @@
 \code{"nonparametric"}, \code{"causal"}.  Defaults to all three.
 Ignored for path-C objects.}
 
-\item{...}{Not currently used for path-A objects; forwarded to
+\item{...}{Unused for path-A objects; forwarded to
 \code{plot.gg_partial_rfsrc} for path-C objects.}
 }
 \value{
 A \code{ggplot} (or \code{patchwork}) object.
 }
 \description{
-Produces ggplot2 partial dependence curves from the named list returned
-by \code{\link{gg_partial_varpro}}.  Continuous predictors are shown as
-overlaid line curves (one per effect type); categorical predictors as
-side-by-side boxplots.  For survival path-C objects (produced when
-\code{scale \%in\% c("surv","chf")} is passed to the extractor) the plot
-is delegated to \code{\link{plot.gg_partial_rfsrc}}.
+Draws the partial dependence curves from the list that
+\code{\link{gg_partial_varpro}} returns.  Continuous predictors get
+overlaid line curves, one per effect type; categorical predictors get
+side-by-side boxplots.  Survival path-C objects (the ones you get when
+\code{scale \%in\% c("surv","chf")} was passed to the extractor) are
+handed off to \code{\link{plot.gg_partial_rfsrc}}, which already knows
+how to draw them.
 }
 \details{
-**Ensemble mortality (scale = "mortality"):** When the provenance scale
-is \code{"mortality"}, the y-axis label reads
-\emph{"Ensemble mortality (expected events)"} to make clear that this
-is an \strong{unbounded relative-risk score}, not a survival probability
-or \eqn{1 - S(t)} (Ishwaran, Kogalur, Blackstone & Lauer, 2008
-<doi:10.1214/08-AOAS169>).
+**Ensemble mortality (scale = "mortality"):** when the provenance scale
+is \code{"mortality"}, the y-axis is labelled
+\emph{"Ensemble mortality (expected events)"}.  The wording is
+deliberate: this is an \strong{unbounded relative-risk score}, not a
+survival probability and not \eqn{1 - S(t)} (Ishwaran, Kogalur,
+Blackstone & Lauer, 2008 <doi:10.1214/08-AOAS169>).
 }
 \examples{
 set.seed(42)

--- a/man/plot.gg_partial_varpro.Rd
+++ b/man/plot.gg_partial_varpro.Rd
@@ -28,8 +28,7 @@ Draws the partial dependence curves from the list that
 overlaid line curves, one per effect type; categorical predictors get
 side-by-side boxplots.  Survival path-C objects (the ones you get when
 \code{scale \%in\% c("surv","chf")} was passed to the extractor) are
-handed off to \code{\link{plot.gg_partial_rfsrc}}, which already knows
-how to draw them.
+handed off to \code{\link{plot.gg_partial_rfsrc}} for drawing.
 }
 \details{
 **Ensemble mortality (scale = "mortality"):** when the provenance scale

--- a/man/plot.gg_roc.Rd
+++ b/man/plot.gg_roc.Rd
@@ -8,30 +8,29 @@
 }
 \arguments{
 \item{x}{A \code{\link{gg_roc}} object, or a raw
-\code{\link[randomForestSRC]{rfsrc}} classification forest or
-\code{\link[randomForest]{randomForest}} classification object.  When a
-forest is supplied, \code{\link{gg_roc}} is called automatically.}
+\code{\link[randomForestSRC]{rfsrc}} or
+\code{\link[randomForest]{randomForest}} classification forest. Hand it a
+forest and \code{\link{gg_roc}} is called for you.}
 
 \item{which_outcome}{Integer; for multi-class problems, the index of the
-class whose ROC curve should be plotted.  When \code{NULL} (default) and
-the forest has more than two classes, ROC curves for all classes are
-overlaid in a single plot.  For binary forests \code{NULL} defaults to
-class index 2.}
+class to plot. When \code{NULL} (default) and the forest has more than two
+classes, the curves for all classes are overlaid in one plot. For binary
+forests, \code{NULL} defaults to class index 2.}
 
-\item{...}{Additional arguments forwarded to \code{\link{gg_roc}} when
-\code{x} is a raw forest object (e.g. \code{oob = FALSE}).}
+\item{...}{Additional arguments passed to \code{\link{gg_roc}} when
+\code{x} is a raw forest (e.g. \code{oob = FALSE}).}
 
-\item{panel}{Character; layout for per-class ROC objects (those produced by
-\code{gg_roc(..., per_class = TRUE)}). \code{"overlay"} (default) draws all
-class curves in one panel coloured by class; \code{"facet"} wraps each
-class into its own panel. Ignored for single-class \code{gg_roc} objects.}
+\item{panel}{Character; layout for per-class ROC objects, the ones from
+\code{gg_roc(..., per_class = TRUE)}. \code{"overlay"} (default) draws
+every class curve in one panel, coloured by class; \code{"facet"} gives
+each class its own panel. Ignored for single-class \code{gg_roc} objects.}
 }
 \value{
-A \code{ggplot} object.  The x-axis shows 1 - Specificity (FPR)
-  and the y-axis shows Sensitivity (TPR).  A dashed red diagonal reference
-  line marks the random-classifier baseline.  The AUC value is annotated
-  on the plot for single-class curves.  Multi-class plots colour and style
-  each class curve distinctly.
+A \code{ggplot} object. The x-axis is 1 - Specificity (FPR), the
+  y-axis is Sensitivity (TPR), and a dashed red diagonal marks the
+  random-classifier baseline. Single-class curves carry the AUC as an
+  annotation; multi-class plots colour and style each class curve
+  distinctly.
 }
 \description{
 ROC plot generic function for a \code{\link{gg_roc}} object.

--- a/man/plot.gg_udependent.Rd
+++ b/man/plot.gg_udependent.Rd
@@ -9,9 +9,10 @@
 \arguments{
 \item{x}{A \code{gg_udependent} object from \code{\link{gg_udependent}}.}
 
-\item{layout}{Character; igraph/ggraph layout algorithm.  Common choices:
-\code{"fr"} (Fruchterman-Reingold, default), \code{"kk"}
-(Kamada-Kawai), \code{"stress"}, \code{"circle"}, \code{"grid"}.}
+\item{layout}{Character; the igraph/ggraph layout algorithm.  Common
+choices are \code{"fr"} (Fruchterman-Reingold, the default),
+\code{"kk"} (Kamada-Kawai), \code{"stress"}, \code{"circle"}, and
+\code{"grid"}.}
 
 \item{...}{Not currently used.}
 }
@@ -19,18 +20,20 @@
 A \code{ggplot} object (built via ggraph).
 }
 \description{
-Renders the variable dependency graph from a \code{gg_udependent} object
-as a ggraph network plot. Nodes are coloured by selection status; edge
-width and opacity reflect dependency strength.
+Draws the dependency graph held in a \code{gg_udependent} object as a
+ggraph network.  Node colour marks whether a variable made the signal
+set, and the width and opacity of an edge tell you how strong the
+dependency between its two variables is.
 }
 \details{
-Requires the \pkg{ggraph} package (\code{Suggests}).  Install it with
+This plot needs the \pkg{ggraph} package, which is in \code{Suggests}
+rather than installed for you.  If it is missing, run
 \code{install.packages("ggraph")}.
 
-Node colour: blue (\code{#4e8fcd}) for signal variables
-(\code{selected = TRUE}), grey (\code{#888888}) otherwise.
-Node size scales with degree.  Edge width and opacity scale with raw
-dependency weight (\code{I[i,j]}).
+A signal variable (\code{selected = TRUE}) gets a blue node
+(\code{#4e8fcd}); the rest are grey (\code{#888888}).  Node size grows
+with degree.  Edge width and opacity both grow with the raw dependency
+weight \code{I[i,j]}.
 }
 \examples{
 \donttest{

--- a/man/plot.gg_variable.Rd
+++ b/man/plot.gg_variable.Rd
@@ -38,13 +38,13 @@
 }
 \value{
 A single \code{ggplot} object when \code{length(xvar) == 1} or
-  \code{panel = TRUE}; otherwise a \code{patchwork} composite stacking
-  one panel per variable in \code{xvar}. Always a single plottable
-  object (never a bare list) so it composes naturally with
+  \code{panel = TRUE}; otherwise a \code{patchwork} composite that stacks
+  one panel per variable in \code{xvar}. Either way the result is one
+  plottable object, never a bare list, so it composes with
   \code{patchwork} and dispatches through \code{ggplot2::autoplot()}.
-  For the patchwork case, callers wanting to inspect a specific
-  panel with \code{ggplot2::layer_data()} should extract that panel
-  first (e.g. \code{ggplot2::layer_data(p[[1]])}).
+  For the patchwork case, to inspect one panel with
+  \code{ggplot2::layer_data()} pull that panel out first
+  (e.g. \code{ggplot2::layer_data(p[[1]])}).
 }
 \description{
 Plot a \code{\link{gg_variable}} object,

--- a/man/plot.gg_varpro.Rd
+++ b/man/plot.gg_varpro.Rd
@@ -9,11 +9,11 @@
 \arguments{
 \item{x}{A \code{gg_varpro} object from \code{\link{gg_varpro}}.}
 
-\item{type}{Character; controls the display scale.  When omitted,
-auto-detected from \code{provenance$local.std}: \code{"z"} if
-\code{local.std = TRUE} (the default), \code{"raw"} if
-\code{local.std = FALSE}.  Explicitly supplying a value that conflicts
-with the extract-time setting raises an error.}
+\item{type}{Character; the display scale.  Leave it off and it is read
+from \code{provenance$local.std}: \code{"z"} when \code{local.std =
+TRUE} (the default), \code{"raw"} when \code{local.std = FALSE}.
+Asking for a scale that the extract step did not prepare raises an
+error.}
 
 \item{...}{Not currently used.}
 }
@@ -21,26 +21,28 @@ with the extract-time setting raises an error.}
 A \code{ggplot} object.
 }
 \description{
-Renders a horizontal boxplot of per-tree importance z-scores (or raw
-importances) with optional per-tree jitter overlay (\code{faithful=TRUE})
-or class-conditional facets (\code{conditional=TRUE}).
+Draws a horizontal boxplot of the per-tree importance z-scores, or of the
+raw importances if you asked for those.  Set \code{faithful = TRUE} at
+extract time and the per-tree points are scattered over the box; for a
+classification forest, \code{conditional = TRUE} splits the picture into
+one facet per class.
 }
 \details{
-**Honest boxplot geometry:** Hinges are the 15th and 85th percentiles of
-the per-tree z-distribution; whiskers extend to the 5th and 95th
-percentiles.  This is \strong{not} a Tukey boxplot.  A mandatory plot
-caption states this explicitly.
+**Honest boxplot geometry:** the hinges are the 15th and 85th percentiles
+of the per-tree z-distribution, and the whiskers run to the 5th and 95th.
+This is \strong{not} a Tukey boxplot, and the plot carries a caption that
+says so.
 
-**\code{faithful = TRUE}:** Per-tree values are overlaid as jittered
-semi-transparent points on the same scale as the boxplot (z-scale when
-\code{local.std = TRUE}, raw-scale when \code{local.std = FALSE}); the
-box is drawn at reduced opacity; a white-outlined filled dot marks the
-mean.
+**\code{faithful = TRUE}:** the per-tree values are jittered over the box
+as semi-transparent points, on the same scale as the box itself (z when
+\code{local.std = TRUE}, raw when \code{local.std = FALSE}).  The box is
+drawn faint to let the points show through, and a white-outlined dot
+marks the mean.
 
-**\code{conditional = TRUE}:** The conditional class-importance scores
+**\code{conditional = TRUE}:** the class-conditional importances
 (\code{$conditional}) are shown as a faceted bar chart
-(\code{facet_wrap(~class, nrow = 1)}); variable sort order follows the
-unconditional median z from \code{$stats}.
+(\code{facet_wrap(~class, nrow = 1)}).  Variables keep the sort order set
+by the unconditional median z in \code{$stats}, so the facets line up.
 }
 \examples{
 \donttest{

--- a/man/plot.gg_varpro.Rd
+++ b/man/plot.gg_varpro.Rd
@@ -24,14 +24,14 @@ A \code{ggplot} object.
 Draws a horizontal boxplot of the per-tree importance z-scores, or of the
 raw importances if you asked for those.  Set \code{faithful = TRUE} at
 extract time and the per-tree points are scattered over the box; for a
-classification forest, \code{conditional = TRUE} splits the picture into
-one facet per class.
+classification forest, \code{conditional = TRUE} splits the plot into one
+facet per class.
 }
 \details{
-**Honest boxplot geometry:** the hinges are the 15th and 85th percentiles
-of the per-tree z-distribution, and the whiskers run to the 5th and 95th.
-This is \strong{not} a Tukey boxplot, and the plot carries a caption that
-says so.
+**Boxplot geometry:** the hinges are the 15th and 85th percentiles of the
+per-tree z-distribution, and the whiskers run to the 5th and 95th.  This
+is \strong{not} a Tukey boxplot, and the plot carries a caption that says
+so.
 
 **\code{faithful = TRUE}:** the per-tree values are jittered over the box
 as semi-transparent points, on the same scale as the box itself (z when

--- a/man/print.gg.Rd
+++ b/man/print.gg.Rd
@@ -55,14 +55,14 @@
 The object \code{x}, invisibly.
 }
 \description{
-Each \code{print.gg_*()} method emits a single-line header containing the
-class label and, when available, forest provenance metadata (source package,
-family, ntree, n). The object is returned invisibly so \code{print()} calls
-chain cleanly in pipes.
+Each \code{print.gg_*()} method prints a one-line header: the class label
+and, where the forest recorded it, provenance (source package, family,
+ntree, n). It returns the object invisibly, so \code{print()} sits cleanly
+in a pipe.
 }
 \details{
-To inspect rows use \code{head()}.  To retrieve per-class diagnostics use
-\code{\link{summary.gg}}.
+To see the rows themselves, use \code{head()}; for per-class diagnostics,
+use \code{\link{summary.gg}}.
 }
 \examples{
 set.seed(42)

--- a/man/summary.gg.Rd
+++ b/man/summary.gg.Rd
@@ -54,15 +54,17 @@
 \item{object}{A \code{gg_*} data object.}
 }
 \value{
-A \code{summary.gg} object (a list with \code{header} and
-  \code{body} character vectors), returned invisibly from
-  \code{print.summary.gg}.
+A \code{summary.gg} object: a list with \code{header} and
+  \code{body} character vectors. \code{print.summary.gg} returns it
+  invisibly.
 }
 \description{
-Each \code{summary.gg_*()} method returns a \code{summary.gg} object
-containing a header line and per-class diagnostic statistics (OOB error
-curve, top VIMP variables, time range, integrated CRPS, etc.).
-\code{print.summary.gg()} renders the object to the console.
+Where \code{print} gives you a one-line header, \code{summary} digs a level
+deeper. Each \code{summary.gg_*()} method returns a \code{summary.gg}
+object: a header line plus a few diagnostic statistics for that object
+type (the OOB error curve, the top VIMP variables, a time range, the
+integrated CRPS, and so on). \code{print.summary.gg()} renders it to the
+console.
 }
 \examples{
 set.seed(42)

--- a/man/surv_partial.rfsrc.Rd
+++ b/man/surv_partial.rfsrc.Rd
@@ -40,9 +40,9 @@ returns a classed \code{gg_partial_rfsrc} object with a dedicated
 }
 \details{
 Computes partial dependence curves for a survival or competing-risk
-\code{\link[randomForestSRC]{rfsrc}} forest by calling
+\code{\link[randomForestSRC]{rfsrc}} forest.  For each predictor it calls
 \code{\link[randomForestSRC]{partial.rfsrc}} at \code{npts} evenly-spaced
-unique values of each predictor across all stored event times.
+unique values, across every stored event time.
 }
 \examples{
 ## ------------------------------------------------------------

--- a/man/varpro_feature_names.Rd
+++ b/man/varpro_feature_names.Rd
@@ -18,9 +18,9 @@ character vector of unique original variable names (no suffixes)
 }
 \description{
 \code{varpro} one-hot encodes factor variables, appending a numeric suffix
-for each level (e.g., \code{sex} becomes \code{sex0} and \code{sex1}).
-This function strips those suffixes iteratively until every name in
-\code{varpro_names} can be matched back to a column in \code{dataset}.
+for each level -- \code{sex} becomes \code{sex0} and \code{sex1}.  To map
+those back, this function strips the suffix one character at a time until
+every name in \code{varpro_names} matches a column in \code{dataset}.
 }
 \examples{
 ## ------------------------------------------------------------------

--- a/vignettes/ggRandomForests-regression.qmd
+++ b/vignettes/ggRandomForests-regression.qmd
@@ -245,7 +245,7 @@ $$
 
 We use `gg_partial_rfsrc()`, which calls `randomForestSRC::partial.rfsrc()`
 directly and returns a `gg_partial_rfsrc` object. The quickest path to a
-figure is `plot(pd)` --- it sorts out continuous and categorical variables
+figure is `plot(pd)`, which sorts out continuous and categorical variables
 for you. When you want to control the layout yourself, the underlying data
 is in `pd$continuous`.
 
@@ -269,8 +269,8 @@ ggplot(pd$continuous, aes(x = x, y = yhat)) +
 
 `lstat` shows a strongly concave relationship, while `rm` stays flat below
 about 6 rooms and then climbs sharply. Shapes like these are awkward to
-capture with a simple parametric transform --- you would have to guess the
-form in advance --- but the random forest picks them up on its own.
+capture with a simple parametric transform, since you would have to guess
+the form in advance, but the random forest picks them up on its own.
 
 # Variable Interactions and Conditioning Plots
 
@@ -400,7 +400,7 @@ We have walked a full random forest regression analysis with
 
 - `gg_error()` showed the OOB error settling well before 500 trees.
 - VIMP (`gg_vimp()`) and minimal depth (`max.subtree()`) agreed on the same
-  story --- `lstat` and `rm` dominate, with a clear gap to everything else.
+  story: `lstat` and `rm` dominate, with a clear gap to everything else.
 - `gg_variable()` traced strongly non-linear predictor--response curves, the
   same shapes the raw-data EDA hinted at.
 - Partial dependence from `gg_partial_rfsrc()` gave the risk-adjusted version

--- a/vignettes/ggRandomForests-regression.qmd
+++ b/vignettes/ggRandomForests-regression.qmd
@@ -408,8 +408,9 @@ We have walked a full random forest regression analysis with
 - Conditioning plots and the interactive surface pulled out the `lstat`--`rm`
   interaction, with the room-size effect strongest in high-status tracts.
 
-Notice the pattern in all of this. Each `gg_*()` function returns a plain
-tidy data frame; the plotting is a separate step. Use the package's `plot()`
+Notice the pattern in all of this. Each `gg_*()` function returns a tidy
+object (often a data frame, sometimes a small list of data frames); the
+plotting is a separate step. Use the package's `plot()`
 methods when the default figure is what you want, and reach for `ggplot2`
 directly when it is not.
 

--- a/vignettes/ggRandomForests-regression.qmd
+++ b/vignettes/ggRandomForests-regression.qmd
@@ -128,9 +128,10 @@ ggplot(dta, aes(x = medv, y = value, color = chas)) +
   facet_wrap(~variable, scales = "free_y", ncol = 3)
 ```
 
-Even from this simple view, the strong relationship between `medv` and both
-`lstat` (lower status %) and `rm` (rooms per dwelling) is apparent. We expect
-the random forest to confirm these as the most important predictors.
+Even from this simple view, two relationships stand out: `medv` against
+`lstat` (lower status %) and `medv` against `rm` (rooms per dwelling). Keep
+those two in mind --- we expect the random forest to rank them as the most
+important predictors, and the rest of the vignette comes back to check.
 
 # Growing a Random Forest
 
@@ -243,9 +244,10 @@ $$
 $$
 
 We use `gg_partial_rfsrc()`, which calls `randomForestSRC::partial.rfsrc()`
-directly and returns a `gg_partial_rfsrc` object.  The quickest path to a plot
-is `plot(pd)`, which handles continuous and categorical variables automatically.
-For a custom layout we can also access `pd$continuous` directly.
+directly and returns a `gg_partial_rfsrc` object. The quickest path to a
+figure is `plot(pd)` --- it sorts out continuous and categorical variables
+for you. When you want to control the layout yourself, the underlying data
+is in `pd$continuous`.
 
 ```{r partial-dep, fig.cap="Partial dependence for top predictors."}
 pd <- gg_partial_rfsrc(rfsrc_Boston, xvar.names = xvar)
@@ -265,10 +267,10 @@ ggplot(pd$continuous, aes(x = x, y = yhat)) +
   theme_bw()
 ```
 
-`lstat` shows a strongly concave relationship, while `rm` has a flat region
-below ~6 rooms before increasing sharply. These non-linear shapes are difficult
-to capture with simple parametric transforms but are naturally handled by the
-random forest.
+`lstat` shows a strongly concave relationship, while `rm` stays flat below
+about 6 rooms and then climbs sharply. Shapes like these are awkward to
+capture with a simple parametric transform --- you would have to guess the
+form in advance --- but the random forest picks them up on its own.
 
 # Variable Interactions and Conditioning Plots
 
@@ -393,23 +395,22 @@ capture naturally.
 
 # Conclusion
 
-This vignette demonstrated a complete random forest regression analysis using
-**randomForestSRC** and **ggRandomForests**:
+We have walked a full random forest regression analysis with
+**randomForestSRC** and **ggRandomForests**, and the pieces line up:
 
-- **OOB error** via `gg_error()` showed the forest stabilized quickly.
-- **VIMP** via `gg_vimp()` and **minimal depth** via `max.subtree()` both
-  identified `lstat` and `rm` as the dominant predictors, with a clear gap to
-  the remaining variables.
-- **Variable dependence** via `gg_variable()` revealed strongly non-linear
-  predictor--response relationships that match the raw data EDA.
-- **Partial dependence** via `gg_partial_rfsrc()` provided risk-adjusted
-  confirmation, showing concave `lstat` and threshold-like `rm` effects.
-- **Conditioning plots** and **interactive surfaces** exposed the `lstat`--`rm`
-  interaction, where the room-size effect is strongest in high-status
-  neighborhoods.
+- `gg_error()` showed the OOB error settling well before 500 trees.
+- VIMP (`gg_vimp()`) and minimal depth (`max.subtree()`) agreed on the same
+  story --- `lstat` and `rm` dominate, with a clear gap to everything else.
+- `gg_variable()` traced strongly non-linear predictor--response curves, the
+  same shapes the raw-data EDA hinted at.
+- Partial dependence from `gg_partial_rfsrc()` gave the risk-adjusted version
+  of those curves: concave for `lstat`, threshold-like for `rm`.
+- Conditioning plots and the interactive surface pulled out the `lstat`--`rm`
+  interaction, with the room-size effect strongest in high-status tracts.
 
-The **ggRandomForests** design separates data extraction from plotting: every
-`gg_*()` function returns a tidy data frame that can be plotted with the
-package's `plot()` methods or fed directly into custom `ggplot2` workflows.
+Notice the pattern in all of this. Each `gg_*()` function returns a plain
+tidy data frame; the plotting is a separate step. Use the package's `plot()`
+methods when the default figure is what you want, and reach for `ggplot2`
+directly when it is not.
 
 # References

--- a/vignettes/ggRandomForests-survival.qmd
+++ b/vignettes/ggRandomForests-survival.qmd
@@ -613,7 +613,7 @@ plot(gg_bs, envelope = TRUE)
 ```
 
 The running CRPS (continuous ranked probability score) is the Brier score
-integrated over time and divided by elapsed time --- in other words, the
+integrated over time and divided by elapsed time, in other words the
 time-average of the curve above. It collapses the whole trajectory into one
 running number, which is handy when you want a single accuracy figure rather
 than a curve to read.
@@ -638,7 +638,7 @@ We have walked a full random survival forest analysis with
   the PBC trial, the same conclusion reached in @fleming:1991.
 - `gg_error()` showed the OOB error settling quickly as trees were added.
 - VIMP (`gg_vimp()`) and minimal depth (`max.subtree()`) landed on the same
-  five predictors --- bilirubin, albumin, copper, prothrombin, and age ---
+  five predictors (bilirubin, albumin, copper, prothrombin, and age),
   which is also where the proportional hazards model landed.
 - `gg_variable()` exposed non-proportional hazards for bilirubin and copper,
   where the gap between time horizons widens.

--- a/vignettes/ggRandomForests-survival.qmd
+++ b/vignettes/ggRandomForests-survival.qmd
@@ -649,8 +649,9 @@ We have walked a full random survival forest analysis with
 - `gg_brier()` measured how accurate the predictions actually were, both
   across time and as a single CRPS summary.
 
-Notice the pattern. Each `gg_*()` function returns a plain tidy data frame;
-the plotting comes after. Lean on the package's `plot()` methods when the
+Notice the pattern. Each `gg_*()` function returns a tidy object (often a
+data frame, sometimes a small list of data frames); the plotting comes
+after. Lean on the package's `plot()` methods when the
 default figure works, and drop down to `ggplot2` directly when it does not.
 
 # References

--- a/vignettes/ggRandomForests-survival.qmd
+++ b/vignettes/ggRandomForests-survival.qmd
@@ -584,35 +584,39 @@ in the conditional plots.
 
 ## Brier Score and CRPS
 
-The Brier score measures prediction accuracy at each point on the event-time
-grid by comparing predicted survival probabilities to observed outcomes, with
-inverse-probability-of-censoring weighting (IPCW) to account for
-right-censoring [@graf:1999]. `gg_brier()` wraps
-`randomForestSRC::get.brier.survival()` and returns a tidy data frame ready
-for plotting.
+VIMP and minimal depth tell us which predictors matter, but they say nothing
+about how good the forest's survival predictions actually are. The Brier
+score answers that question. At each point on the event-time grid it compares
+the predicted survival probability against what actually happened, with
+inverse-probability-of-censoring weighting (IPCW) so that right-censored
+subjects do not bias the result [@graf:1999]. `gg_brier()` wraps
+`randomForestSRC::get.brier.survival()` and hands back a tidy data frame
+ready to plot.
 
 ```{r brier-overall, fig.width=7, fig.height=3.5, fig.cap="Time-resolved Brier score for the PBC survival forest."}
 gg_bs <- gg_brier(rfsrc_pbc)
 plot(gg_bs)
 ```
 
-The score starts near zero (all subjects alive, predictions trivially correct),
-peaks around the median event time where uncertainty is greatest, then
-decreases as the remaining at-risk pool shrinks.
+Read the curve left to right. Early on it sits near zero --- almost everyone
+is still alive, so predicting survival is easy. It climbs to a peak around the
+median event time, where the outcome is genuinely uncertain, then falls again
+as the at-risk pool shrinks and the remaining predictions get easier.
 
-The 15--85% per-subject envelope shows how spread the individual Brier
-contributions are at each time. A narrow ribbon indicates the forest assigns
-similar predicted risks across subjects; a wide ribbon points to
-heterogeneous risk predictions.
+Setting `envelope = TRUE` adds a 15--85% ribbon around that line, showing how
+spread out the individual subjects' Brier contributions are at each time. A
+narrow ribbon means the forest is assigning similar risks across subjects; a
+wide one means the predicted risks are pulling apart.
 
 ```{r brier-envelope, fig.width=7, fig.height=3.5, fig.cap="Brier score with 15--85% per-subject envelope."}
 plot(gg_bs, envelope = TRUE)
 ```
 
-The running CRPS (continuous ranked probability score) integrates the Brier
-score over time, normalised by elapsed time. It provides a single
-time-averaged accuracy measure that penalises poorly calibrated predictions
-throughout the follow-up period.
+The running CRPS (continuous ranked probability score) is the Brier score
+integrated over time and divided by elapsed time --- in other words, the
+time-average of the curve above. It collapses the whole trajectory into one
+running number, which is handy when you want a single accuracy figure rather
+than a curve to read.
 
 ```{r brier-crps, fig.width=7, fig.height=3.5, fig.cap="Running CRPS for the PBC survival forest."}
 plot(gg_bs, type = "crps")
@@ -627,26 +631,26 @@ attr(gg_bs, "crps_integrated")
 
 # Conclusion
 
-This vignette demonstrated a complete random survival forest analysis using
-**randomForestSRC** and **ggRandomForests**:
+We have walked a full random survival forest analysis with
+**randomForestSRC** and **ggRandomForests**, and the results hang together:
 
-- **Kaplan--Meier curves** via `gg_survival()` confirmed no treatment effect in
-  the PBC trial, consistent with @fleming:1991.
-- **OOB error** via `gg_error()` showed the forest stabilized quickly.
-- **VIMP** via `gg_vimp()` and **minimal depth** via `max.subtree()` both
-  identified bilirubin, albumin, copper, prothrombin, and age as key
-  predictors --- matching the proportional hazards model.
-- **Variable dependence** via `gg_variable()` revealed non-proportional hazards
-  effects for bilirubin and copper.
-- **Partial dependence** via `gg_partial_rfsrc()` provided risk-adjusted
-  confirmation and supported the log-transforms used in parametric models.
-- **Conditional plots** and **interactive surfaces** exposed the bilirubin--albumin
-  interaction.
-- **Brier score and CRPS** via `gg_brier()` quantified time-resolved prediction
-  accuracy and overall calibration of the survival forest.
+- `gg_survival()` drew Kaplan--Meier curves that showed no treatment effect in
+  the PBC trial, the same conclusion reached in @fleming:1991.
+- `gg_error()` showed the OOB error settling quickly as trees were added.
+- VIMP (`gg_vimp()`) and minimal depth (`max.subtree()`) landed on the same
+  five predictors --- bilirubin, albumin, copper, prothrombin, and age ---
+  which is also where the proportional hazards model landed.
+- `gg_variable()` exposed non-proportional hazards for bilirubin and copper,
+  where the gap between time horizons widens.
+- Partial dependence from `gg_partial_rfsrc()` gave the risk-adjusted version
+  of those curves and backed the log-transforms used in the parametric model.
+- Conditioning plots and the interactive surface drew out the
+  bilirubin--albumin interaction.
+- `gg_brier()` measured how accurate the predictions actually were, both
+  across time and as a single CRPS summary.
 
-The **ggRandomForests** design separates data extraction from plotting: every
-`gg_*()` function returns a tidy data frame that can be plotted with the
-package's `plot()` methods or fed directly into custom `ggplot2` workflows.
+Notice the pattern. Each `gg_*()` function returns a plain tidy data frame;
+the plotting comes after. Lean on the package's `plot()` methods when the
+default figure works, and drop down to `ggplot2` directly when it does not.
 
 # References

--- a/vignettes/ggRandomForests.qmd
+++ b/vignettes/ggRandomForests.qmd
@@ -114,5 +114,6 @@ facet labels.
 * The full API reference lives at <https://ehrlinger.github.io/ggRandomForests/>.
 * `?gg_error`, `?gg_variable`, `?gg_vimp`, and `?quantile_pts` cover the
   remaining arguments and have their own examples.
-* Every `gg_*` object is a plain data frame underneath, so you can skip the
-  `plot()` methods entirely and build the figure yourself with `ggplot2`.
+* The `gg_error`, `gg_variable`, and `gg_vimp` objects shown here are tidy
+  data frames underneath, so you can skip the `plot()` methods entirely and
+  build the figure yourself with `ggplot2`.

--- a/vignettes/ggRandomForests.qmd
+++ b/vignettes/ggRandomForests.qmd
@@ -21,7 +21,7 @@ plotted directly. **ggRandomForests** does that digging for you: it pulls
 tidy data objects out of a `randomForestSRC` or `randomForest` fit, and
 those objects drop straight into the `ggplot2` workflows you already know.
 This vignette walks through the three objects you will reach for most often
---- `gg_error`, `gg_variable`, and `gg_vimp` --- plus a small helper for
+(`gg_error`, `gg_variable`, and `gg_vimp`), plus a small helper for
 cutting a predictor into evenly populated groups.
 
 ```{r pkg-setup, include=FALSE}
@@ -67,7 +67,7 @@ str(var_df[, c("lstat", "yhat")])
 
 `gg_variable()` recovers the training data straight from the model call,
 so it still works when the forest was fit inside a helper function or
-against a `subset()` expression --- cases where the data is not sitting in
+against a `subset()` expression, cases where the data is not sitting in
 the global environment. The object you get back keeps the raw predictors
 alongside the prediction: a single `yhat` column for regression, or one
 `yhat.<class>` column per class for classification. To plot one predictor,
@@ -90,8 +90,8 @@ plot(vimp_df)
 
 Variable importance is not always stored on the fitted object. If a
 `randomForest` fit is missing its importance scores, `gg_vimp()` will try to
-compute them for you. When even that is not possible --- the forest was grown
-with `importance = FALSE` and the predictors are no longer reachable ---
+compute them for you. When even that is not possible (the forest was grown
+with `importance = FALSE` and the predictors are no longer reachable),
 the function warns and returns `NA` in place of the scores, so a plot still
 draws rather than failing outright.
 

--- a/vignettes/ggRandomForests.qmd
+++ b/vignettes/ggRandomForests.qmd
@@ -15,11 +15,14 @@ vignette: >
   %\VignetteEncoding{UTF-8}
 ---
 
-The **ggRandomForests** package extracts tidy data objects from either
-`randomForestSRC` or `randomForest` fits and feeds them into familiar
-`ggplot2` workflows. This vignette highlights the most common objects—
-`gg_error`, `gg_variable`, and `gg_vimp`—along with a small helper for
-building balanced conditioning intervals.
+A fitted random forest carries a lot of information, but getting at it
+usually means digging through list structures that were never meant to be
+plotted directly. **ggRandomForests** does that digging for you: it pulls
+tidy data objects out of a `randomForestSRC` or `randomForest` fit, and
+those objects drop straight into the `ggplot2` workflows you already know.
+This vignette walks through the three objects you will reach for most often
+--- `gg_error`, `gg_variable`, and `gg_vimp` --- plus a small helper for
+cutting a predictor into evenly populated groups.
 
 ```{r pkg-setup, include=FALSE}
 if (requireNamespace("ggRandomForests", quietly = TRUE)) {
@@ -41,10 +44,12 @@ err_df <- ggRandomForests::gg_error(rf_iris, training = TRUE)
 head(err_df)
 ```
 
-The `gg_error()` object stores the cumulative OOB error rate for each
-outcome column plus the `ntree` counter. When `training = TRUE`, the
-function reconstructs the original model frame and appends the in-bag
-error trajectory (`train`). Plotting overlays both curves by default:
+A forest's error rate settles down as trees are added, and the `gg_error()`
+object lets you watch that happen. It holds the cumulative out-of-bag (OOB)
+error rate for each outcome column, indexed by the `ntree` counter. Ask for
+`training = TRUE` and the function reconstructs the original model frame and
+adds the in-bag error trajectory (`train`) as well, so you can see both
+curves at once:
 
 ```{r error-plot, fig.height=4}
 plot(err_df)
@@ -60,12 +65,13 @@ var_df <- ggRandomForests::gg_variable(rf_boston)
 str(var_df[, c("lstat", "yhat")])
 ```
 
-Because the original training data are recovered from the model call,
-`gg_variable()` works even when the forest was trained within helper
-functions or against a `subset()` expression. The output keeps the raw
-predictors plus either a continuous `yhat` column (regression) or per-class
-probabilities (`yhat.<class>` for classification). Plotting a single
-variable is straightforward:
+`gg_variable()` recovers the training data straight from the model call,
+so it still works when the forest was fit inside a helper function or
+against a `subset()` expression --- cases where the data is not sitting in
+the global environment. The object you get back keeps the raw predictors
+alongside the prediction: a single `yhat` column for regression, or one
+`yhat.<class>` column per class for classification. To plot one predictor,
+name it with `xvar`:
 
 ```{r variable-plot, fig.height=4}
 plot(var_df, xvar = "lstat")
@@ -82,11 +88,12 @@ head(vimp_df)
 plot(vimp_df)
 ```
 
-If a `randomForest` object lacks stored importance scores, `gg_vimp()`
-tries to compute them on the fly. When the forest truly cannot provide the
-information (for example when `importance = FALSE` and the predictors are
-no longer accessible), the function emits a warning and returns `NA`
-placeholders so plots still render.
+Variable importance is not always stored on the fitted object. If a
+`randomForest` fit is missing its importance scores, `gg_vimp()` will try to
+compute them for you. When even that is not possible --- the forest was grown
+with `importance = FALSE` and the predictors are no longer reachable ---
+the function warns and returns `NA` in place of the scores, so a plot still
+draws rather than failing outright.
 
 ## Balanced conditioning cuts with `quantile_pts()`
 
@@ -96,13 +103,16 @@ rm_groups <- cut(boston$rm, breaks = rm_breaks)
 table(rm_groups)
 ```
 
-The helper wraps `stats::quantile()` to produce evenly populated strata
-that drop directly into `cut()` when building coplots or facet labels.
+When you build a coplot, you want each conditioning group to hold a roughly
+equal share of the data --- equal-width bins leave the sparse tails nearly
+empty. `quantile_pts()` wraps `stats::quantile()` to give you break points
+that do exactly that, and they pass straight to `cut()` for the grouping or
+facet labels.
 
 ## Next steps
 
-* Inspect the full API reference at <https://ehrlinger.github.io/ggRandomForests/>.
-* Use `?gg_error`, `?gg_variable`, `?gg_vimp`, and `?quantile_pts` for
-  additional arguments and examples.
-* Pair these data objects with your own `ggplot2` themes to align with your
-  preferred publication style.
+* The full API reference lives at <https://ehrlinger.github.io/ggRandomForests/>.
+* `?gg_error`, `?gg_variable`, `?gg_vimp`, and `?quantile_pts` cover the
+  remaining arguments and have their own examples.
+* Every `gg_*` object is a plain data frame underneath, so you can skip the
+  `plot()` methods entirely and build the figure yourself with `ggplot2`.


### PR DESCRIPTION
## Summary

Rewrites the AI-written documentation across ggRandomForests so the package reads in one consistent human voice. Voice-only: no factual or content changes. Function signatures, argument names, return-value facts, example code, version numbers, and issue references are unchanged.

Covers roxygen (varPro family, gg_brier, ROC/randomForest surface, gg_partial family, S3 methods), the three vignettes, README, and the v2.8.0 NEWS entries. Mixed files had only their 2026-era AI prose rewritten; original JSS-era prose was left untouched.

Adds `dev/voice-fingerprint.md` (the two-register voice reference, synced from the author's vault) and `dev/voice-audit-classification.md` (records what was and was not in scope). Design spec and implementation plan are in `dev/plans/`.

## Test plan
- [x] devtools::check(args = "--as-cran") — 0 errors, 0 warnings, 0 notes
- [x] All 3 vignettes render
- [x] devtools::test() — 0 failures
- [x] Em-dash density: added <= removed
- [x] Diff is documentation-only (roxygen/man/vignettes/README/NEWS/dev), no code or test changes