### PR TITLE
docs(vignette): fix placeholder VignetteIndexEntry

### DIFF
--- a/vignettes/ggRandomForests.qmd
+++ b/vignettes/ggRandomForests.qmd
@@ -12,7 +12,7 @@ editor:
   markdown: 
     wrap: 80
 vignette: >
-  %\VignetteIndexEntry{Vignette's Title}
+  %\VignetteIndexEntry{Exploring Random Forests with ggRandomForests}
   %\VignetteEngine{quarto::html}
   %\VignetteEncoding{UTF-8}
 ---


### PR DESCRIPTION
The intro vignette (`vignettes/ggRandomForests.qmd`) shipped with the template-default `\VignetteIndexEntry{Vignette's Title}`, so CRAN's vignette list shows **"Vignette's Title"** instead of the real one. Its document `title:` was always correct — only the index entry was stale.

Fixed to `\VignetteIndexEntry{Exploring Random Forests with ggRandomForests}` (matches the document title). Verified the other three vignettes already have correct index entries; no other template placeholders remain.

Doc-only; rides in the next release (3.1.3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)