### PR TITLE
fix: .Rbuildignore excludes stray Rplots.pdf (clears top-level NOTE)

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -54,3 +54,6 @@ framed.sty
 ^vignettes/\.quarto$
 ^vignettes/.*_files$
 ^vignettes/.*\.html$
+# Stray default-device plot artefact (created by plotting with no open device),
+# at the root or under tests/ — never ship it.
+Rplots\.pdf$


### PR DESCRIPTION
## The NOTE
Local `devtools::check()` on 3.4.0 flagged:
```
checking top-level files ... NOTE
  Non-standard file/directory found at top level: 'Rplots.pdf'
```

## Cause
`Rplots.pdf` is a default-device artefact R writes when a plot is drawn with no open graphics device (interactive smoke-tests, testthat runs). It's already in `.gitignore` (so it never gets committed) but was **not** in `.Rbuildignore`, so `R CMD build` copied the stray working-tree file into the tarball → the NOTE. (The `.Rbuildignore` hygiene from #107 landed on the v4/`dev_rhf` line, not `main`.)

This is why the release-gate build was clean — it built from a `git clean`'d copy, so no stray was present.

## Fix
Add an unanchored `Rplots\.pdf$` rule to `.Rbuildignore` — excludes the artefact from the tarball at the root **or** under `tests/`, regardless of who left one behind.

**Verified:** with strays touched at both `./Rplots.pdf` and `./tests/testthat/Rplots.pdf`, the built tarball contains no `Rplots.pdf`.

No version bump, no NEWS (build-artefact hygiene, not user-visible). Version stays 3.4.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)