### PR TITLE
test(snapshots): stop devtools::test() from pruning vdiffr baselines

### DIFF
--- a/tests/testthat/test_snapshots.R
+++ b/tests/testthat/test_snapshots.R
@@ -442,4 +442,24 @@ test_that("gg-ivarpro-class-which-obs", {
   vdiffr::expect_doppelganger("gg-ivarpro-class-which-obs", p)
 })
 
+} else {
+
+## ---- Preserve baselines when the vdiffr comparison is opted out ------------
+# When VDIFFR_RUN_TESTS != "true" (or vdiffr is unavailable) none of the
+# expect_doppelganger() calls above register, so testthat's snapshot cleanup
+# would treat every committed baseline under _snaps/snapshots/ as orphaned and
+# delete it during a normal `devtools::test()` run. Announcing each file marks
+# it as still in use so cleanup leaves the repo untouched.
+# See ?testthat::announce_snapshot_file.
+test_that("vdiffr baseline snapshots are preserved when comparison is skipped", {
+  # announce_snapshot_file() (and vdiffr's file snapshots) are 3rd-edition
+  # features; the package otherwise defaults to edition 2, so opt in locally.
+  local_edition(3)
+  snap_dir <- test_path("_snaps", "snapshots")
+  skip_if(!dir.exists(snap_dir), "no vdiffr baselines present to preserve")
+  svgs <- list.files(snap_dir, pattern = "\\.svg$")
+  for (f in svgs) announce_snapshot_file(name = f)
+  succeed()
+})
+
 } # end CI guard


### PR DESCRIPTION
## Problem
A plain `devtools::test()` (with `VDIFFR_RUN_TESTS` unset) **deletes all 37 tracked baseline SVGs** under `tests/testthat/_snaps/snapshots/`. The snapshot suite in `test_snapshots.R` is guarded behind `requireNamespace("vdiffr") && VDIFFR_RUN_TESTS == "true"`, so when that's off, **no `expect_doppelganger()` registers** — and testthat's snapshot cleanup treats every committed baseline as orphaned and prunes it. A careless `git commit -a` would then wipe the baselines from the repo.

## Fix
Add an `else` branch that announces each committed baseline via `testthat::announce_snapshot_file()` so cleanup keeps them. Because the package defaults to testthat edition 2 and `announce_snapshot_file()` is a 3rd-edition feature, the block opts in with `local_edition(3)` (scoped to that one test). The opt-in comparison path (`VDIFFR_RUN_TESTS=true`) is untouched — the change is purely additive.

## Verification
- Full `devtools::test()` with `VDIFFR_RUN_TESTS` unset → **0 snapshot deletions**, `git status` clean, suite green.
- `R CMD check --as-cran` (with manual build) → **Status: OK (0/0/0)**.

Isolated from the in-flight v3.1.0 CRAN release (test-only change; no R/, Rd, vignette, or DESCRIPTION impact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)