### PR TITLE
docs(NEWS): record the gg_partial survival labeling fix (#15)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,16 @@ ggRandomForests v3.5.0
 * Added `gg_shap()` and `plot.gg_shap()` (with `shap_importance()`,
   `shap_beeswarm()`, `shap_dependence()`) for SHAP explanations of
   regression and classification forests, wrapping `kernelshap` (Suggests).
+* `gg_partial()` no longer lets survival partial dependence be mistaken for a
+  probability. `randomForestSRC::plot.variable()` defaults to
+  `surv.type = "mort"`, so `yhat` is *mortality* -- an expected event count,
+  not a value on [0, 1] -- and it only superficially resembles a percentage.
+  `yhat` is passed through unscaled (rescaling it would corrupt the quantity);
+  instead the label describing what was plotted is carried on the object as
+  `attr(x, "ylabel")` and used as the y-axis title by `plot.gg_partial()`.
+  Note that `gg_partial_rfsrc()` defaults to `partial.type = "surv"` and so
+  does report survival probabilities: the two entry points report different
+  quantities by default. (#15)
 
 ggRandomForests v3.4.1
 ======================


### PR DESCRIPTION
PR #150 merged without a `NEWS.md` entry, but the fix is user-visible: the y-axis of a survival partial plot now names the quantity actually plotted (mortality) instead of a generic "Partial Effect".

Adds a bullet to the **unreleased v3.5.0** section. No version bump — CRAN is at 3.4.0, `main`/DESCRIPTION/NEWS are all at 3.5.0 and there is no `v3.5.0` tag, so 3.5.0 is the in-development section still accumulating work. DESCRIPTION and NEWS stay in sync, and `test_ggrandomforests_news.R` passes.

The entry records the substance of the decision — that `yhat` is deliberately **not** rescaled, because mortality is an expected event count rather than a percentage — and flags that `gg_partial_rfsrc()` defaults to survival probabilities, so the two entry points report different quantities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)