### PR TITLE
fix(ci): move archived SHAP k-fold scripts out of R/ to unbreak main

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -28,6 +28,7 @@ framed.sty
 ^CRAN-RELEASE$
 ^CRAN-SUBMISSION$
 ^\.github$
+^data-raw$
 ^\.claude$
 ^CLAUDE\.md$
 ^\.git$

--- a/.lintr
+++ b/.lintr
@@ -11,6 +11,7 @@ linters: linters_with_defaults(
   )
 exclusions: list(
     "R/ggrandomforests.news.R",
-    "R/zzz.R"
+    "R/zzz.R",
+    "data-raw"
   )
 encoding: "UTF-8"

--- a/data-raw/shap-kfold-reference.R
+++ b/data-raw/shap-kfold-reference.R
@@ -1,3 +1,14 @@
+# Archived reference script -- not part of the package.
+#
+# A preserved record of an exploratory k-fold XGBoost SHAP analysis. It is kept
+# for reference only and will not run as-is: it depends on objects
+# (`model_list`, `X`, `folds`, `formula_var_name_to_english`, `x_to_x_mat`)
+# that are never defined here, and on packages (`xgboost`, `SHAPforxgboost`,
+# `data.table`, `pacman`) that are not package dependencies.
+#
+# This directory is listed in .Rbuildignore, so nothing here is built, checked,
+# linted, or shipped in the tarball.
+
 pacman::p_load(xgboost, SHAPforxgboost, data.table)
 
 # Extract SHAP per fold ----

--- a/data-raw/shap-kfold-summary-reference.R
+++ b/data-raw/shap-kfold-summary-reference.R
@@ -1,3 +1,14 @@
+# Archived reference script -- not part of the package.
+#
+# A preserved record of an exploratory k-fold XGBoost SHAP summary analysis. It
+# is kept for reference only and will not run as-is: it depends on objects
+# (`model_list`, `X`, `figure_dir`, `formula_var_name_to_english`, `x_to_x_mat`)
+# that are never defined here, and on packages (`SHAPforxgboost`, `dplyr`) that
+# are not fully declared for this workflow.
+#
+# This directory is listed in .Rbuildignore, so nothing here is built, checked,
+# linted, or shipped in the tarball.
+
 shap_values_list_mat <- lapply(model_list, function(model) {
   as.matrix(shap.values(xgb_model = model, X_train = x_to_x_mat(X))$shap_score)
 })


### PR DESCRIPTION
## Why main is red

Every workflow on `main` is failing — `R-CMD-check-standard`, `R-CMD-check-release`, `pkgdown`, `test-coverage`, and `lint`. There is **one** root cause behind the first four, and a second, separate one behind `lint`.

**Root cause 1 — the package could not install.**
PR #144 added two exploratory XGBoost SHAP scripts (`R/shap.R`, `R/shap2.R`) as *bare top-level code*. R evaluates every top-level expression in `R/` during `R CMD INSTALL` (that is how lazy-loading works), so the package tried to run a k-fold SHAP analysis while installing itself:

```
Error in loadNamespace(x) : there is no package called ‘pacman’
Error: unable to load R code in package ‘ggRandomForests’
ERROR: lazy loading failed for package ‘ggRandomForests’
```

Install is step zero for R CMD check, pkgdown and covr alike, so one bad line took out four workflows.

**Root cause 2 — lint.** The same two files carried 68 style violations (`pipe_consistency`, `trailing_whitespace`, `commas`, ...). They were the *only* source of lints in the package.

## The fix

These are archived reference scripts, not package code. They depend on objects that are never defined anywhere (`model_list`, `X`, `folds`, `x_to_x_mat`) and on packages that are not declared dependencies (`xgboost`, `SHAPforxgboost`, `data.table`, `pacman`). They cannot run as-is and are not meant to.

So rather than wrap them in a never-called function — which would keep them in `R/`, where `codetools` would still emit "no visible binding for global variable" NOTEs and the linter would still demand 68 fixes to dead code — this moves them out of `R/` entirely:

- `R/shap.R`  → `data-raw/shap-kfold-reference.R`
- `R/shap2.R` → `data-raw/shap-kfold-summary-reference.R`
- `.Rbuildignore`: add `^data-raw$` so the directory never enters the tarball
- `.lintr`: add `data-raw` to `exclusions` — **`lint_package()` scans `data-raw/` by default**, so `.Rbuildignore` alone would not have silenced lint
- each file keeps a header comment recording what it is and why it will not run

Both moves are 100% renames, so the diff is just the two headers plus two config lines.

## Verification

Run locally against this branch:

| Gate | Before | After |
|---|---|---|
| `R CMD INSTALL` | lazy loading failed | **`* DONE (ggRandomForests)`** |
| `lintr::lint_package()` | 68 lints | **0 lints** |
| `R CMD build` | — | **`data-raw/` absent from tarball** |
| `R CMD check --as-cran` | could not install | **0 errors, 0 warnings, 0 notes** |

## Note

`R CMD check` locally reports one extra NOTE for an untracked `AGENTS.md` at top level. It is untracked, so it cannot reach CI. If it is ever committed it will need an `^AGENTS\.md$` entry in `.Rbuildignore`, or it will fail CI (`error_on: "warning"`).

Separately: `.gitignore` has per-vignette artifact rules for every vignette except the new classification one from #147, so `vignettes/ggRandomForests-classification.html` and its `_files/` dir show up as untracked build artifacts. Not fixed here to keep this diff surgical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)