### PR TITLE
fix: ignore local CLAUDE.md (build + git)

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -29,6 +29,7 @@ framed.sty
 ^CRAN-SUBMISSION$
 ^\.github$
 ^\.claude$
+^CLAUDE\.md$
 ^\.git$
 ^\.vscode$
 ^doc$

--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ vignettes/uvarpro_files/
 vignettes/uvarpro.html
 
 .claude
+CLAUDE.md
 .positai
 
 # Brainstorm / visual-companion scratch


### PR DESCRIPTION
## Issue
A local `CLAUDE.md` (repo-specific Claude instructions — references the Obsidian codemap / `read-codemap` skill) sits at the repo root. It's untracked, but nothing kept `R CMD build` from copying it into the tarball → a `checking top-level files ... NOTE: Non-standard file/directory found at top level: 'CLAUDE.md'`.

Exactly the same class as the stray `Rplots.pdf` handled in #135 — an untracked working-tree file that `.gitignore` hides from git but `.Rbuildignore` was not excluding from the build.

## Fix
- `.Rbuildignore`: add `^CLAUDE\.md$` (never ship it in the tarball)
- `.gitignore`: add `CLAUDE.md` (never commit it)

**Verified:** with `CLAUDE.md` present in the source tree, `R CMD build` produces a tarball containing no `CLAUDE.md`.

No version bump, no NEWS (build-artefact hygiene, not user-visible). Version stays 3.4.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)