### PR TITLE
ci: CI on dev line + pkgdown /dev/ preview

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -2,7 +2,7 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
   pull_request:
 
 name: R-CMD-check.yaml

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -2,7 +2,7 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
   pull_request:
 
 name: lint.yaml

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -42,8 +42,13 @@ jobs:
         run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
         shell: Rscript {0}
 
-      # Release line: main / release / manual dispatch -> gh-pages ROOT
-      # (the published v3.x site). Never deploys from dev.
+      # The deploy target follows the ref the run is on, NOT the event type:
+      #   - any non-dev ref (main push, release, or workflow_dispatch on main)
+      #     -> gh-pages ROOT (the published v3.x site).
+      #   - the dev ref (push or workflow_dispatch on dev) -> /dev/ (next step).
+      # So a manual dispatch publishes root only when launched on a non-dev
+      # branch; dispatching on dev refreshes the /dev/ preview instead. Root is
+      # never published from dev.
       - name: Deploy to GitHub pages 🚀
         if: github.event_name != 'pull_request' && github.ref != 'refs/heads/dev'
         uses: JamesIves/github-pages-deploy-action@v4.5.0
@@ -52,9 +57,9 @@ jobs:
           branch: gh-pages
           folder: docs
 
-      # Dev integration line: push/dispatch on dev -> gh-pages /dev/ preview
-      # subfolder. Browsable at <site>/dev/ without clobbering the released
-      # root site. Used to review v4.0.0 work in progress.
+      # Dev integration line: a push OR a workflow_dispatch on the dev ref
+      # -> gh-pages /dev/ preview subfolder. Browsable at <site>/dev/ without
+      # clobbering the released root site. Used to review v4.0.0 work.
       - name: Deploy dev preview to /dev/ 🔍
         if: github.event_name != 'pull_request' && github.ref == 'refs/heads/dev'
         uses: JamesIves/github-pages-deploy-action@v4.5.0

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -2,7 +2,7 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
   pull_request:
   release:
     types: [published]
@@ -42,10 +42,24 @@ jobs:
         run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
         shell: Rscript {0}
 
+      # Release line: main / release / manual dispatch -> gh-pages ROOT
+      # (the published v3.x site). Never deploys from dev.
       - name: Deploy to GitHub pages 🚀
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && github.ref != 'refs/heads/dev'
         uses: JamesIves/github-pages-deploy-action@v4.5.0
         with:
           clean: false
           branch: gh-pages
           folder: docs
+
+      # Dev integration line: push/dispatch on dev -> gh-pages /dev/ preview
+      # subfolder. Browsable at <site>/dev/ without clobbering the released
+      # root site. Used to review v4.0.0 work in progress.
+      - name: Deploy dev preview to /dev/ 🔍
+        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/dev'
+        uses: JamesIves/github-pages-deploy-action@v4.5.0
+        with:
+          clean: false
+          branch: gh-pages
+          folder: docs
+          target-folder: dev

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -2,7 +2,7 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
   pull_request:
 
 name: test-coverage.yaml


### PR DESCRIPTION
First Phase-0 setup PR for the v4.0.0 RHF integration line. **Base branch: `dev`.**

## Summary
- Add `dev` to `push` triggers for **R-CMD-check**, **lint**, **test-coverage** so the integration branch shows status on pushes/merges. (PRs into `dev` were already covered by the unfiltered `pull_request` trigger.)
- **pkgdown**: add `dev` to push triggers and **split the deploy**:
  - `main` / release / `workflow_dispatch` → gh-pages **root** (published v3.x site — untouched).
  - `dev` push → **`/dev/` subfolder** preview at `https://ehrlinger.github.io/ggRandomForests/dev/`.
  - PRs still build-only (no deploy).

## Why
Keeps `main` as the frozen CRAN-release line (v3.0.0 is in review) while giving the v4.0.0 work a green integration line and a browsable doc preview that never clobbers the released site.

## Notes
- YAML validated locally (`yaml.safe_load`).
- The `/dev/` preview takes effect once this merges into `dev` (the dev-push trigger then uses the updated workflow). First dev pkgdown run will mirror v3.0.0 until Phase 1 lands functional changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)