### PR TITLE
build: keep stray Rplots.pdf out of the build tarball

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -54,3 +54,6 @@ framed.sty
 ^vignettes/\.quarto$
 ^vignettes/.*_files$
 ^vignettes/.*\.html$
+# Stray default-device plot dumps from running examples/tests locally
+# (already in .gitignore; this keeps them out of the build tarball too)
+Rplots\.pdf$


### PR DESCRIPTION
## Summary
Add `Rplots\.pdf$` to `.Rbuildignore` so a stray `Rplots.pdf` never gets bundled into the build tarball.

## Why
`devtools::check` / `run_examples` execute the `\donttest` `gg_*` examples, which end in `plot(...)` and auto-print to the default graphics device, leaving `tests/testthat/Rplots.pdf`. It's already in `.gitignore` (never committed), but `R CMD build` uses `.Rbuildignore` — which didn't exclude it — so a local build picked up the ~6.9 MB stray and inflated the tarball. **No test creates it** (verified across the suite under both default and `NOT_CRAN=true`); it's purely an example-execution artifact.

This is preventative build hygiene — no package code or behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)