### PR TITLE
docs(regression vignette): add SHAP Analysis section

### DIFF
--- a/vignettes/ggRandomForests-regression.qmd
+++ b/vignettes/ggRandomForests-regression.qmd
@@ -246,8 +246,8 @@ plenty to see the patterns at a fraction of the cost.
 
 ```{r shap-fit}
 set.seed(42)
-sub <- Boston[sample(nrow(Boston), 40), setdiff(colnames(Boston), "medv")]
-gg_shp <- gg_shap(rfsrc_Boston, newdata = sub, bg_n = 50)
+shap_sample <- Boston[sample(nrow(Boston), 40), setdiff(colnames(Boston), "medv")]
+gg_shp <- gg_shap(rfsrc_Boston, newdata = shap_sample, bg_n = 50)
 ```
 
 ## SHAP importance

--- a/vignettes/ggRandomForests-regression.qmd
+++ b/vignettes/ggRandomForests-regression.qmd
@@ -223,6 +223,81 @@ the minimal depth top variables for the remainder of the analysis.
 xvar <- md_Boston$topvars
 ```
 
+# SHAP Analysis
+
+VIMP and varPro both rank *how much* a variable matters, averaged over the
+whole forest. They cannot tell you how much a variable mattered for one
+specific tract's prediction --- that requires a different kind of
+accounting. SHAP (SHapley Additive exPlanations) borrows an idea from
+cooperative game theory: treat the 13 predictors as players splitting a
+payout, and ask how much each one contributed to this tract's predicted
+`medv`, averaged fairly over every order the players could have joined the
+game. The result is a signed contribution per predictor per tract, and those
+contributions add up exactly: the forest's overall average prediction (the
+*baseline*) plus the sum of one tract's contributions equals that tract's
+actual predicted value. No other importance measure in this vignette makes
+that promise.
+
+`gg_shap()` computes these contributions by calling
+[kernelshap](https://cran.r-project.org/package=kernelshap), which needs one
+prediction per predictor per background draw, per tract explained. Scoring
+all 506 tracts is expensive, so we explain a random sample of 40 instead,
+plenty to see the patterns at a fraction of the cost.
+
+```{r shap-fit}
+set.seed(42)
+sub <- Boston[sample(nrow(Boston), 40), setdiff(colnames(Boston), "medv")]
+gg_shp <- gg_shap(rfsrc_Boston, newdata = sub, bg_n = 50)
+```
+
+## SHAP importance
+
+Averaging the absolute contribution of each variable across the 40 tracts
+gives a ranking directly comparable to VIMP.
+
+```{r shap-importance-plot, fig.cap="Mean absolute SHAP value per predictor."}
+plot(gg_shp, type = "importance")
+```
+
+`lstat` and `rm` come out on top again, same as VIMP and minimal depth ---
+three different mechanisms, one answer. That agreement is reassuring, but
+it's the next two plots where SHAP earns its keep.
+
+## SHAP beeswarm
+
+The beeswarm plot is one dot per tract per variable: its horizontal position
+is the SHAP contribution (negative pulls the prediction down, positive pushes
+it up), and its color is that tract's value for the variable, scaled low to
+high within each row so the pattern doesn't get washed out by variables on
+very different scales.
+
+```{r shap-beeswarm-plot, fig.cap="SHAP beeswarm: every dot is one tract's contribution for one predictor."}
+plot(gg_shp, type = "beeswarm")
+```
+
+`lstat` shows a clean color gradient: the yellow (high lower-status
+population) dots sit on the negative side, the purple (low) dots on the
+positive side. `rm` runs the other way. Both track what the EDA scatterplot
+already hinted at, but now stated as a contribution to an individual
+prediction rather than a marginal trend.
+
+## SHAP dependence
+
+Plotting one variable's SHAP contribution against its own value is the
+closest SHAP gets to a partial dependence plot, tract by tract instead of
+averaged.
+
+```{r shap-dependence-plot, fig.cap="SHAP dependence for lstat."}
+plot(gg_shp, type = "dependence", xvar = "lstat")
+```
+
+The downward slope matches the sign of the correlation directly: tracts with
+more lower-status population get pulled below the baseline prediction, tracts
+with less get pushed above it. The next section asks the same question a
+second way, partial dependence averaged over the whole forest instead of
+tract by tract, and the two views should agree on the shape even though
+they're built from entirely different mechanics.
+
 # Variable Dependence
 
 ## Variable dependence plots


### PR DESCRIPTION
## Summary
- Adds a "SHAP Analysis" section to `ggRandomForests-regression.qmd`, positioned between Variable Selection (VIMP/minimal depth) and Variable Dependence — SHAP importance is the natural sequel to VIMP, and this sets up the "same question, different mechanism" comparison right before partial dependence.
- Covers all three `gg_shap()` views: importance (mean |SHAP|), beeswarm (per-tract, per-variable signed contribution colored by feature value), and dependence (SHAP vs. feature value for `lstat`).
- Explains a random sample of 40 tracts rather than all 506 Boston housing tracts — `kernelshap` isn't in exact mode above 8 predictors (this forest has 13), and scoring all 506 took 2.7 min locally vs. ~15s for the sample. That matters here because vignettes rebuild during `R CMD check`, and this repo has a hard <10 min check-time budget.
- Every factual claim in the prose (SHAP/VIMP importance agreement, `lstat`'s contribution direction, the additive baseline + Σ SHAP = prediction property) was verified against live output before writing, not asserted from memory or copied from the design doc.

## Test plan
- [x] Vignette renders cleanly end-to-end via `quarto render` (49 chunks, no errors/warnings)
- [x] Full test suite: 0 failures (1310 pass)
- [x] `devtools::check(manual = TRUE)` — **0 errors / 0 warnings / 0 notes**, 3m56s (vignette rebuild step: 45s, up from ~28s pre-SHAP) — comfortably under the 10-minute CRAN budget
- [x] Spot-checked generated plots (beeswarm color direction matches viridis's actual low→high mapping and the verified correlation sign; dependence plot slope matches the verified correlation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)