### PR TITLE
fix(gg_partial): label the plotted quantity instead of rescaling it (#15)

### DIFF
--- a/R/gg_partial.R
+++ b/R/gg_partial.R
@@ -142,9 +142,9 @@ gg_partial <- function(part_dta,
 
   result <- list(continuous = continuous, categorical = categorical)
   class(result) <- "gg_partial"
-  ## Carry rfsrc's own description of the plotted quantity. For survival forests
-  ## plot.variable defaults to surv.type = "mort", so yhat is mortality (an
-  ## expected event count) rather than a survival probability; without this
+  ## Carry plot.variable()'s own description of the plotted quantity. For
+  ## survival forests it defaults to surv.type = "mort", so yhat is mortality
+  ## (an expected event count) rather than a survival probability; without this
   ## label the two are easily confused. See gg_partial's @note.
   attr(result, "ylabel") <- part_dta$ylabel
   return(result)

--- a/R/gg_partial.R
+++ b/R/gg_partial.R
@@ -59,16 +59,16 @@
 #'   there is no `randomForest` method (the `randomForest` package
 #'   provides no comparable partial-dependence interface).
 #'
-#' @note For survival forests, \code{rfsrc::plot.variable} defaults to
-#'   \code{surv.type = "mort"}, so \code{yhat} is \emph{mortality} -- the
+#' @note For survival forests, \code{randomForestSRC::plot.variable} defaults
+#'   to \code{surv.type = "mort"}, so \code{yhat} is \emph{mortality} -- the
 #'   expected number of events -- and not a survival probability. It is
 #'   therefore not on \eqn{[0, 1]} and is not directly comparable with the
 #'   survival probabilities returned by \code{\link{gg_variable}}. For a
 #'   comparable quantity, ask for it explicitly:
-#'   \code{plot.variable(rf, partial = TRUE, surv.type = "surv")}. The label
-#'   describing the plotted quantity is recorded on the returned object as
-#'   \code{attr(x, "ylabel")} and is used as the y-axis title by
-#'   \code{\link{plot.gg_partial}}.
+#'   \code{randomForestSRC::plot.variable(rf, partial = TRUE,
+#'   surv.type = "surv")}. The label describing the plotted quantity is
+#'   recorded on the returned object as \code{attr(x, "ylabel")} and is used
+#'   as the y-axis title by \code{\link{plot.gg_partial}}.
 #'
 #'   Note that \code{\link{gg_partial_rfsrc}} defaults to
 #'   \code{partial.type = "surv"} and so reports survival probabilities. The

--- a/R/gg_partial.R
+++ b/R/gg_partial.R
@@ -69,6 +69,10 @@
 #'   describing the plotted quantity is recorded on the returned object as
 #'   \code{attr(x, "ylabel")} and is used as the y-axis title by
 #'   \code{\link{plot.gg_partial}}.
+#'
+#'   Note that \code{\link{gg_partial_rfsrc}} defaults to
+#'   \code{partial.type = "surv"} and so reports survival probabilities. The
+#'   two entry points therefore report different quantities by default.
 #' @export
 gg_partial <- function(part_dta,
                        nvars = NULL,

--- a/R/gg_partial.R
+++ b/R/gg_partial.R
@@ -58,6 +58,17 @@
 #' @note Partial-dependence extraction is `randomForestSRC`-only;
 #'   there is no `randomForest` method (the `randomForest` package
 #'   provides no comparable partial-dependence interface).
+#'
+#' @note For survival forests, \code{rfsrc::plot.variable} defaults to
+#'   \code{surv.type = "mort"}, so \code{yhat} is \emph{mortality} -- the
+#'   expected number of events -- and not a survival probability. It is
+#'   therefore not on \eqn{[0, 1]} and is not directly comparable with the
+#'   survival probabilities returned by \code{\link{gg_variable}}. For a
+#'   comparable quantity, ask for it explicitly:
+#'   \code{plot.variable(rf, partial = TRUE, surv.type = "surv")}. The label
+#'   describing the plotted quantity is recorded on the returned object as
+#'   \code{attr(x, "ylabel")} and is used as the y-axis title by
+#'   \code{\link{plot.gg_partial}}.
 #' @export
 gg_partial <- function(part_dta,
                        nvars = NULL,
@@ -126,5 +137,10 @@ gg_partial <- function(part_dta,
 
   result <- list(continuous = continuous, categorical = categorical)
   class(result) <- "gg_partial"
+  ## Carry rfsrc's own description of the plotted quantity. For survival forests
+  ## plot.variable defaults to surv.type = "mort", so yhat is mortality (an
+  ## expected event count) rather than a survival probability; without this
+  ## label the two are easily confused. See gg_partial's @note.
+  attr(result, "ylabel") <- part_dta$ylabel
   return(result)
 }

--- a/R/gg_partial.R
+++ b/R/gg_partial.R
@@ -8,18 +8,19 @@
 #' average effect of the swept predictor alone.
 #'
 #' \code{gg_partial} handles the bookkeeping step after you've already called
-#' \code{rfsrc::plot.variable(partial = TRUE)}: it takes the list that function
-#' returns and separates the variables into two tidy data frames -- one for
-#' continuous predictors (plotted as lines) and one for categorical predictors
-#' (plotted as bar charts).  The split is controlled by \code{cat_limit}:
-#' variables with more unique x-values than this threshold are treated as
-#' continuous; all others are categorical.
+#' \code{randomForestSRC::plot.variable(partial = TRUE)}: it takes the list
+#' that function returns and separates the variables into two tidy data frames
+#' -- one for continuous predictors (plotted as lines) and one for categorical
+#' predictors (plotted as bar charts).  The split is controlled by
+#' \code{cat_limit}: variables with more unique x-values than this threshold
+#' are treated as continuous; all others are categorical.
 #'
 #' If you'd rather skip the \code{plot.variable} step and pass the fitted
 #' forest directly, see \code{\link{gg_partial_rfsrc}}, which calls
 #' \code{partial.rfsrc} for you.
 #'
-#' @param part_dta partial plot data from \code{rfsrc::plot.variable}
+#' @param part_dta partial plot data from
+#'   \code{randomForestSRC::plot.variable}
 #' @param nvars how many of the partial plot variables to calculate
 #' @param cat_limit Categorical features are built when there are fewer than
 #'  \code{cat_limit} unique feature values.

--- a/R/gg_partial_rfsrc.R
+++ b/R/gg_partial_rfsrc.R
@@ -108,7 +108,7 @@
 #' @note For survival forests this function defaults to
 #'   \code{partial.type = "surv"}, so \code{yhat} is a survival probability on
 #'   \eqn{[0, 1]}. \code{\link{gg_partial}} wraps
-#'   \code{rfsrc::plot.variable} instead, which defaults to
+#'   \code{randomForestSRC::plot.variable} instead, which defaults to
 #'   \code{surv.type = "mort"} and therefore yields \emph{mortality} (an
 #'   expected event count). The two entry points consequently report different
 #'   quantities by default; check the y-axis label, which each records on the

--- a/R/gg_partial_rfsrc.R
+++ b/R/gg_partial_rfsrc.R
@@ -105,6 +105,15 @@
 #' prt_dta <- gg_partial_rfsrc(airq.obj,
 #'                        xvar.names = c("Wind"))
 #'
+#' @note For survival forests this function defaults to
+#'   \code{partial.type = "surv"}, so \code{yhat} is a survival probability on
+#'   \eqn{[0, 1]}. \code{\link{gg_partial}} wraps
+#'   \code{rfsrc::plot.variable} instead, which defaults to
+#'   \code{surv.type = "mort"} and therefore yields \emph{mortality} (an
+#'   expected event count). The two entry points consequently report different
+#'   quantities by default; check the y-axis label, which each records on the
+#'   returned object.
+#'
 #' @importFrom dplyr mutate filter select all_of
 #' @export
 gg_partial_rfsrc <- function(rf_model,

--- a/R/plot.gg_partial.R
+++ b/R/plot.gg_partial.R
@@ -64,9 +64,10 @@ partial_surv_y_label <- function(partial.type) {
 plot.gg_partial <- function(x, ...) {
   gg_dta <- x
 
-  ## rfsrc records what the partial yhat actually is ("mortality", "predicted
-  ## survival (time=...)", "probability setosa", expression(hat(y))). Prefer it
-  ## over the generic label so mortality is never mistaken for a probability.
+  ## plot.variable() records what the partial yhat actually is ("mortality",
+  ## "predicted survival (time=...)", "probability setosa", expression(hat(y))).
+  ## Prefer it over the generic label so mortality is never mistaken for a
+  ## probability.
   y_lab <- attr(gg_dta, "ylabel")
   if (is.null(y_lab)) {
     y_lab <- "Partial Effect"

--- a/R/plot.gg_partial.R
+++ b/R/plot.gg_partial.R
@@ -64,6 +64,14 @@ partial_surv_y_label <- function(partial.type) {
 plot.gg_partial <- function(x, ...) {
   gg_dta <- x
 
+  ## rfsrc records what the partial yhat actually is ("mortality", "predicted
+  ## survival (time=...)", "probability setosa", expression(hat(y))). Prefer it
+  ## over the generic label so mortality is never mistaken for a probability.
+  y_lab <- attr(gg_dta, "ylabel")
+  if (is.null(y_lab)) {
+    y_lab <- "Partial Effect"
+  }
+
   gg_cont <- NULL
   if (!is.null(gg_dta$continuous) && nrow(gg_dta$continuous) > 0) {
     cont <- gg_dta$continuous
@@ -78,7 +86,7 @@ plot.gg_partial <- function(x, ...) {
 
     gg_cont <- gg_cont +
       ggplot2::facet_wrap(~name, scales = "free_x") +
-      ggplot2::labs(x = NULL, y = "Partial Effect")
+      ggplot2::labs(x = NULL, y = y_lab)
   }
 
   gg_cat <- NULL
@@ -88,7 +96,7 @@ plot.gg_partial <- function(x, ...) {
                               ggplot2::aes(x = .data$x, y = .data$yhat)) +
       ggplot2::geom_bar(stat = "identity", width = 0.5) +
       ggplot2::facet_wrap(~name, scales = "free_x") +
-      ggplot2::labs(x = NULL, y = "Partial Effect")
+      ggplot2::labs(x = NULL, y = y_lab)
   }
 
   if (!is.null(gg_cont) && !is.null(gg_cat)) {

--- a/man/gg_partial.Rd
+++ b/man/gg_partial.Rd
@@ -61,6 +61,10 @@ comparable quantity, ask for it explicitly:
 describing the plotted quantity is recorded on the returned object as
 \code{attr(x, "ylabel")} and is used as the y-axis title by
 \code{\link{plot.gg_partial}}.
+
+Note that \code{\link{gg_partial_rfsrc}} defaults to
+\code{partial.type = "surv"} and so reports survival probabilities. The
+two entry points therefore report different quantities by default.
 }
 \examples{
 ## Build a small regression forest on the airquality dataset

--- a/man/gg_partial.Rd
+++ b/man/gg_partial.Rd
@@ -50,6 +50,17 @@ forest directly, see \code{\link{gg_partial_rfsrc}}, which calls
 Partial-dependence extraction is \code{randomForestSRC}-only;
 there is no \code{randomForest} method (the \code{randomForest} package
 provides no comparable partial-dependence interface).
+
+For survival forests, \code{rfsrc::plot.variable} defaults to
+\code{surv.type = "mort"}, so \code{yhat} is \emph{mortality} -- the
+expected number of events -- and not a survival probability. It is
+therefore not on \eqn{[0, 1]} and is not directly comparable with the
+survival probabilities returned by \code{\link{gg_variable}}. For a
+comparable quantity, ask for it explicitly:
+\code{plot.variable(rf, partial = TRUE, surv.type = "surv")}. The label
+describing the plotted quantity is recorded on the returned object as
+\code{attr(x, "ylabel")} and is used as the y-axis title by
+\code{\link{plot.gg_partial}}.
 }
 \examples{
 ## Build a small regression forest on the airquality dataset

--- a/man/gg_partial.Rd
+++ b/man/gg_partial.Rd
@@ -51,16 +51,16 @@ Partial-dependence extraction is \code{randomForestSRC}-only;
 there is no \code{randomForest} method (the \code{randomForest} package
 provides no comparable partial-dependence interface).
 
-For survival forests, \code{rfsrc::plot.variable} defaults to
-\code{surv.type = "mort"}, so \code{yhat} is \emph{mortality} -- the
+For survival forests, \code{randomForestSRC::plot.variable} defaults
+to \code{surv.type = "mort"}, so \code{yhat} is \emph{mortality} -- the
 expected number of events -- and not a survival probability. It is
 therefore not on \eqn{[0, 1]} and is not directly comparable with the
 survival probabilities returned by \code{\link{gg_variable}}. For a
 comparable quantity, ask for it explicitly:
-\code{plot.variable(rf, partial = TRUE, surv.type = "surv")}. The label
-describing the plotted quantity is recorded on the returned object as
-\code{attr(x, "ylabel")} and is used as the y-axis title by
-\code{\link{plot.gg_partial}}.
+\code{randomForestSRC::plot.variable(rf, partial = TRUE,
+  surv.type = "surv")}. The label describing the plotted quantity is
+recorded on the returned object as \code{attr(x, "ylabel")} and is used
+as the y-axis title by \code{\link{plot.gg_partial}}.
 
 Note that \code{\link{gg_partial_rfsrc}} defaults to
 \code{partial.type = "surv"} and so reports survival probabilities. The

--- a/man/gg_partial.Rd
+++ b/man/gg_partial.Rd
@@ -7,7 +7,8 @@
 gg_partial(part_dta, nvars = NULL, cat_limit = 10, model = NULL)
 }
 \arguments{
-\item{part_dta}{partial plot data from \code{rfsrc::plot.variable}}
+\item{part_dta}{partial plot data from
+\code{randomForestSRC::plot.variable}}
 
 \item{nvars}{how many of the partial plot variables to calculate}
 
@@ -35,12 +36,12 @@ average effect of the swept predictor alone.
 }
 \details{
 \code{gg_partial} handles the bookkeeping step after you've already called
-\code{rfsrc::plot.variable(partial = TRUE)}: it takes the list that function
-returns and separates the variables into two tidy data frames -- one for
-continuous predictors (plotted as lines) and one for categorical predictors
-(plotted as bar charts).  The split is controlled by \code{cat_limit}:
-variables with more unique x-values than this threshold are treated as
-continuous; all others are categorical.
+\code{randomForestSRC::plot.variable(partial = TRUE)}: it takes the list
+that function returns and separates the variables into two tidy data frames
+-- one for continuous predictors (plotted as lines) and one for categorical
+predictors (plotted as bar charts).  The split is controlled by
+\code{cat_limit}: variables with more unique x-values than this threshold
+are treated as continuous; all others are categorical.
 
 If you'd rather skip the \code{plot.variable} step and pass the fitted
 forest directly, see \code{\link{gg_partial_rfsrc}}, which calls

--- a/man/gg_partial_rfsrc.Rd
+++ b/man/gg_partial_rfsrc.Rd
@@ -91,7 +91,7 @@ plot layers them as separate coloured lines.
 For survival forests this function defaults to
 \code{partial.type = "surv"}, so \code{yhat} is a survival probability on
 \eqn{[0, 1]}. \code{\link{gg_partial}} wraps
-\code{rfsrc::plot.variable} instead, which defaults to
+\code{randomForestSRC::plot.variable} instead, which defaults to
 \code{surv.type = "mort"} and therefore yields \emph{mortality} (an
 expected event count). The two entry points consequently report different
 quantities by default; check the y-axis label, which each records on the

--- a/man/gg_partial_rfsrc.Rd
+++ b/man/gg_partial_rfsrc.Rd
@@ -87,6 +87,16 @@ You can request the curve at one or more time horizons via
 \code{partial.time}; the resulting data have a \code{time} column so the
 plot layers them as separate coloured lines.
 }
+\note{
+For survival forests this function defaults to
+\code{partial.type = "surv"}, so \code{yhat} is a survival probability on
+\eqn{[0, 1]}. \code{\link{gg_partial}} wraps
+\code{rfsrc::plot.variable} instead, which defaults to
+\code{surv.type = "mort"} and therefore yields \emph{mortality} (an
+expected event count). The two entry points consequently report different
+quantities by default; check the y-axis label, which each records on the
+returned object.
+}
 \section{Survival forests and \code{partial.time}}{
 
 \code{\link[randomForestSRC]{partial.rfsrc}} expects every value in

--- a/tests/testthat/test_gg_partial.R
+++ b/tests/testthat/test_gg_partial.R
@@ -1,6 +1,7 @@
 # Tests for gg_partial and gg_partial_rfsrc
 
-# Helper: create mock partial plot data (matching rfsrc::plot.variable structure)
+# Helper: create mock partial plot data (matching the structure returned by
+# randomForestSRC::plot.variable())
 make_mock_partial_data <- function() {
   set.seed(42)
   # Wind: continuous (15 unique values > cat_limit of 10)
@@ -424,11 +425,12 @@ test_that("gg_partial_rfsrc survival: returns correct column names", {
 # ---- yhat scale / ylabel provenance (issue #15) ---------------------------
 
 test_that("gg_partial passes yhat through unscaled", {
-  # Guards issue #15. rfsrc::plot.variable defaults to surv.type = "mort", so a
-  # survival forest's yhat is *mortality* (an expected event count), not a
-  # survival probability. It only superficially resembles a percentage. Any
-  # rescaling here (e.g. dividing by 100 to "match" gg_variable's [0, 1])
-  # would silently corrupt it into a meaningless quantity.
+  # Guards issue #15. randomForestSRC::plot.variable() defaults to
+  # surv.type = "mort", so a survival forest's yhat is *mortality* (an
+  # expected event count), not a survival probability. It only superficially
+  # resembles a percentage. Any rescaling here (e.g. dividing by 100 to
+  # "match" gg_variable's [0, 1]) would silently corrupt it into a
+  # meaningless quantity.
   mock_dta <- make_mock_partial_data()
   result <- gg_partial(mock_dta)
 

--- a/tests/testthat/test_gg_partial.R
+++ b/tests/testthat/test_gg_partial.R
@@ -420,3 +420,52 @@ test_that("gg_partial_rfsrc survival: returns correct column names", {
 
   expect_true(all(c("x", "yhat", "name", "time") %in% colnames(result$continuous)))
 })
+
+# ---- yhat scale / ylabel provenance (issue #15) ---------------------------
+
+test_that("gg_partial passes yhat through unscaled", {
+  # Guards issue #15. rfsrc::plot.variable defaults to surv.type = "mort", so a
+  # survival forest's yhat is *mortality* (an expected event count), not a
+  # survival probability. It only superficially resembles a percentage. Any
+  # rescaling here (e.g. dividing by 100 to "match" gg_variable's [0, 1])
+  # would silently corrupt it into a meaningless quantity.
+  mock_dta <- make_mock_partial_data()
+  result <- gg_partial(mock_dta)
+
+  expect_equal(
+    result$continuous$yhat,
+    mock_dta$plotthis$Wind$yhat
+  )
+})
+
+test_that("gg_partial records the ylabel describing the plotted quantity", {
+  mock_dta <- make_mock_partial_data()
+  mock_dta$ylabel <- "mortality"
+
+  result <- gg_partial(mock_dta)
+  expect_equal(attr(result, "ylabel"), "mortality")
+})
+
+test_that("gg_partial tolerates part_dta with no ylabel", {
+  mock_dta <- make_mock_partial_data()  # helper supplies no ylabel
+  result <- gg_partial(mock_dta)
+
+  expect_null(attr(result, "ylabel"))
+  expect_s3_class(result, "gg_partial")
+})
+
+test_that("plot.gg_partial labels the y axis with the recorded quantity", {
+  mock_dta <- make_mock_partial_data()
+  mock_dta$ylabel <- "mortality"
+
+  gg <- plot(gg_partial(mock_dta))
+  # continuous and categorical are combined by patchwork; check the first panel
+  expect_equal(gg[[1]]$labels$y, "mortality")
+})
+
+test_that("plot.gg_partial falls back to 'Partial Effect' with no ylabel", {
+  mock_dta <- make_mock_partial_data()
+
+  gg <- plot(gg_partial(mock_dta))
+  expect_equal(gg[[1]]$labels$y, "Partial Effect")
+})


### PR DESCRIPTION
Closes the investigation on #15. **The issue's premise is wrong, and the fix it proposes would silently corrupt data.** This PR changes no numbers.

## What #15 claims

> For survival and classification forests, variable dependence is returned on [0,1], partial dependence for survival is returned as [0,100]. Should be able to detect the difference and convert.

## What is actually happening

`rfsrc::plot.variable()` has `surv.type = c("mort", "rel.freq", "surv", ...)`, and `match.arg` takes the first — so **the default is mortality, not survival probability**.

Same forest, same variable, only `surv.type` differs:

| `surv.type` | rfsrc's `ylabel` | `gg_partial` yhat |
|---|---|---|
| **`"mort"`** ← default | `mortality` | **[32.502, 89.202]** |
| `"surv"` | `predicted survival (time=1191)` | **[0.519, 0.846]** |
| `"rel.freq"` | `standardized mortality` | [0.118, 0.323] |

**pbc has 161 events.** Mortality is the *expected number of events*, so 32–89 is exactly what mortality looks like on this data. It is not "survival probability × 100" — it only superficially resembles a percentage because it happens to fall under 100.

`gg_variable` (survival probability, `[0,1]`) and `gg_partial` (mortality, a count) are therefore **different quantities, not one quantity on two scales.**

Dividing by 100 would produce a number that is neither a probability nor a mortality, while looking plausibly like the former. On pbc it would pass review; on a dataset with ~900 events the same "fix" would emit yhat > 1 and the corruption would be obvious.

The consistency the issue wants already exists — it just needs `surv.type = "surv"`.

## The real defect

`gg_partial()` **discarded rfsrc's `ylabel`**, so `plot.gg_partial()` drew every y-axis as a generic `"Partial Effect"` — whether it showed mortality, a survival probability, or a class probability. That is precisely how a mortality count gets mistaken for a probability and filed as a scale bug.

## This PR

Change no numbers; make the quantity self-identifying.

- `gg_partial()` records rfsrc's `ylabel` as `attr(x, "ylabel")`
- `plot.gg_partial()` uses it for the y-axis, falling back to `"Partial Effect"` when absent
- `@note` documents the `surv.type = "mort"` default and how to get probabilities comparable to `gg_variable()`
- **a regression test pins `yhat` as pass-through**, so the rescaling described in the issue cannot be introduced later

| | y-axis before | y-axis now | yhat |
|---|---|---|---|
| survival (`mort`) | `Partial Effect` | `mortality` | unchanged |
| survival (`surv`) | `Partial Effect` | `predicted survival (time=1191)` | unchanged |
| classification | `Partial Effect` | `probability setosa` | unchanged |
| regression | `Partial Effect` | ŷ (plotmath) | unchanged |

## Verification

- `identical(gg_partial(pv)$continuous$yhat, pv$plotthis$bili$yhat)` — **TRUE in every family**. Labelling only.
- `devtools::test()` — **1316 pass, 0 fail**
- `lintr::lint_package()` — **0 lints**
- `R CMD check --as-cran` — **0 errors, 0 warnings, 0 notes**

## Related: the two entry points default to different quantities

`gg_partial_rfsrc()` is **not** buggy (an earlier draft of this PR said otherwise; that was an accessor error on my part, since it returns a `{continuous, categorical}` structure). It is healthy: 69 rows, yhat in [0.338, 0.915].

But it exposed the real cross-function inconsistency:

| function | wraps | default | quantity |
|---|---|---|---|
| `gg_partial()` | `plot.variable` | `surv.type = "mort"` | **mortality** [32.502, 89.202] |
| `gg_partial_rfsrc()` | `partial.rfsrc` | `partial.type = "surv"` | **survival probability** [0.338, 0.915] |

`gg_partial()` structurally **cannot** align this: it receives `part_dta`, the already-computed result of the user's own `plot.variable()` call, so `surv.type` is fixed at the caller's site before `gg_partial()` sees anything. Labelling the quantity is the only available fix — which is what this PR does.

Notably `plot.gg_partial_rfsrc()` already carried a `partial.type` attribute and labelled its y-axis from it. This PR applies that same existing convention to the `plot.variable` path, which had never been given it. A cross-referencing `@note` on both functions documents the differing defaults.