### PR TITLE
Release v3.0.0 (varPro integration)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: ggRandomForests
 Type: Package
 Title: Visually Exploring Random Forests
-Version: 2.7.3.9016
+Version: 3.0.0
 Date: 2026-05-28
 Authors@R: person("John", "Ehrlinger",
   role = c("aut", "cre"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,9 +8,8 @@ ggRandomForests v3.0.0
   major-version territory. Survival / multivariate varPro families,
   ROC confidence intervals, and hazard estimates are deferred to
   v3.1.0.
-* CRAN-audit cleanup: the
-  `gg_brier()` / `plot.gg_brier()` examples move from `\dontrun` to
-  `\donttest` (so they execute under `R CMD check --as-cran` and on
+* CRAN-audit cleanup: the `gg_brier()` / `plot.gg_brier()` examples move
+  from `\dontrun` to `\donttest` (so they execute under `R CMD check --as-cran` and on
   CRAN; `library(survival)` added so `Surv()` resolves), the
   per-variable `message()` in the deprecated `surv_partial.rfsrc()` is
   removed (its one behaviour change: that function no longer prints a

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,14 @@
 Package: ggRandomForests
-Version: 2.7.3.9016
+Version: 3.0.0
 
-ggRandomForests v3.0.0 (development) — continued
-=================================================
-* CRAN-audit cleanup ahead of the v3.0.0 release candidate: the
+ggRandomForests v3.0.0
+======================
+* **Version jump to 3.0.0.** The varPro integration is a major scope
+  expansion plus the `gg_partialpro()` soft-deprecation, which is
+  major-version territory. Survival / multivariate varPro families,
+  ROC confidence intervals, and hazard estimates are deferred to
+  v3.1.0.
+* CRAN-audit cleanup: the
   `gg_brier()` / `plot.gg_brier()` examples move from `\dontrun` to
   `\donttest` (so they execute under `R CMD check --as-cran` and on
   CRAN; `library(survival)` added so `Surv()` resolves), the
@@ -11,10 +16,6 @@ ggRandomForests v3.0.0 (development) — continued
   removed (its one behaviour change: that function no longer prints a
   line per variable), and the README points to the new "varpro"
   vignette.
-* This release is renumbered to **v3.0.0** (from the working v2.8.0
-  label). The varPro integration is a major scope expansion plus a
-  soft-deprecation (`gg_partialpro`), which is major-version territory.
-  Deferred-work references move to v3.1.0.
 * Fix: importance plots now consistently put the most-important variable
   at the **top**. `gg_varpro()`, `gg_beta_varpro()`, and `gg_ivarpro()`
   previously built their `variable` factor with descending levels, so
@@ -176,9 +177,6 @@ ggRandomForests v3.0.0 (development) — continued
     `facet_wrap(~class, nrow=1)` bar chart.
   - Set `local.std = FALSE` to allow `plot(..., type = "raw")`, which shows
     raw per-tree importance instead of the z-normalised values.
-
-ggRandomForests v3.0.0 (development)
-====================================
 * `gg_variable.randomForest`: classification fix (#87).
   - For a classification forest, `gg_variable.randomForest()` now stores
     per-class OOB vote fractions as `yhat.<classname>` columns, read from

--- a/R/gg_beta_varpro.R
+++ b/R/gg_beta_varpro.R
@@ -3,8 +3,10 @@
 #'
 #' Tidy wrapper around [varPro::beta.varpro()] for the regression or
 #' classification family.
-#' Aggregates the per-rule lasso coefficient (beta-hat) by variable into
-#' `mean(|beta-hat|)` and flags variables above a scalar cutoff. Optional
+#' Aggregates the per-rule lasso coefficient \eqn{\hat{\beta}}{beta hat} by
+#' variable into the mean absolute value
+#' \eqn{\mathrm{mean}(|\hat{\beta}|)}{mean(|beta hat|)} and flags variables
+#' above a scalar cutoff. Optional
 #' `beta_fit` argument lets callers compute the expensive
 #' `beta.varpro()` step once and reuse the result.
 #'
@@ -22,27 +24,35 @@
 #'
 #' - Per rule, `glmnet` fits a one-predictor lasso of the response on
 #'   the released variable inside the rule's OOB region. `use.cv = TRUE`
-#'   selects lambda by 10-fold CV (default `nfolds = 10`); `use.1se = TRUE`
-#'   (default) picks `lambda.1se`. `use.cv = FALSE` uses the full lambda path.
-#' - `imp` is the **fitted coefficient beta-hat** at the chosen lambda. **Sign is
+#'   selects \eqn{\lambda}{lambda} by 10-fold CV (default `nfolds = 10`);
+#'   `use.1se = TRUE` (default) picks `lambda.1se`. `use.cv = FALSE` uses the
+#'   full \eqn{\lambda}{lambda} path.
+#' - `imp` is the **fitted coefficient** \eqn{\hat{\beta}}{beta hat} at the
+#'   chosen \eqn{\lambda}{lambda}. **Sign is
 #'   real** (direction of local association). **Magnitude depends on
 #'   the predictor's units** (raw `x`, no standardisation); a predictor
-#'   in millimetres has a smaller |beta-hat| than the same predictor in metres.
-#' - Lasso shrinkage can drive beta-hat to **exactly zero**. Those zeros are
+#'   in millimetres has a smaller \eqn{|\hat{\beta}|}{|beta hat|} than the
+#'   same predictor in metres.
+#' - Lasso shrinkage can drive \eqn{\hat{\beta}}{beta hat} to **exactly zero**.
+#'   Those zeros are
 #'   data, not missingness, and are kept in the aggregation. Convergence
 #'   failures land as `NA_real_` and are dropped.
-#' - The per-variable aggregate is `beta_mean = mean(|beta-hat|)` across the
+#' - The per-variable aggregate is `beta_mean`,
+#'   \eqn{\mathrm{mean}(|\hat{\beta}|)}{mean(|beta hat|)}, across the
 #'   rules where this variable was released. It is **not** a permutation
 #'   importance, **not** a split-strength importance, and **not** directly
 #'   comparable on the same numeric axis to `gg_varpro()`'s z-scores.
 #'   Disagreement with `gg_varpro` is often diagnostic, not a bug.
 #'
-#' In code form: `imp_r = beta-hat_glmnet(y | x_v restricted to rule r, lambda chosen by use.cv / use.1se)`.
+#' In code form: `imp_r` is the glmnet coefficient \eqn{\hat{\beta}}{beta hat}
+#' fit on `y ~ x_v` restricted to rule r, with \eqn{\lambda}{lambda} chosen by
+#' `use.cv` / `use.1se`.
 #'
 #' @section What's in the output:
 #' One row per released variable. Columns:
 #' - `variable`: predictor name.
-#' - `beta_mean`: mean of `|beta-hat|` across that variable's rules.
+#' - `beta_mean`: mean of \eqn{|\hat{\beta}|}{|beta hat|} across that
+#'   variable's rules.
 #' - `n_rules`: count of rules contributing (zero-beta rules included; only
 #'   `NA` failures excluded).
 #' - `selected`: `beta_mean >= cutoff`.
@@ -75,7 +85,8 @@
 #' For a varpro classification fit (`object$family == "class"`,
 #' binary or multi-class), the returned frame is long-format with an
 #' extra `class` column: one row per (variable, class) pair. The
-#' `beta_mean` column aggregates the **per-class lasso beta-hat** stored in
+#' `beta_mean` column aggregates the **per-class lasso coefficient**
+#' \eqn{\hat{\beta}}{beta hat} stored in
 #' `beta.varpro()`'s `imp.<k>` columns (one per class level). Same
 #' pedantic-beta semantics as regression, applied independently to each
 #' class.

--- a/R/gg_beta_varpro.R
+++ b/R/gg_beta_varpro.R
@@ -1,10 +1,10 @@
 ##=============================================================================
-#' Per-variable lasso-β importance from a varPro fit
+#' Per-variable lasso-beta importance from a varPro fit
 #'
 #' Tidy wrapper around [varPro::beta.varpro()] for the regression or
 #' classification family.
-#' Aggregates the per-rule lasso coefficient (β̂) by variable into
-#' `mean(|β̂|)` and flags variables above a scalar cutoff. Optional
+#' Aggregates the per-rule lasso coefficient (beta-hat) by variable into
+#' `mean(|beta-hat|)` and flags variables above a scalar cutoff. Optional
 #' `beta_fit` argument lets callers compute the expensive
 #' `beta.varpro()` step once and reuse the result.
 #'
@@ -22,28 +22,28 @@
 #'
 #' - Per rule, `glmnet` fits a one-predictor lasso of the response on
 #'   the released variable inside the rule's OOB region. `use.cv = TRUE`
-#'   selects λ by 10-fold CV (default `nfolds = 10`); `use.1se = TRUE`
-#'   (default) picks `lambda.1se`. `use.cv = FALSE` uses the full λ path.
-#' - `imp` is the **fitted coefficient β̂** at the chosen λ. **Sign is
+#'   selects lambda by 10-fold CV (default `nfolds = 10`); `use.1se = TRUE`
+#'   (default) picks `lambda.1se`. `use.cv = FALSE` uses the full lambda path.
+#' - `imp` is the **fitted coefficient beta-hat** at the chosen lambda. **Sign is
 #'   real** (direction of local association). **Magnitude depends on
 #'   the predictor's units** (raw `x`, no standardisation); a predictor
-#'   in millimetres has a smaller |β̂| than the same predictor in metres.
-#' - Lasso shrinkage can drive β̂ to **exactly zero**. Those zeros are
+#'   in millimetres has a smaller |beta-hat| than the same predictor in metres.
+#' - Lasso shrinkage can drive beta-hat to **exactly zero**. Those zeros are
 #'   data, not missingness, and are kept in the aggregation. Convergence
 #'   failures land as `NA_real_` and are dropped.
-#' - The per-variable aggregate is `beta_mean = mean(|β̂|)` across the
+#' - The per-variable aggregate is `beta_mean = mean(|beta-hat|)` across the
 #'   rules where this variable was released. It is **not** a permutation
 #'   importance, **not** a split-strength importance, and **not** directly
 #'   comparable on the same numeric axis to `gg_varpro()`'s z-scores.
 #'   Disagreement with `gg_varpro` is often diagnostic, not a bug.
 #'
-#' In code form: `imp_r = β̂_glmnet(y | x_v restricted to rule r, λ chosen by use.cv / use.1se)`.
+#' In code form: `imp_r = beta-hat_glmnet(y | x_v restricted to rule r, lambda chosen by use.cv / use.1se)`.
 #'
 #' @section What's in the output:
 #' One row per released variable. Columns:
 #' - `variable`: predictor name.
-#' - `beta_mean`: mean of `|β̂|` across that variable's rules.
-#' - `n_rules`: count of rules contributing (zero-β rules included; only
+#' - `beta_mean`: mean of `|beta-hat|` across that variable's rules.
+#' - `n_rules`: count of rules contributing (zero-beta rules included; only
 #'   `NA` failures excluded).
 #' - `selected`: `beta_mean >= cutoff`.
 #'
@@ -75,9 +75,9 @@
 #' For a varpro classification fit (`object$family == "class"`,
 #' binary or multi-class), the returned frame is long-format with an
 #' extra `class` column: one row per (variable, class) pair. The
-#' `beta_mean` column aggregates the **per-class lasso β̂** stored in
+#' `beta_mean` column aggregates the **per-class lasso beta-hat** stored in
 #' `beta.varpro()`'s `imp.<k>` columns (one per class level). Same
-#' pedantic-β semantics as regression, applied independently to each
+#' pedantic-beta semantics as regression, applied independently to each
 #' class.
 #'
 #' **Binary default**: `which_class = NULL` resolves to the *last*

--- a/R/plot.gg_beta_varpro.R
+++ b/R/plot.gg_beta_varpro.R
@@ -1,7 +1,9 @@
 ##=============================================================================
 #' Plot a `gg_beta_varpro` object
 #'
-#' Horizontal bar chart of `mean(|beta-hat|)` per variable, sorted descending so
+#' Horizontal bar chart of the mean absolute coefficient
+#' \eqn{\mathrm{mean}(|\hat{\beta}|)}{mean(|beta hat|)} per variable, sorted
+#' descending so
 #' the eye lands on the top variable first. Bars filled blue when above the
 #' selection cutoff, grey otherwise. Dashed red line marks the cutoff.
 #'
@@ -15,7 +17,8 @@
 #' bars are comparable up to that unit caveat.
 #'
 #' Variables above the cutoff are coloured blue and flagged `selected`;
-#' variables below are grey. Lasso shrinkage can drive a rule's beta-hat to
+#' variables below are grey. Lasso shrinkage can drive a rule's
+#' \eqn{\hat{\beta}}{beta hat} to
 #' exactly zero — those rules are kept in the average, so a variable
 #' with many shrunk-to-zero rules will sit lower in the ranking than
 #' one whose released coefficients are consistently non-zero.

--- a/R/plot.gg_beta_varpro.R
+++ b/R/plot.gg_beta_varpro.R
@@ -1,7 +1,7 @@
 ##=============================================================================
 #' Plot a `gg_beta_varpro` object
 #'
-#' Horizontal bar chart of `mean(|β̂|)` per variable, sorted descending so
+#' Horizontal bar chart of `mean(|beta-hat|)` per variable, sorted descending so
 #' the eye lands on the top variable first. Bars filled blue when above the
 #' selection cutoff, grey otherwise. Dashed red line marks the cutoff.
 #'
@@ -15,7 +15,7 @@
 #' bars are comparable up to that unit caveat.
 #'
 #' Variables above the cutoff are coloured blue and flagged `selected`;
-#' variables below are grey. Lasso shrinkage can drive a rule's β̂ to
+#' variables below are grey. Lasso shrinkage can drive a rule's beta-hat to
 #' exactly zero — those rules are kept in the average, so a variable
 #' with many shrunk-to-zero rules will sit lower in the ranking than
 #' one whose released coefficients are consistently non-zero.
@@ -28,7 +28,7 @@
 #' @section What this tells you:
 #' Use the bar chart as a selection ranking, not as an effect-size axis.
 #' Pair it with [gg_varpro()] to see where split-strength importance and
-#' local lasso-β importance agree or disagree; disagreement is often the
+#' local lasso-beta importance agree or disagree; disagreement is often the
 #' interesting signal.
 #'
 #' @param x A `gg_beta_varpro` object from [gg_beta_varpro()].

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,21 +1,38 @@
-## v2.7.3 — New features and documentation
+## v3.0.0 — varPro integration (major release)
 
-This is a new submission following v2.7.2 (accepted to CRAN 2026-04-29).
+This is a major release following v2.7.3 (current on CRAN). The version
+jumps to 3.0.0 because it adds a substantial new feature layer and
+soft-deprecates one user-facing function.
 
-### Changes in v2.7.3
+### Major changes in v3.0.0
 
-- New `gg_brier()` extractor and `plot.gg_brier()` for time-resolved
-  Brier scores and CRPS on survival forests.
-- Visual unification of ribbon overlays across all plot methods.
-- `print()`, `summary()`, and `autoplot()` S3 methods for all 10
-  `gg_*` data classes.
-- `plot.gg_partial()`, `plot.gg_partial_rfsrc()`, and
-  `plot.gg_partialpro()` now always return a single `ggplot`/`patchwork`
-  object; `patchwork` moved from `Suggests` to `Imports`.
+- **New varPro wrapper family.** Tidy extractors and `plot()` methods for
+  the `varPro` package: `gg_partial_varpro()` (partial dependence),
+  `gg_varpro()` (variable importance), `gg_udependent()` (cross-variable
+  dependency graph), `gg_isopro()` (isolation-forest anomaly scores),
+  `gg_beta_varpro()` (per-rule beta importance), and `gg_ivarpro()`
+  (individual / local importance), each with `print` / `summary` /
+  `autoplot` companions and a dedicated "varpro" vignette.
+- **Soft-deprecation.** `gg_partialpro()` now warns and forwards to
+  `gg_partial_varpro()`; it will be removed in the release after v3.0.0.
+- **randomForest engine fixes.** `gg_variable.randomForest()`
+  classification, `gg_roc()` / `calc_roc()` for `randomForest` (true
+  probability-based, macro-averaged ROC), per-class one-vs-rest ROC
+  (`per_class = TRUE`), and `plot.gg_variable()` now returns a single
+  `ggplot` / `patchwork` object rather than a bare list.
+- **Importance-plot ordering.** All importance plots now place the
+  most-important variable at the top, matching the `gg_vimp` convention.
+
+### Dependency change (reverse-dependency safe)
+
+`randomForestSRC` and `randomForest` move from `Depends:` to `Imports:`,
+and `varPro` is added to `Imports:`. `library(ggRandomForests)` no longer
+attaches the forest packages to the search path. There are **0 reverse
+dependencies** on CRAN, so no downstream packages are affected.
 
 ## Test environments
 
-* **Local:** R 4.5.3 on macOS Tahoe 26.4.1 (aarch64-apple-darwin20).
+* **Local:** R 4.5.3 on macOS (aarch64-apple-darwin20).
   `R CMD check --as-cran` returns 0 errors, 0 warnings, 0 notes.
 * **GitHub Actions matrix:** ubuntu-latest (R-devel / R-release /
   R-oldrel-1), windows-latest (R-release), macos-latest (R-release) —
@@ -26,4 +43,5 @@ This is a new submission following v2.7.2 (accepted to CRAN 2026-04-29).
 
 ## NOTE disposition
 
-No notes in local `R CMD check --as-cran`.
+No notes in local `R CMD check --as-cran`. Examples that fit survival
+forests are wrapped in `\donttest` and run in a few seconds each.

--- a/man/gg_beta_varpro.Rd
+++ b/man/gg_beta_varpro.Rd
@@ -41,8 +41,10 @@ last-factor-level) collapses the output to a single class.
 \description{
 Tidy wrapper around \code{\link[varPro:beta.varpro]{varPro::beta.varpro()}} for the regression or
 classification family.
-Aggregates the per-rule lasso coefficient (beta-hat) by variable into
-\verb{mean(|beta-hat|)} and flags variables above a scalar cutoff. Optional
+Aggregates the per-rule lasso coefficient \eqn{\hat{\beta}}{beta hat} by
+variable into the mean absolute value
+\eqn{\mathrm{mean}(|\hat{\beta}|)}{mean(|beta hat|)} and flags variables
+above a scalar cutoff. Optional
 \code{beta_fit} argument lets callers compute the expensive
 \code{beta.varpro()} step once and reuse the result.
 }
@@ -68,23 +70,30 @@ regression coefficient. Specifically:
 \itemize{
 \item Per rule, \code{glmnet} fits a one-predictor lasso of the response on
 the released variable inside the rule's OOB region. \code{use.cv = TRUE}
-selects lambda by 10-fold CV (default \code{nfolds = 10}); \code{use.1se = TRUE}
-(default) picks \code{lambda.1se}. \code{use.cv = FALSE} uses the full lambda path.
-\item \code{imp} is the \strong{fitted coefficient beta-hat} at the chosen lambda. \strong{Sign is
+selects \eqn{\lambda}{lambda} by 10-fold CV (default \code{nfolds = 10});
+\code{use.1se = TRUE} (default) picks \code{lambda.1se}. \code{use.cv = FALSE} uses the
+full \eqn{\lambda}{lambda} path.
+\item \code{imp} is the \strong{fitted coefficient} \eqn{\hat{\beta}}{beta hat} at the
+chosen \eqn{\lambda}{lambda}. \strong{Sign is
 real} (direction of local association). \strong{Magnitude depends on
 the predictor's units} (raw \code{x}, no standardisation); a predictor
-in millimetres has a smaller |beta-hat| than the same predictor in metres.
-\item Lasso shrinkage can drive beta-hat to \strong{exactly zero}. Those zeros are
+in millimetres has a smaller \eqn{|\hat{\beta}|}{|beta hat|} than the
+same predictor in metres.
+\item Lasso shrinkage can drive \eqn{\hat{\beta}}{beta hat} to \strong{exactly zero}.
+Those zeros are
 data, not missingness, and are kept in the aggregation. Convergence
 failures land as \code{NA_real_} and are dropped.
-\item The per-variable aggregate is \verb{beta_mean = mean(|beta-hat|)} across the
+\item The per-variable aggregate is \code{beta_mean},
+\eqn{\mathrm{mean}(|\hat{\beta}|)}{mean(|beta hat|)}, across the
 rules where this variable was released. It is \strong{not} a permutation
 importance, \strong{not} a split-strength importance, and \strong{not} directly
 comparable on the same numeric axis to \code{gg_varpro()}'s z-scores.
 Disagreement with \code{gg_varpro} is often diagnostic, not a bug.
 }
 
-In code form: \verb{imp_r = beta-hat_glmnet(y | x_v restricted to rule r, lambda chosen by use.cv / use.1se)}.
+In code form: \code{imp_r} is the glmnet coefficient \eqn{\hat{\beta}}{beta hat}
+fit on \code{y ~ x_v} restricted to rule r, with \eqn{\lambda}{lambda} chosen by
+\code{use.cv} / \code{use.1se}.
 }
 
 \section{What's in the output}{
@@ -92,7 +101,8 @@ In code form: \verb{imp_r = beta-hat_glmnet(y | x_v restricted to rule r, lambda
 One row per released variable. Columns:
 \itemize{
 \item \code{variable}: predictor name.
-\item \code{beta_mean}: mean of \verb{|beta-hat|} across that variable's rules.
+\item \code{beta_mean}: mean of \eqn{|\hat{\beta}|}{|beta hat|} across that
+variable's rules.
 \item \code{n_rules}: count of rules contributing (zero-beta rules included; only
 \code{NA} failures excluded).
 \item \code{selected}: \code{beta_mean >= cutoff}.
@@ -131,7 +141,8 @@ Provenance carries \code{precomputed = TRUE} when \code{beta_fit} was supplied.
 For a varpro classification fit (\code{object$family == "class"},
 binary or multi-class), the returned frame is long-format with an
 extra \code{class} column: one row per (variable, class) pair. The
-\code{beta_mean} column aggregates the \strong{per-class lasso beta-hat} stored in
+\code{beta_mean} column aggregates the \strong{per-class lasso coefficient}
+\eqn{\hat{\beta}}{beta hat} stored in
 \code{beta.varpro()}'s \verb{imp.<k>} columns (one per class level). Same
 pedantic-beta semantics as regression, applied independently to each
 class.

--- a/man/gg_beta_varpro.Rd
+++ b/man/gg_beta_varpro.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/gg_beta_varpro.R
 \name{gg_beta_varpro}
 \alias{gg_beta_varpro}
-\title{Per-variable lasso-β importance from a varPro fit}
+\title{Per-variable lasso-beta importance from a varPro fit}
 \usage{
 gg_beta_varpro(object, ..., cutoff = NULL, beta_fit = NULL, which_class = NULL)
 }
@@ -41,8 +41,8 @@ last-factor-level) collapses the output to a single class.
 \description{
 Tidy wrapper around \code{\link[varPro:beta.varpro]{varPro::beta.varpro()}} for the regression or
 classification family.
-Aggregates the per-rule lasso coefficient (β̂) by variable into
-\verb{mean(|β̂|)} and flags variables above a scalar cutoff. Optional
+Aggregates the per-rule lasso coefficient (beta-hat) by variable into
+\verb{mean(|beta-hat|)} and flags variables above a scalar cutoff. Optional
 \code{beta_fit} argument lets callers compute the expensive
 \code{beta.varpro()} step once and reuse the result.
 }
@@ -68,23 +68,23 @@ regression coefficient. Specifically:
 \itemize{
 \item Per rule, \code{glmnet} fits a one-predictor lasso of the response on
 the released variable inside the rule's OOB region. \code{use.cv = TRUE}
-selects λ by 10-fold CV (default \code{nfolds = 10}); \code{use.1se = TRUE}
-(default) picks \code{lambda.1se}. \code{use.cv = FALSE} uses the full λ path.
-\item \code{imp} is the \strong{fitted coefficient β̂} at the chosen λ. \strong{Sign is
+selects lambda by 10-fold CV (default \code{nfolds = 10}); \code{use.1se = TRUE}
+(default) picks \code{lambda.1se}. \code{use.cv = FALSE} uses the full lambda path.
+\item \code{imp} is the \strong{fitted coefficient beta-hat} at the chosen lambda. \strong{Sign is
 real} (direction of local association). \strong{Magnitude depends on
 the predictor's units} (raw \code{x}, no standardisation); a predictor
-in millimetres has a smaller |β̂| than the same predictor in metres.
-\item Lasso shrinkage can drive β̂ to \strong{exactly zero}. Those zeros are
+in millimetres has a smaller |beta-hat| than the same predictor in metres.
+\item Lasso shrinkage can drive beta-hat to \strong{exactly zero}. Those zeros are
 data, not missingness, and are kept in the aggregation. Convergence
 failures land as \code{NA_real_} and are dropped.
-\item The per-variable aggregate is \verb{beta_mean = mean(|β̂|)} across the
+\item The per-variable aggregate is \verb{beta_mean = mean(|beta-hat|)} across the
 rules where this variable was released. It is \strong{not} a permutation
 importance, \strong{not} a split-strength importance, and \strong{not} directly
 comparable on the same numeric axis to \code{gg_varpro()}'s z-scores.
 Disagreement with \code{gg_varpro} is often diagnostic, not a bug.
 }
 
-In code form: \verb{imp_r = β̂_glmnet(y | x_v restricted to rule r, λ chosen by use.cv / use.1se)}.
+In code form: \verb{imp_r = beta-hat_glmnet(y | x_v restricted to rule r, lambda chosen by use.cv / use.1se)}.
 }
 
 \section{What's in the output}{
@@ -92,8 +92,8 @@ In code form: \verb{imp_r = β̂_glmnet(y | x_v restricted to rule r, λ chosen 
 One row per released variable. Columns:
 \itemize{
 \item \code{variable}: predictor name.
-\item \code{beta_mean}: mean of \verb{|β̂|} across that variable's rules.
-\item \code{n_rules}: count of rules contributing (zero-β rules included; only
+\item \code{beta_mean}: mean of \verb{|beta-hat|} across that variable's rules.
+\item \code{n_rules}: count of rules contributing (zero-beta rules included; only
 \code{NA} failures excluded).
 \item \code{selected}: \code{beta_mean >= cutoff}.
 }
@@ -131,9 +131,9 @@ Provenance carries \code{precomputed = TRUE} when \code{beta_fit} was supplied.
 For a varpro classification fit (\code{object$family == "class"},
 binary or multi-class), the returned frame is long-format with an
 extra \code{class} column: one row per (variable, class) pair. The
-\code{beta_mean} column aggregates the \strong{per-class lasso β̂} stored in
+\code{beta_mean} column aggregates the \strong{per-class lasso beta-hat} stored in
 \code{beta.varpro()}'s \verb{imp.<k>} columns (one per class level). Same
-pedantic-β semantics as regression, applied independently to each
+pedantic-beta semantics as regression, applied independently to each
 class.
 
 \strong{Binary default}: \code{which_class = NULL} resolves to the \emph{last}

--- a/man/plot.gg_beta_varpro.Rd
+++ b/man/plot.gg_beta_varpro.Rd
@@ -15,7 +15,9 @@
 A \code{ggplot} object.
 }
 \description{
-Horizontal bar chart of \verb{mean(|beta-hat|)} per variable, sorted descending so
+Horizontal bar chart of the mean absolute coefficient
+\eqn{\mathrm{mean}(|\hat{\beta}|)}{mean(|beta hat|)} per variable, sorted
+descending so
 the eye lands on the top variable first. Bars filled blue when above the
 selection cutoff, grey otherwise. Dashed red line marks the cutoff.
 }
@@ -30,7 +32,8 @@ units require keeping the units context in mind. Within one data set,
 bars are comparable up to that unit caveat.
 
 Variables above the cutoff are coloured blue and flagged \code{selected};
-variables below are grey. Lasso shrinkage can drive a rule's beta-hat to
+variables below are grey. Lasso shrinkage can drive a rule's
+\eqn{\hat{\beta}}{beta hat} to
 exactly zero — those rules are kept in the average, so a variable
 with many shrunk-to-zero rules will sit lower in the ranking than
 one whose released coefficients are consistently non-zero.

--- a/man/plot.gg_beta_varpro.Rd
+++ b/man/plot.gg_beta_varpro.Rd
@@ -15,7 +15,7 @@
 A \code{ggplot} object.
 }
 \description{
-Horizontal bar chart of \verb{mean(|β̂|)} per variable, sorted descending so
+Horizontal bar chart of \verb{mean(|beta-hat|)} per variable, sorted descending so
 the eye lands on the top variable first. Bars filled blue when above the
 selection cutoff, grey otherwise. Dashed red line marks the cutoff.
 }
@@ -30,7 +30,7 @@ units require keeping the units context in mind. Within one data set,
 bars are comparable up to that unit caveat.
 
 Variables above the cutoff are coloured blue and flagged \code{selected};
-variables below are grey. Lasso shrinkage can drive a rule's β̂ to
+variables below are grey. Lasso shrinkage can drive a rule's beta-hat to
 exactly zero — those rules are kept in the average, so a variable
 with many shrunk-to-zero rules will sit lower in the ranking than
 one whose released coefficients are consistently non-zero.
@@ -45,7 +45,7 @@ comparison. Each facet has its own cutoff line.
 
 Use the bar chart as a selection ranking, not as an effect-size axis.
 Pair it with \code{\link[=gg_varpro]{gg_varpro()}} to see where split-strength importance and
-local lasso-β importance agree or disagree; disagreement is often the
+local lasso-beta importance agree or disagree; disagreement is often the
 interesting signal.
 }
 


### PR DESCRIPTION
## Summary
Cuts the **v3.0.0** release candidate. Follows v2.7.3 (current on CRAN); the major bump reflects the new varPro wrapper layer plus the `gg_partialpro()` soft-deprecation.

- **Version** `2.7.3.9016` → `3.0.0` (DESCRIPTION + NEWS).
- **NEWS** — consolidated the two fragmented `v3.0.0 (development)` blocks into one clean `ggRandomForests v3.0.0` entry; the renumber note becomes a single "Version jump to 3.0.0" bullet that names the v3.1.0 deferrals.
- **cran-comments.md** — full rewrite for the v3.0.0 submission (varPro layer, soft-deprecation, RF engine fixes, `Depends:`→`Imports:` framed as reverse-dependency-safe with 0 revdeps, test environments, 0-note disposition).
- **PDF-manual fix** — replaced raw Unicode math (Greek β/λ and the combining circumflex in β̂) in the `gg_beta_varpro` / `plot.gg_beta_varpro` roxygen with ASCII; regenerated the `.Rd`. The full `--as-cran` manual build had flagged this as a WARNING (earlier `--no-manual` checks masked it).

## Verification
- `R CMD check --as-cran` **with PDF manual**: **0 errors / 0 warnings / 0 notes** (`ggRandomForests 3.0.0`).
- Full CRAN **"Code Issues" cookbook** chapter verified — all 11 items clean (T/F, seeds, print/cat, options/par/setwd, file writes, tempdir, `.GlobalEnv`, `installed.packages`, `options(warn=-1)`, software install, ≤2 cores).
- Reverse dependencies: **0**. `urlchecker::url_check()`: clean.

## Not in scope (deferred to v3.1.0)
ROC confidence intervals (#7), varPro survival/multivariate families, hazard estimates (#4/#5/#71). Documented in code, NEWS, and the varpro vignette.

## Post-merge checklist (for the maintainer)
- [ ] CI green across the matrix
- [ ] Close #26 (delivered by per-class ROC, PR #91)
- [ ] `devtools::submit_cran()` / upload to CRAN
- [ ] Tag `v3.0.0` after acceptance

🤖 Generated with [Claude Code](https://claude.com/claude-code)