### PR TITLE
docs(cran-comments): reflect actual test environments (mac-builder down)

### DIFF
--- a/cran-comments.md
+++ b/cran-comments.md
@@ -35,9 +35,12 @@ single submission.
 * **Local:** R 4.6.0 on macOS (aarch64-apple-darwin23).
   `R CMD check --as-cran` (with the manual) returns 0 errors, 0 warnings,
   0 notes.
-* **win-builder:** R-devel, R-release, and R-oldrelease (Windows Server 2022,
-  x86_64) — Status: OK.
-* **mac-builder:** R 4.6.0 (aarch64-apple-darwin23, macOS) — Status: OK.
+* **win-builder:** R-devel (R 90199), R-release (4.6.1), and R-oldrelease
+  (4.5.3), Windows Server 2022, x86_64 — all Status: OK.
+* **macOS:** covered by the local aarch64-apple-darwin23 check above. The
+  mac.r-project.org macOS builder was unavailable at submission time
+  (HTTP 502), so no mac-builder result is included; the macOS platform is
+  also exercised by the macos-latest GitHub Actions job below.
 * **GitHub Actions matrix:** ubuntu-latest (R-devel / R-release /
   R-oldrel-1), windows-latest (R-release), macos-latest (R-release).
 * **Reverse-dependency check:** 0 reverse dependencies on CRAN.


### PR DESCRIPTION
## Why
mac-builder (`mac.r-project.org/macbuilder`) is returning **HTTP 502** at submission time, so there is no mac-builder result. The current `cran-comments.md` claims **"mac-builder ... Status: OK"**, which didn't happen — and that text is sent to CRAN verbatim by `submit_cran()`.

## Change
- Replace the mac-builder line with an honest statement: macOS is covered by the **local `aarch64-apple-darwin23` `--as-cran` check** (0/0/0) and the **macos-latest GitHub Actions** job.
- Pin the win-builder versions to the ones actually run this cycle: R-devel r90199, R-release 4.6.1, R-oldrelease 4.5.3 — **all Status: OK** (logs reviewed).

Doc-only; no code, no version change. `cran-comments.md` is `.Rbuildignore`d so this doesn't affect the tarball or check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)