### PR TITLE
docs(examples): \donttest slow plot.gg_variable example sections (clear oldrel timing NOTE)

### DIFF
--- a/R/plot.gg_variable.R
+++ b/R/plot.gg_variable.R
@@ -84,16 +84,19 @@
 #' plot(gg_dta, xvar = "Temp")
 #' plot(gg_dta, xvar = "Solar.R")
 #'
-#' # Panel plot across continuous predictors
-#' plot(gg_dta, xvar = c("Solar.R", "Wind", "Temp", "Day"), panel = TRUE)
-#'
 #' # Factor variable uses notched boxplots
 #' plot(gg_dta, xvar = "Month", notch = TRUE)
+#'
+#' \donttest{
+#' # Panel plot across continuous predictors (loess smooths; slower)
+#' plot(gg_dta, xvar = c("Solar.R", "Wind", "Temp", "Day"), panel = TRUE)
+#' }
 #'
 #' ## ------------------------------------------------------------
 #' ## survival examples
 #' ## ------------------------------------------------------------
 #' ## -------- veteran data
+#' \donttest{
 #' data(veteran, package = "randomForestSRC")
 #' set.seed(42)
 #' rfsrc_veteran <- randomForestSRC::rfsrc(Surv(time, status) ~ ., veteran,
@@ -119,6 +122,7 @@
 #'
 #' # Panel coplot across two predictors and three time points
 #' plot(gg_dta, xvar = c("age", "diagtime"), panel = TRUE)
+#' }
 #'
 #' @export
 plot.gg_variable <- function(x, # nolint: cyclocomp_linter

--- a/man/plot.gg_variable.Rd
+++ b/man/plot.gg_variable.Rd
@@ -84,16 +84,19 @@ plot(gg_dta, xvar = "Wind")
 plot(gg_dta, xvar = "Temp")
 plot(gg_dta, xvar = "Solar.R")
 
-# Panel plot across continuous predictors
-plot(gg_dta, xvar = c("Solar.R", "Wind", "Temp", "Day"), panel = TRUE)
-
 # Factor variable uses notched boxplots
 plot(gg_dta, xvar = "Month", notch = TRUE)
+
+\donttest{
+# Panel plot across continuous predictors (loess smooths; slower)
+plot(gg_dta, xvar = c("Solar.R", "Wind", "Temp", "Day"), panel = TRUE)
+}
 
 ## ------------------------------------------------------------
 ## survival examples
 ## ------------------------------------------------------------
 ## -------- veteran data
+\donttest{
 data(veteran, package = "randomForestSRC")
 set.seed(42)
 rfsrc_veteran <- randomForestSRC::rfsrc(Surv(time, status) ~ ., veteran,
@@ -119,6 +122,7 @@ plot(gg_dta, xvar = "age")
 
 # Panel coplot across two predictors and three time points
 plot(gg_dta, xvar = c("age", "diagtime"), panel = TRUE)
+}
 
 }
 \references{


### PR DESCRIPTION
Release polish for the v3.1.0 submission. win-builder **R-oldrelease** flagged 1 NOTE:

```
Examples with CPU or elapsed time > 10s
                 user system elapsed
plot.gg_variable 9.92   0.44   10.33
```

Benign and oldrelease-only (R-release and R-devel were both 0/0/0), but cheap to clear for a spotless submission.

## Change
Wrap the two slowest example sections in `\donttest{}`:
- the regression **panel** plot (4 loess smooths), and
- the full **survival** section (veteran forest + multi-time variable/panel plots).

The fast classification examples + basic regression single-variable plots still run in the timed pass. CRAN still executes the `\donttest` blocks under `--run-donttest`. No behaviour change; `man/plot.gg_variable.Rd` regenerated.

## Verification
`R CMD check --as-cran` (with manual build):
- `checking examples [14s] OK` — no `>10s` NOTE
- `checking examples with --run-donttest [28s] OK` — donttest blocks still execute
- **Status: OK (0/0/0)**

After merge, the post-#110 `main` is clean 0/0/0 across release/devel/oldrel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)