### PR TITLE
test: deterministic single-outcome gg_vimp positive-flag regression test

### DIFF
--- a/tests/testthat/test_gg_vimp.R
+++ b/tests/testthat/test_gg_vimp.R
@@ -335,23 +335,29 @@ test_that("gg_vimp.rfsrc single-outcome: positive flag correctly uses the VIMP c
   # Regression test for the bug where gg_dta$vimp was accessed but the column
   # is named "VIMP" (uppercase) in single-outcome rfsrc fits, leaving positive
   # always TRUE even for variables with non-positive VIMP.
-  data(airquality)
+  #
+  # Force one VIMP non-positive so the test deterministically exercises the bug
+  # condition. A zero-variance ("const") predictor is unreliable here:
+  # permutation VIMP of a weak/constant variable can land slightly > 0 (and
+  # rfsrc may drop a constant column), so it does not guarantee a non-positive
+  # VIMP on every platform (observed failing on R-release). The pre-fix code
+  # left `positive` TRUE regardless of the VIMP sign.
+  set.seed(2024L)
   rf <- randomForestSRC::rfsrc(Ozone ~ ., data = na.omit(airquality),
-                               ntree = 50, importance = TRUE)
+                               ntree = 200, importance = TRUE)
+  rf$importance[1] <- -1
   gg_dta <- gg_vimp(rf)
 
   expect_s3_class(gg_dta, "gg_vimp")
   expect_true("positive" %in% colnames(gg_dta))
-  # The positive flag should correctly reflect the sign of VIMP:
-  # variables with vimp <= 0 must have positive == FALSE.
+
   vimp_col <- intersect(c("vimp", "VIMP"), colnames(gg_dta))[1]
-  neg_mask <- gg_dta[[vimp_col]] <= 0
-  if (any(neg_mask, na.rm = TRUE)) {
-    expect_true(all(!gg_dta$positive[which(neg_mask)]),
-                info = "Variables with non-positive VIMP must have positive == FALSE")
-  }
-  # Even if all VIMP happen to be positive here, the column must exist.
-  expect_true(length(unique(is.na(gg_dta$positive))) <= 1)
+  expect_false(is.na(vimp_col))
+  # The invariant, asserted for every row: positive is TRUE exactly when VIMP > 0.
+  expect_equal(gg_dta$positive, gg_dta[[vimp_col]] > 0)
+  # The injected -1 guarantees at least one non-positive VIMP, so the pre-fix
+  # all-TRUE behaviour would fail here.
+  expect_true(any(!gg_dta$positive))
   expect_s3_class(plot(gg_dta), "ggplot")
 })
 

--- a/tests/testthat/test_gg_vimp.R
+++ b/tests/testthat/test_gg_vimp.R
@@ -342,9 +342,10 @@ test_that("gg_vimp.rfsrc single-outcome: positive flag correctly uses the VIMP c
   # rfsrc may drop a constant column), so it does not guarantee a non-positive
   # VIMP on every platform (observed failing on R-release). The pre-fix code
   # left `positive` TRUE regardless of the VIMP sign.
+  data(airquality, package = "datasets")
   set.seed(2024L)
   rf <- randomForestSRC::rfsrc(Ozone ~ ., data = na.omit(airquality),
-                               ntree = 200, importance = TRUE)
+                               ntree = 50, importance = TRUE)
   rf$importance[1] <- -1
   gg_dta <- gg_vimp(rf)
 


### PR DESCRIPTION
## What

Replaces the single-outcome `gg_vimp` positive-flag test block in `test_gg_vimp.R` with the **deterministic** version already living on `dev_rhf` (V4). Test-only change; no source, docs, or version change.

## Why

This test guards the V3 bug (fixed in 3.1.0) where `gg_dta$vimp` was accessed while the single-outcome rfsrc column is uppercase `VIMP`, leaving `positive` always `TRUE` regardless of VIMP sign. The version currently on `main` is **probabilistic**:

- It only asserts the invariant `if (any(neg_mask))` — on a seed where every VIMP comes out positive, it exercises nothing. Its own comment concedes "Even if all VIMP happen to be positive here, the column must exist."
- The const/weak-predictor approach was observed failing on R-release: permutation VIMP of a weak variable can land slightly > 0, and rfsrc may drop a constant column — so a non-positive VIMP isn't guaranteed on every platform.

The deterministic version injects `rf$importance[1] <- -1` to force a non-positive VIMP, then asserts the full invariant on **every** row (`positive == VIMP > 0`) plus `any(!positive)`, so the pre-fix all-TRUE behaviour cannot slip through.

The V4 dev line already carries this; since V4/CRAN review is deferred, `main` (the CRAN line) otherwise keeps the weaker test for its own shipped fix. This closes that gap now.

## Verification

`testthat::test_file("tests/testthat/test_gg_vimp.R")` on this branch: **63 pass / 0 fail / 0 skip**. The `gg_vimp` source is identical on both lines (the 3.1.0 fix), so the injected-`-1` test passes here unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)