### PR TITLE
test(snapshots): stop devtools::test() from pruning vdiffr baselines

### DIFF
--- a/tests/testthat/test_snapshots.R
+++ b/tests/testthat/test_snapshots.R
@@ -476,4 +476,24 @@ test_that("gg-auct-chf", {
   vdiffr::expect_doppelganger("gg-auct-chf", plot(gg))
 })
 
+} else {
+
+## ---- Preserve baselines when the vdiffr comparison is opted out ------------
+# When VDIFFR_RUN_TESTS != "true" (or vdiffr is unavailable) none of the
+# expect_doppelganger() calls above register, so testthat's snapshot cleanup
+# would treat every committed baseline under _snaps/snapshots/ as orphaned and
+# delete it during a normal `devtools::test()` run. Announcing each file marks
+# it as still in use so cleanup leaves the repo untouched.
+# See ?testthat::announce_snapshot_file.
+test_that("vdiffr baseline snapshots are preserved when comparison is skipped", {
+  # announce_snapshot_file() (and vdiffr's file snapshots) are 3rd-edition
+  # features; the package otherwise defaults to edition 2, so opt in locally.
+  local_edition(3)
+  snap_dir <- test_path("_snaps", "snapshots")
+  skip_if(!dir.exists(snap_dir), "no vdiffr baselines present to preserve")
+  svgs <- list.files(snap_dir, pattern = "\\.svg$")
+  for (f in svgs) announce_snapshot_file(name = f)
+  succeed()
+})
+
 } # end CI guard

--- a/tests/testthat/test_snapshots.R
+++ b/tests/testthat/test_snapshots.R
@@ -16,7 +16,7 @@
 #   2. Run devtools::test(filter = "snapshots")
 #   3. Call testthat::snapshot_accept()
 #   4. Commit tests/testthat/_snaps/ to the repo
-if (requireNamespace("vdiffr", quietly = TRUE) &&
+if (requireNamespace("vdiffr", quietly = TRUE) && # nolint: cyclocomp_linter
     identical(Sys.getenv("VDIFFR_RUN_TESTS"), "true")) {
 
 ## ---- Shared fixtures -------------------------------------------------------


### PR DESCRIPTION
Targets `dev` (the active line), per the branch model — bug/tooling fixes go to `dev`, while `main` stays at the v3.1.0 CRAN release. Supersedes #111 (which was mistargeted at `main`).

## Problem
A plain `devtools::test()` (`VDIFFR_RUN_TESTS` unset) **deletes all tracked baseline SVGs** under `tests/testthat/_snaps/snapshots/`. The snapshot suite in `test_snapshots.R` is guarded behind `VDIFFR_RUN_TESTS == "true"`, so when off, no `expect_doppelganger()` registers and testthat's cleanup prunes the "orphaned" baselines from the repo.

## Fix
An additive `else` branch announces each committed baseline via `testthat::announce_snapshot_file()` (under `local_edition(3)`, since the package defaults to edition 2) so cleanup keeps them. The opt-in comparison path is untouched. Resolved cleanly against dev's RHF snapshot tests (`gg-rhf-*`, `gg-auct-chf`).

## Verification (on dev)
- `devtools::test()` snapshot run with `VDIFFR_RUN_TESTS` unset → **0 deletions** (all 40 dev baselines preserved), clean tree.
- File parses; resolution keeps dev's RHF snapshot tests intact.
- (The identical change was confirmed `R CMD check --as-cran` = Status OK on the main-based branch.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)