### PR TITLE
chore: open 3.1.2.9000 dev cycle after the CRAN release

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: ggRandomForests
 Type: Package
 Title: Visually Exploring Random Forests
-Version: 3.1.2
+Version: 3.1.2.9000
 Date: 2026-06-13
 Authors@R: person("John", "Ehrlinger",
   role = c("aut", "cre"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 Package: ggRandomForests
-Version: 3.1.2
+Version: 3.1.2.9000
+
+ggRandomForests v3.1.2.9000 (development)
+=========================================
+* Development version opened after the v3.1.2 CRAN release.
 
 ggRandomForests v3.1.2
 ======================


### PR DESCRIPTION
v3.1.2 accepted to CRAN 2026-06-13. Bumps `main` to the post-release `.9000` dev version (DESCRIPTION + NEWS dual update so the news-version test passes), matching the #115 pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)