### PR TITLE
docs: short uvarpro vignette + varPro trim + fix stale VignetteIndexEntry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,9 @@ vignettes/ggRandomForests.html
 vignettes/varpro_cache/
 vignettes/varpro_files/
 vignettes/varpro.html
+vignettes/uvarpro_cache/
+vignettes/uvarpro_files/
+vignettes/uvarpro.html
 
 .claude
 .positai

--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,15 @@ ggRandomForests v3.4.0
   graph) with the "which variables are signal" ranking; shares the
   `beta_fit` entropy matrix. Follows the `get.beta.entropy` + `sdependent`
   workflow from the `varPro::uvarpro()` help (iowa-housing example).
+* New `uvarpro` vignette: a short, focused walk-through of the unsupervised
+  varPro wrappers (`gg_udependent()`, `gg_beta_uvarpro()`, `gg_sdependent()`)
+  on a single `uvarpro()` fit, using the shared `beta_fit` matrix. The three
+  unsupervised sections were lifted out of the `varpro` vignette, which now
+  points to the new one and covers the five supervised wrappers.
+* Fixed the main vignette's `\VignetteIndexEntry`, which still carried the
+  template placeholder "Vignette's Title" -- it now reads "Exploring Random
+  Forests with ggRandomForests" (the index entry CRAN lists, not the document
+  title, was the stale one).
 
 ggRandomForests v3.3.0
 ======================

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -46,6 +46,8 @@ navbar:
           href: articles/ggRandomForests-regression.html
         - text: "Exploring variable importance with varPro"
           href: articles/varpro.html
+        - text: "Variable selection without an outcome: unsupervised varPro"
+          href: articles/uvarpro.html
 
 reference:
   - title: "Forest Objects"
@@ -144,6 +146,7 @@ articles:
       - ggRandomForests-survival
       - ggRandomForests-regression
       - varpro
+      - uvarpro
 
 news:
   releases:

--- a/vignettes/ggRandomForests.qmd
+++ b/vignettes/ggRandomForests.qmd
@@ -12,7 +12,7 @@ editor:
   markdown: 
     wrap: 80
 vignette: >
-  %\VignetteIndexEntry{Vignette's Title}
+  %\VignetteIndexEntry{Exploring Random Forests with ggRandomForests}
   %\VignetteEngine{quarto::html}
   %\VignetteEncoding{UTF-8}
 ---

--- a/vignettes/precompute_varpro.R
+++ b/vignettes/precompute_varpro.R
@@ -44,8 +44,6 @@ pd_boston  <- gg_partial_varpro(object = v_boston)
 b_boston   <- varPro::beta.varpro(v_boston)
 iv_boston  <- varPro::ivarpro(v_boston)
 set.seed(20260527L)
-u_boston   <- varPro::uvarpro(boston_x, ntree = 50)
-set.seed(20260527L)
 iso_boston <- varPro::isopro(data = boston_x, method = "rnd",
                              sampsize = 256, ntree = 50)
 
@@ -79,9 +77,9 @@ iso_pbc <- varPro::isopro(data = pbc_small[, c("age", "albumin", "bili",
 # vignette never invokes those on a stripped object (pd_pbc is cached and
 # gg_isopro() is training-path only). Dropping those heavy
 # slots takes the file from ~1.6 MB to ~0.4 MB (validated: every vignette
-# wrapper call returns output identical to the un-stripped object). Two
-# exceptions keep their forest: v_boston is printed in the vignette
-# (print.varpro reads $rf), and u_boston feeds gg_udependent(), which uses it.
+# wrapper call returns output identical to the un-stripped object). One
+# exception keeps its forest: v_boston is printed in the vignette
+# (print.varpro reads $rf).
 .strip_varpro <- function(v) {              # $rf: unused on the cached path
   v$rf <- NULL
   v
@@ -109,7 +107,6 @@ saveRDS(
     pd_boston     = pd_boston,
     b_boston      = b_boston,
     iv_boston     = iv_boston,
-    u_boston      = u_boston,
     iso_boston    = iso_boston,
     # iris (class)
     v_iris_binary = v_iris_binary,

--- a/vignettes/uvarpro.qmd
+++ b/vignettes/uvarpro.qmd
@@ -1,0 +1,159 @@
+---
+title: "Variable selection without an outcome: unsupervised varPro"
+author: "John Ehrlinger"
+date: today
+format:
+  html:
+    fig-format: png
+    fig-dpi: 96
+    toc: true
+    toc-depth: 2
+    html-math-method: mathjax
+    code-fold: false
+bibliography: ggRandomForests.bib
+vignette: >
+  %\VignetteIndexEntry{Variable selection without an outcome: unsupervised varPro}
+  %\VignetteEngine{quarto::html}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(
+  message    = FALSE,
+  warning    = FALSE,
+  fig.width  = 7,
+  fig.height = 4.5,
+  cache      = TRUE,
+  cache.path = "uvarpro_cache/"
+)
+options(mc.cores = 1, rf.cores = 1)
+```
+
+```{r libs}
+library(ggplot2)
+
+# Match the pattern used by the other vignettes: try the installed
+# package first, fall back to pkgload::load_all() for the R CMD check
+# vignette rebuild where the package isn't yet on .libPaths(). All varPro
+# calls below are ::-qualified, so no library(varPro) is needed.
+if (requireNamespace("ggRandomForests", quietly = TRUE)) {
+  library(ggRandomForests)
+} else if (requireNamespace("pkgload", quietly = TRUE)) {
+  pkgload::load_all(export_all = FALSE, helpers = FALSE,
+                    attach_testthat = FALSE)
+} else {
+  stop("Install ggRandomForests (or pkgload for dev builds) to render this vignette.")
+}
+```
+
+# Importance without a response
+
+Most measures of variable importance start from a question: which predictors
+help explain *this* outcome? Permutation VIMP, the varPro release rules, the
+per-rule lasso weights behind `gg_beta_varpro()` — all of them score a variable
+by how much it moves a response `y`. The companion
+[varPro vignette](varpro.html) walks that supervised toolkit end to end.
+
+But sometimes there is no `y`. You have a matrix of predictors and you want to
+know which columns carry the structure of the data: which variables define its
+shape, which travel together, and which are close to noise. That is the job of
+unsupervised varPro. `varPro::uvarpro()` grows a forest on the predictor matrix
+alone, with no response, and scores each variable by how much entropy it
+contributes to the regions the forest carves out [@Lu2024varpro]. "Important"
+here
+does not mean useful for prediction. It means a variable helps reconstruct the
+feature space that the others cannot.
+
+This is a short vignette. It walks the three `gg_*` views of a single
+`uvarpro()` fit, and each one answers a different question about that fit: what
+depends on what, what ranks highest, and where to draw the line between signal
+and noise.
+
+# One fit, three views
+
+We'll use `mtcars`. Its columns are all numeric, and several of them measure
+closely related things — displacement, horsepower, weight, and cylinder count
+all track engine size — so the unsupervised structure is easy to read.
+
+```{r fit}
+set.seed(1)
+u <- varPro::uvarpro(mtcars, ntree = 50)
+```
+
+Notice what `uvarpro()` was handed: the data frame, and nothing else. No
+formula, no outcome column singled out. All three views below read off this one
+fit. Two of them rest on the same `get.beta.entropy()` matrix, which is the only
+part worth caching, so we compute it once and pass it to both rather than paying
+for it twice:
+
+```{r beta_fit}
+beta_fit <- varPro::get.beta.entropy(u)
+```
+
+## What depends on what: `gg_udependent()`
+
+`gg_udependent()` reads cross-variable structure off the fit and draws it as a
+network: nodes are variables, edges are dependencies above a configurable
+threshold. The picture is built with `ggraph`, which lives in `Suggests` rather
+than `Imports`, so install it if you want this view.
+
+```{r udep, eval = requireNamespace("ggraph", quietly = TRUE)}
+plot(gg_udependent(u))
+```
+
+Clusters of mutually connected variables are worth a second look. Because the
+fit has no response, a cluster tells you these columns are correlated in feature
+space regardless of whether any of them would matter for a prediction. When you
+do have a downstream model, that is useful on its own: a variable can be
+important for prediction and still sit in a tight cluster with a near-duplicate,
+and in that case parsimony may favour dropping one member of the cluster without
+losing much.
+
+## What ranks highest: `gg_beta_uvarpro()`
+
+The network shows *structure*; `gg_beta_uvarpro()` turns the same fit into a
+*ranking*. It is the unsupervised analogue of `gg_beta_varpro()`: from the
+entropy matrix it aggregates the per-region lasso coefficients into a mean
+absolute weight per variable (`beta_mean`), orders them most-important first,
+and flags the ones above a selection cutoff. Here we hand it the `beta_fit` we
+already computed.
+
+```{r beta}
+plot(gg_beta_uvarpro(u, beta_fit = beta_fit))
+```
+
+Read it as the unsupervised counterpart of a VIMP bar chart. The tall bars are
+the variables that most define the structure of the predictor space. Paired with
+the network above, you get both halves of the story: *which* variables carry the
+most unsupervised signal, and *how* they group.
+
+## Where to draw the line: `gg_sdependent()`
+
+A ranking invites the obvious next question: where is the cut? Which variables
+are signal, and which are noise? `gg_sdependent()` answers that narrower
+question off the same fit. It wraps `varPro::sdependent()` and returns one row
+per candidate variable — an importance score, its degree in the dependency
+graph, and a `signal` flag — drawn as a ranked lollipop.
+
+```{r sdep}
+plot(gg_sdependent(u, beta_fit = beta_fit))
+```
+
+Where `gg_beta_uvarpro()` ranks *all* the variables, `gg_sdependent()` makes the
+cut explicit, separating the columns the unsupervised analysis treats as signal
+from the ones it treats as noise.
+
+# Reading the three together
+
+The three views are one workflow, not three unrelated plots. Start with
+`gg_udependent()` to see the structure, rank it with `gg_beta_uvarpro()`, then
+let `gg_sdependent()` draw the signal-versus-noise line. They all derive from the
+one `uvarpro()` fit, and two of them from the one `get.beta.entropy()` matrix, so
+computing that matrix once (as we did above) and passing it in keeps the whole
+sequence cheap.
+
+For the supervised side of varPro — VIMP, partial dependence, per-rule lasso
+refinement, local importance, and anomaly scoring — see the companion
+[varPro vignette](varpro.html).
+
+# References

--- a/vignettes/varpro.qmd
+++ b/vignettes/varpro.qmd
@@ -594,9 +594,9 @@ story. Both are tracked for v3.1.0.
 
 If you call either on a survival fit you'll get a clear error message
 pointing at the deferred work, not a silent miscalculation. The
-family-support matrix in §6 records this; the rest of the toolkit
-that *does* work on survival (`gg_varpro`, `gg_partial_varpro`, and
-`gg_isopro` above).
+family-support matrix in the closing reference section records this; the
+rest of the toolkit that *does* work on survival (`gg_varpro`,
+`gg_partial_varpro`, and `gg_isopro` above).
 
 # Cross-cutting reference
 
@@ -664,8 +664,8 @@ varPro's survival path (including the treatment of time-dependent
 covariates) is in @Lee:2021.
 
 Each wrapper's help page carries a "What this is doing" section that
-goes one level deeper than this vignette. The cross-cutting reference
-in §6 maps each wrapper to the forest families it supports and notes
-which capabilities are deferred to v3.1.0.
+goes one level deeper than this vignette. The cross-cutting reference at
+the end of this vignette maps each wrapper to the forest families it
+supports and notes which capabilities are deferred.
 
 # References

--- a/vignettes/varpro.qmd
+++ b/vignettes/varpro.qmd
@@ -122,16 +122,18 @@ is large; the conditional view catches that. One-hot consolidation via
 `get.orgvimp()` and `get.topvars()` maps the per-level scores back to the
 original factor, so downstream reporting stays on familiar ground.
 
-That core machinery feeds six ggRandomForests wrappers. **`gg_varpro()`**
-summarises the per-tree importance distribution. **`gg_beta_varpro()`**
-refines those release-rule contrasts with a per-rule lasso. **`gg_partial_varpro()`**
-turns the release machinery into partial-dependence curves.
-**`gg_udependent()`** reads cross-variable dependency off a `uvarpro()`
-fit. **`gg_isopro()`** scores observations for anomaly using an
-isolation-forest variant. **`gg_ivarpro()`** computes per-observation
-local importance.
+That core machinery feeds five supervised ggRandomForests wrappers.
+**`gg_varpro()`** summarises the per-tree importance distribution.
+**`gg_beta_varpro()`** refines those release-rule contrasts with a per-rule
+lasso. **`gg_partial_varpro()`** turns the release machinery into
+partial-dependence curves. **`gg_isopro()`** scores observations for anomaly
+using an isolation-forest variant. **`gg_ivarpro()`** computes per-observation
+local importance. A separate set of *unsupervised* wrappers —
+`gg_udependent()`, `gg_beta_uvarpro()`, and `gg_sdependent()` — reads structure
+off a `uvarpro()` fit that has no response at all; those get their own
+walk-through in the companion [uvarpro vignette](uvarpro.html).
 
-This vignette walks all six wrappers on three worked examples: a
+This vignette walks the five supervised wrappers on three worked examples: a
 regression problem (Boston housing), a classification problem (iris,
 binary and multi-class), and a survival problem (PBC). The closing
 section is a one-page reference matrix mapping each wrapper to the
@@ -262,77 +264,15 @@ signal: a variable that ranks high here but low there is one whose
 local linear effect inside many rules is real even when the release
 contrast is modest.
 
-## Cross-variable dependency with `gg_udependent()`
+## Unsupervised views: see the uvarpro vignette
 
-The three views so far take one variable at a time. `gg_udependent()`
-reads cross-variable structure off a `uvarpro()` fit and draws the
-result as a network: nodes are variables, edges are dependencies above a
-configurable threshold. The visual is built with `ggraph`, which is in
-`Suggests` rather than `Imports`; install it if you want this view.
-
-```{r boston-uvarpro, cache=TRUE}
-# Precomputed offline (see precompute_varpro.R); falls back to a live fit.
-u_boston <- if (is.null(.vp$u_boston)) {
-  varPro::uvarpro(Boston[, setdiff(names(Boston), "medv")], ntree = 50)
-} else {
-  .vp$u_boston
-}
-```
-
-```{r boston-gg-udependent, eval = requireNamespace("ggraph", quietly = TRUE)}
-plot(gg_udependent(u_boston))
-```
-
-Clusters of mutually-connected variables are worth checking for
-redundancy: they may be several views of the same underlying quantity.
-`uvarpro()` operates on the predictor matrix alone; there is no response
-in the fit, which is what makes the network genuinely unsupervised.
-Variables that cluster here are correlated in feature space regardless of
-whether any of them matters for prediction. That information is
-complementary to the ranking from `gg_varpro()`: a variable can be
-important for prediction and still sit in a tight cluster with a
-near-duplicate; in that situation, model parsimony may favour dropping
-one of the cluster members without losing much predictive accuracy.
-
-## Unsupervised importance with `gg_beta_uvarpro()`
-
-The dependency network shows *structure*; `gg_beta_uvarpro()` turns the
-same `uvarpro()` fit into a *ranking*. It is the unsupervised analogue of
-`gg_beta_varpro()`: from `varPro::get.beta.entropy()` it aggregates the
-per-region lasso coefficients into a mean absolute weight per variable
-(`beta_mean`), orders most-important first, and flags the variables above
-a selection cutoff. With no response in the fit, "important" means a
-variable that carries entropy the others do not — it helps reconstruct
-the feature space, not predict an outcome.
-
-```{r boston-gg-beta-uvarpro}
-plot(gg_beta_uvarpro(u_boston))
-```
-
-Read it as the unsupervised counterpart to a VIMP bar chart: the tall
-bars are the variables that most define the structure of the predictor
-space. Pairing this with the `gg_udependent()` network tells you both
-*which* variables carry the most unsupervised signal and *how* they
-group.
-
-## Signal-variable detection with `gg_sdependent()`
-
-You have a ranking from `gg_beta_uvarpro()`; now you want the cut line.
-Which variables are signal, and which are noise? `gg_sdependent()` answers
-that narrower question off the same fit. It wraps `varPro::sdependent()`
-and returns one row per candidate variable with an importance score, its
-degree in the dependency graph, and a `signal` flag, drawn as a ranked
-lollipop.
-
-```{r boston-gg-sdependent}
-plot(gg_sdependent(u_boston))
-```
-
-Where `gg_beta_uvarpro()` ranks *all* variables by entropy contribution,
-`gg_sdependent()` makes the cut explicit: it separates the variables the
-unsupervised analysis treats as carrying genuine signal from those it
-treats as noise. The two views share the `get.beta.entropy()` matrix, so
-they are cheap to compute together once `uvarpro()` has run.
+The wrappers so far all score variables against a response. varPro also has an
+unsupervised mode: `varPro::uvarpro()` grows a forest on the predictor matrix
+alone, and three more wrappers read off that fit — `gg_udependent()` draws the
+cross-variable dependency network, `gg_beta_uvarpro()` ranks the variables by
+their entropy contribution, and `gg_sdependent()` marks the cut between signal
+and noise. Because there is no outcome in play, they get their own short
+walk-through in the companion [uvarpro vignette](uvarpro.html).
 
 ## Anomaly scoring with `gg_isopro()`
 
@@ -655,8 +595,8 @@ story. Both are tracked for v3.1.0.
 If you call either on a survival fit you'll get a clear error message
 pointing at the deferred work, not a silent miscalculation. The
 family-support matrix in §6 records this; the rest of the toolkit
-that *does* work on survival (`gg_varpro`, `gg_partial_varpro`,
-`gg_isopro` above; `gg_udependent` shown in §3 on the X-matrix).
+that *does* work on survival (`gg_varpro`, `gg_partial_varpro`, and
+`gg_isopro` above).
 
 # Cross-cutting reference
 
@@ -666,7 +606,6 @@ that *does* work on survival (`gg_varpro`, `gg_partial_varpro`,
 |---|---|---|---|---|
 | `gg_partial_varpro` | ✓ | ✓ (prob) | ✓ (S(τ); rmst/mortality/chf) | ✗ (not audited) |
 | `gg_varpro` | ✓ | ✓ (`conditional = TRUE`) | ✓ | ✗ (errors) |
-| `gg_udependent` | ✓ (uvarpro on X) | ✓ (X) | ✓ (X) | ✓ (X) |
 | `gg_isopro` | ✓ (X) | ✓ (X) | ✓ (X) | ✓ (X) |
 | `gg_beta_varpro` | ✓ | ✓ | ✗ (upstream stop) | ✗ (deferred) |
 | `gg_ivarpro` | ✓ | ✓ | ✗ (deferred) | ✗ (deferred) |


### PR DESCRIPTION
## Summary

Gives the unsupervised varPro tools their own short vignette, and fixes a stale CRAN listing spotted along the way. No version bump — this folds into the accumulating 3.4.0 delta.

### New: `vignettes/uvarpro.qmd`
A short, focused vignette for the unsupervised wrappers (persona: general R practitioner). Opens from the familiar (importance methods need a `y`), pivots to the no-outcome premise, and walks **one `mtcars` `uvarpro()` fit** through three views:
- `gg_udependent()` — the dependency **structure**
- `gg_beta_uvarpro()` — the entropy **ranking**
- `gg_sdependent()` — the signal/noise **cut**

Uses the `beta_fit` cache-once idiom (compute `get.beta.entropy()` once, pass to both wrappers that need it). `mtcars` at `ntree=50` keeps the vignette build cheap — no precompute `.rds` needed. Renders clean: 3 figures (incl. the `ggraph` network), citation resolves.

### Trimmed: `vignettes/varpro.qmd` (now supervised-only)
The three unsupervised sections were lifted out so there's one source of truth:
- Intro reworked from "six wrappers" to "five supervised wrappers," pointing to the new vignette (the old intro already advertised 6 but demonstrated 8 — this fixes that drift).
- Three worked subsections → one short pointer section.
- Fixed the broken `§3` cross-reference; removed the `gg_udependent` row from the family-support matrix.
- `precompute_varpro.R`: removed the now-dead `u_boston` fit + list entry + stale comment.

Re-renders clean off the precomputed `.rds`.

### Fixed: stale CRAN vignette title
`ggRandomForests.qmd` still carried the quarto template placeholder:
```
%\VignetteIndexEntry{Vignette's Title}
```
This is what CRAN listed as **"Vignette's Title"** on the [package page](https://cran.r-project.org/web/packages/ggRandomForests/index.html) (the document `title:` was fine, so the rendered vignette looked correct — CRAN's index reads the `\VignetteIndexEntry{}` metadata). Now: `Exploring Random Forests with ggRandomForests`. Shipping stale since ≥ 3.2.0.

### Housekeeping
- `.gitignore`: ignore the `uvarpro_*` build artifacts (`.Rbuildignore` already covers them via wildcards).
- NEWS bullets added under the existing 3.4.0 heading.

## Verification
- `quarto render uvarpro.qmd` → exit 0, all 3 figures + reference list present.
- `quarto render varpro.qmd` → exit 0 (trim didn't break it).
- Smoke-tested all three `gg_*` calls on `mtcars` via `pkgload::load_all()`.
- No dangling refs: `u_boston`, "six wrappers", `§3` all gone from `varpro.qmd`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)