### PR TITLE
fix(gg_varpro): clear error on survival fits instead of cryptic cbind

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,11 @@ Version: 3.0.0.9001
 
 ggRandomForests v4.0.0 (development)
 ====================================
+* `gg_varpro()` on a survival `varpro` fit now stops with a clear message
+  ("survival varPro fits not supported yet; use `gg_vimp()` on an rfsrc
+  survival forest") instead of the cryptic downstream `differing number of
+  rows` error. Release-rule importance still covers regression and
+  classification; survival support is future work.
 * `gg_auct()` / `plot.gg_auct()`: tidy wrapper and plot for time-varying
   AUC from `randomForestRHF::auct.rhf()` (RHF Phase 2). Returns a long
   frame `time / auc / se / lower / upper / marker` with an `iauc`

--- a/R/gg_varpro.R
+++ b/R/gg_varpro.R
@@ -181,6 +181,18 @@ gg_varpro <- function(object,
   if (!inherits(object, "varpro")) {
     stop("'object' must be a varpro fit (class \"varpro\").", call. = FALSE)
   }
+  if (!object$family %in% c("regr", "class")) {
+    if (identical(object$family, "surv")) {
+      stop("gg_varpro() does not support survival varPro fits yet ",
+           "(object$family == \"surv\"). Release-rule importance is ",
+           "implemented for regression and classification fits. For survival ",
+           "variable importance, use gg_vimp() on an rfsrc survival forest.",
+           call. = FALSE)
+    }
+    stop("gg_varpro() supports regression and classification varPro fits ",
+         "(object$family \"regr\" or \"class\"); got \"", object$family, "\".",
+         call. = FALSE)
+  }
   if (conditional && !identical(object$family, "class")) {
     stop("conditional=TRUE requires a classification forest ",
          "(object$family == \"class\").", call. = FALSE)

--- a/R/gg_varpro.R
+++ b/R/gg_varpro.R
@@ -181,16 +181,18 @@ gg_varpro <- function(object,
   if (!inherits(object, "varpro")) {
     stop("'object' must be a varpro fit (class \"varpro\").", call. = FALSE)
   }
-  if (!object$family %in% c("regr", "class")) {
-    if (identical(object$family, "surv")) {
+  fam <- object$family
+  if (!is.character(fam) || length(fam) != 1L || !fam %in% c("regr", "class")) {
+    if (identical(fam, "surv")) {
       stop("gg_varpro() does not support survival varPro fits yet ",
            "(object$family == \"surv\"). Release-rule importance is ",
            "implemented for regression and classification fits. For survival ",
            "variable importance, use gg_vimp() on an rfsrc survival forest.",
            call. = FALSE)
     }
+    fam_lbl <- if (is.character(fam) && length(fam) == 1L) fam else "unknown"
     stop("gg_varpro() supports regression and classification varPro fits ",
-         "(object$family \"regr\" or \"class\"); got \"", object$family, "\".",
+         "(object$family \"regr\" or \"class\"); got \"", fam_lbl, "\".",
          call. = FALSE)
   }
   if (conditional && !identical(object$family, "class")) {

--- a/tests/testthat/test_gg_varpro.R
+++ b/tests/testthat/test_gg_varpro.R
@@ -36,6 +36,7 @@ test_that("gg_varpro: survival fit -> clear 'not supported yet' stop", {
   # error from the downstream importance reshape. (varPro survival support is
   # deferred; for survival importance use gg_vimp() on an rfsrc forest.)
   skip_if_not_installed("survival")
+  skip_if_not_installed("randomForestSRC")
   # bare Surv(); parseFormula rejects the survival::Surv(...) namespace form
   Surv <- survival::Surv # nolint: object_name_linter
   data(pbc, package = "randomForestSRC")

--- a/tests/testthat/test_gg_varpro.R
+++ b/tests/testthat/test_gg_varpro.R
@@ -36,7 +36,8 @@ test_that("gg_varpro: survival fit -> clear 'not supported yet' stop", {
   # error from the downstream importance reshape. (varPro survival support is
   # deferred; for survival importance use gg_vimp() on an rfsrc forest.)
   skip_if_not_installed("survival")
-  Surv <- survival::Surv  # bare Surv(); parseFormula rejects survival::Surv(...)
+  # bare Surv(); parseFormula rejects the survival::Surv(...) namespace form
+  Surv <- survival::Surv # nolint: object_name_linter
   data(pbc, package = "randomForestSRC")
   set.seed(42L)
   vp_surv <- varPro::varpro(Surv(days, status) ~ .,

--- a/tests/testthat/test_gg_varpro.R
+++ b/tests/testthat/test_gg_varpro.R
@@ -30,6 +30,20 @@ test_that("gg_varpro: conditional=TRUE on regression -> stop", {
                regexp = "classification")
 })
 
+test_that("gg_varpro: survival fit -> clear 'not supported yet' stop", {
+  # gg_varpro extracts regr/class families; a survival fit must fail with a
+  # clear message rather than the cryptic "differing number of rows" cbind
+  # error from the downstream importance reshape. (varPro survival support is
+  # deferred; for survival importance use gg_vimp() on an rfsrc forest.)
+  skip_if_not_installed("survival")
+  Surv <- survival::Surv  # bare Surv(); parseFormula rejects survival::Surv(...)
+  data(pbc, package = "randomForestSRC")
+  set.seed(42L)
+  vp_surv <- varPro::varpro(Surv(days, status) ~ .,
+                            data = na.omit(pbc), ntree = 25L)
+  expect_error(gg_varpro(vp_surv), regexp = "survival")
+})
+
 test_that("gg_varpro: faithful=TRUE + local.std=TRUE is valid, records local.std=TRUE", {
   vp <- make_vp_regr()
   gg <- gg_varpro(vp, faithful = TRUE, local.std = TRUE)


### PR DESCRIPTION
Targets `dev` (not a release). Small UX fix found while building the v3.1.0 release-announcement side-by-side figure.

## Problem
`gg_varpro()` on a survival `varpro()` fit dies with `arguments imply differing number of rows: 12, 0` — the downstream importance reshape gets an empty (0-row) importance frame because varPro survival importance isn't wired through the extractor. The error gives the user no idea what's wrong.

## Fix
Validate `object$family` up front in `.validate_varpro_imp_inputs()`. Supported families are `regr` and `class`; a `surv` fit now stops with:

> gg_varpro() does not support survival varPro fits yet (object$family == "surv"). Release-rule importance is implemented for regression and classification fits. For survival variable importance, use gg_vimp() on an rfsrc survival forest.

(Any other unsupported family gets a generic clear message.) Regression and classification paths are unchanged.

## Verification
- Survival fit → clear error (regex `survival`); regression + classification → still OK.
- New regression test in `test_gg_varpro.R`; full `test_gg_varpro.R` green.
- NEWS bullet under the v4.0.0 (development) heading.

Note: this is the graceful-error stopgap. Full survival/multivariate varPro support remains future work on this line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)