### PR TITLE
chore: ignore rendered classification vignette artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,7 +62,9 @@ CLAUDE.md
 # Rendered vignette artifacts (current quarto vignette names)
 vignettes/ggRandomForests-regression.html
 vignettes/ggRandomForests-survival.html
+vignettes/ggRandomForests-classification.html
 vignettes/ggRandomForests-regression_files/
 vignettes/ggRandomForests-survival_files/
+vignettes/ggRandomForests-classification_files/
 # Built package tarballs
 *.tar.gz


### PR DESCRIPTION
PR #147 added the classification vignette but not its `.gitignore` artifact rules, so `vignettes/ggRandomForests-classification.html` and its `_files/` directory turned up as untracked noise after every render — and were one stray `git add -A` away from being committed.

Every other quarto vignette already has these rules. This brings the classification one in line:

```
 vignettes/ggRandomForests-regression.html
 vignettes/ggRandomForests-survival.html
+vignettes/ggRandomForests-classification.html
 vignettes/ggRandomForests-regression_files/
 vignettes/ggRandomForests-survival_files/
+vignettes/ggRandomForests-classification_files/
```

**No `_cache` rule.** The regression and varpro vignettes declare caching and therefore have `_cache` rules; the classification vignette does not enable caching, so no `_cache` directory is produced and a rule would be speculative.

Verified: both artifacts are now matched by `git check-ignore`, `git status` is clean, and the `.qmd` source is confirmed **not** ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)