### PR TITLE
fix(tests): load pbc into the helper's own environment, not .GlobalEnv

### DIFF
--- a/tests/testthat/helper-rhf-fixtures.R
+++ b/tests/testthat/helper-rhf-fixtures.R
@@ -12,7 +12,12 @@
     if (!requireNamespace("randomForestSRC", quietly = TRUE)) {
       testthat::skip("randomForestSRC not installed")
     }
-    data(pbc, package = "randomForestSRC")
+    # envir = environment() is required, not stylistic: data() defaults to
+    # .GlobalEnv, which is not on this function's lexical chain under
+    # devtools::test() (testthat roots the helper env in the attached search
+    # path), so a bare data(pbc) binds a pbc this function cannot see.
+    utils::data("pbc", package = "randomForestSRC", envir = environment())
+
     d <- randomForestRHF::convert.counting(
       survival::Surv(days, status) ~ ., stats::na.omit(pbc)
     )


### PR DESCRIPTION
Fixes the 10 pre-existing test failures on `dev_rhf` (surfaced while preparing the forward-merge in #153). One-line fix; the diagnosis is the interesting part.

## Root cause — a scoping bug, not a missing dataset

`utils::data()` defaults to `envir = .GlobalEnv`. Under `devtools::test()`, testthat roots the helper environment in the **attached search path**:

```
package:ggRandomForests -> package:testthat -> package:stats -> ... -> base -> R_EmptyEnv
```

`.GlobalEnv` is **not on that chain**. So `.rhf_pbc()` loaded `pbc` into an environment it structurally could not see, and the next line failed to find it.

Confirmed by instrumenting the helper:

```
pbc in globalenv AFTER data():  TRUE     <- it loaded fine
exists("pbc") from inside fn:   FALSE    <- but is unreachable from here
```

This explains both puzzles:
- **Why it passed under `testthat::test_file()`** but failed under a full `devtools::test()` — the former’s environment chain *does* reach the global env.
- **Why `test_gg_brier.R` makes the identical `data(pbc, ...)` call and passes** — it runs at *test-file* scope, not inside a helper function. `helper-rhf-fixtures.R` was the only helper calling `data()` from inside a function body, and so the only one affected.

## Fix

`envir = environment()` binds `pbc` in the function’s own frame, which is always visible. This is not a stylistic choice — it is load-bearing, hence the comment. It matches the idiom **already used** in `test_gg_partial_varpro.R:408` and `test_print_summary.R:91`.

## Verification

Full `devtools::test()` with `TESTTHAT_MAX_FAILS=1000` (so nothing hides behind the 10-failure cap):

| | Failures |
| --- | --- |
| `dev_rhf` before | **10** (5 `test_gg_rhf.R`, 5 `test_gg_auct.R`) |
| this branch | **0** |

No other `data()` call sites were touched — every other one is at test-file scope and works correctly today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)