### PR TITLE
fix(gg_shap): enforce the bg_n / which.class integer contract instead of coercing

### DIFF
--- a/R/gg_shap.R
+++ b/R/gg_shap.R
@@ -53,7 +53,8 @@ gg_shap <- function(object, newdata, bg_n = 50, which.class = 1, ...) {
 .gg_shap_validate_bg_n <- function(bg_n) {
   if (!is.numeric(bg_n) || length(bg_n) != 1L || !is.finite(bg_n) ||
         bg_n < 1 || bg_n != trunc(bg_n) || bg_n > .Machine$integer.max) {
-    stop("gg_shap: bg_n must be a single positive integer.", call. = FALSE)
+    stop("gg_shap: bg_n must be a single positive integer between 1 and ",
+         .Machine$integer.max, ".", call. = FALSE)
   }
   as.integer(bg_n)
 }

--- a/R/gg_shap.R
+++ b/R/gg_shap.R
@@ -47,11 +47,32 @@ gg_shap <- function(object, newdata, bg_n = 50, which.class = 1, ...) {
 }
 
 # Internal: validate and coerce bg_n to a single positive integer. Not exported.
+# The whole-number and integer-range checks matter: as.integer() would turn 1.9
+# into 1, and Inf or 1e10 into NA, silently sampling the wrong number of
+# background rows instead of reporting the bad input.
 .gg_shap_validate_bg_n <- function(bg_n) {
-  if (!is.numeric(bg_n) || length(bg_n) != 1L || is.na(bg_n) || bg_n < 1) {
+  if (!is.numeric(bg_n) || length(bg_n) != 1L || !is.finite(bg_n) ||
+        bg_n < 1 || bg_n != trunc(bg_n) || bg_n > .Machine$integer.max) {
     stop("gg_shap: bg_n must be a single positive integer.", call. = FALSE)
   }
   as.integer(bg_n)
+}
+
+# Internal: validate which.class as a single in-range class index. Not exported.
+# A bare range check lets 2.9 through, and matrix indexing then truncates it to
+# column 2 -- silently returning SHAP values for a class the caller did not ask
+# for. NA/NaN would instead fail the range test itself with R's opaque
+# "missing value where TRUE/FALSE needed".
+.gg_shap_validate_which_class <- function(which.class, n_class) {
+  if (!is.numeric(which.class) || length(which.class) != 1L ||
+        !is.finite(which.class) || which.class != trunc(which.class)) {
+    stop("gg_shap: which.class must be a single integer.", call. = FALSE)
+  }
+  if (which.class < 1 || which.class > n_class) {
+    stop("gg_shap: which.class (", which.class, ") is out of range. Valid ",
+         "values are 1 to ", n_class, ".", call. = FALSE)
+  }
+  as.integer(which.class)
 }
 
 #' @export
@@ -82,11 +103,8 @@ gg_shap.rfsrc <- function(object, newdata, bg_n = 50, which.class = 1, ...) {
 
   is_class <- object$family == "class"
   if (is_class) {
-    n_class <- ncol(object$predicted)
-    if (which.class < 1 || which.class > n_class) {
-      stop("gg_shap: which.class (", which.class, ") is out of range. Valid ",
-           "values are 1 to ", n_class, ".", call. = FALSE)
-    }
+    which.class <- .gg_shap_validate_which_class(which.class,
+                                                 ncol(object$predicted))
   }
   pred_fun <- function(object, newdata) {
     pr <- predict(object, newdata)$predicted
@@ -128,11 +146,8 @@ gg_shap.randomForest <- function(object, newdata, bg_n = 50,
 
   is_class <- object$type == "classification"
   if (is_class) {
-    n_class <- length(object$classes)
-    if (which.class < 1 || which.class > n_class) {
-      stop("gg_shap: which.class (", which.class, ") is out of range. Valid ",
-           "values are 1 to ", n_class, ".", call. = FALSE)
-    }
+    which.class <- .gg_shap_validate_which_class(which.class,
+                                                 length(object$classes))
   }
   pred_fun <- function(object, newdata) {
     if (is_class) {

--- a/R/gg_shap.R
+++ b/R/gg_shap.R
@@ -46,13 +46,18 @@ gg_shap <- function(object, newdata, bg_n = 50, which.class = 1, ...) {
   UseMethod("gg_shap", object)
 }
 
+# Internal: TRUE when x is one finite, whole number. Both gg_shap index-ish
+# arguments need exactly this test, so it lives in one place. Not exported.
+.gg_shap_is_count <- function(x) {
+  is.numeric(x) && length(x) == 1L && is.finite(x) && x == trunc(x)
+}
+
 # Internal: validate and coerce bg_n to a single positive integer. Not exported.
 # The whole-number and integer-range checks matter: as.integer() would turn 1.9
 # into 1, and Inf or 1e10 into NA, silently sampling the wrong number of
 # background rows instead of reporting the bad input.
 .gg_shap_validate_bg_n <- function(bg_n) {
-  if (!is.numeric(bg_n) || length(bg_n) != 1L || !is.finite(bg_n) ||
-        bg_n < 1 || bg_n != trunc(bg_n) || bg_n > .Machine$integer.max) {
+  if (!.gg_shap_is_count(bg_n) || bg_n < 1 || bg_n > .Machine$integer.max) {
     stop("gg_shap: bg_n must be a single positive integer between 1 and ",
          .Machine$integer.max, ".", call. = FALSE)
   }
@@ -65,8 +70,7 @@ gg_shap <- function(object, newdata, bg_n = 50, which.class = 1, ...) {
 # for. NA/NaN would instead fail the range test itself with R's opaque
 # "missing value where TRUE/FALSE needed".
 .gg_shap_validate_which_class <- function(which.class, n_class) {
-  if (!is.numeric(which.class) || length(which.class) != 1L ||
-        !is.finite(which.class) || which.class != trunc(which.class)) {
+  if (!.gg_shap_is_count(which.class)) {
     stop("gg_shap: which.class must be a single integer.", call. = FALSE)
   }
   if (which.class < 1 || which.class > n_class) {

--- a/tests/testthat/test_gg_shap.R
+++ b/tests/testthat/test_gg_shap.R
@@ -210,3 +210,37 @@ test_that("shap_beeswarm scales finite values even when a variable has Inf entri
 ## Visual regression tests for the three plot.gg_shap types are in
 ## test_snapshots.R (guarded by VDIFFR_RUN_TESTS=true), following the package
 ## convention.
+
+test_that("gg_shap rejects bg_n that is not a whole, finite, in-range number", {
+  skip_if_not_installed("kernelshap")
+  skip_on_cran()
+
+  rf <- randomForestSRC::rfsrc(Ozone ~ ., data = na.omit(airquality),
+                               ntree = 50)
+
+  # as.integer() would silently turn each of these into 1 or NA, so the
+  # "positive integer" contract has to be enforced, not coerced into.
+  expect_error(gg_shap(rf, bg_n = 1.9), "positive integer")
+  expect_error(gg_shap(rf, bg_n = Inf), "positive integer")
+  expect_error(gg_shap(rf, bg_n = 1e10), "positive integer")
+  expect_error(gg_shap(rf, bg_n = NA_real_), "positive integer")
+  expect_error(gg_shap(rf, bg_n = c(10, 20)), "positive integer")
+})
+
+test_that("gg_shap rejects which.class that is not a whole, finite number", {
+  skip_if_not_installed("kernelshap")
+  skip_on_cran()
+
+  rf <- randomForestSRC::rfsrc(Species ~ ., data = iris, ntree = 50)
+
+  # 2.9 passes a bare range check and then silently indexes column 2.
+  expect_error(gg_shap(rf, bg_n = 20, which.class = 2.9), "single integer")
+  expect_error(gg_shap(rf, bg_n = 20, which.class = NA_real_), "single integer")
+  expect_error(gg_shap(rf, bg_n = 20, which.class = Inf), "single integer")
+  # In-range check still applies.
+  expect_error(gg_shap(rf, bg_n = 20, which.class = 99), "out of range")
+
+  rf_rf <- randomForest::randomForest(Species ~ ., data = iris, ntree = 50)
+  expect_error(gg_shap(rf_rf, bg_n = 20, which.class = 2.9), "single integer")
+  expect_error(gg_shap(rf_rf, bg_n = 20, which.class = 99), "out of range")
+})

--- a/tests/testthat/test_gg_shap.R
+++ b/tests/testthat/test_gg_shap.R
@@ -213,10 +213,13 @@ test_that("shap_beeswarm scales finite values even when a variable has Inf entri
 
 test_that("gg_shap rejects bg_n that is not a whole, finite, in-range number", {
   skip_if_not_installed("kernelshap")
-  skip_on_cran()
-
+  # No skip_on_cran(): every expectation below errors during argument
+  # validation, before kernelshap::kernelshap() is ever reached, so the test
+  # costs one small forest fit. Skipping it would leave the integer contract
+  # unguarded in a default R CMD check. ntree is minimal for the same reason --
+  # the fit only has to produce a valid rfsrc object.
   rf <- randomForestSRC::rfsrc(Ozone ~ ., data = na.omit(airquality),
-                               ntree = 50)
+                               ntree = 10)
 
   # as.integer() would silently turn each of these into 1 or NA, so the
   # "positive integer" contract has to be enforced, not coerced into.
@@ -229,9 +232,9 @@ test_that("gg_shap rejects bg_n that is not a whole, finite, in-range number", {
 
 test_that("gg_shap rejects which.class that is not a whole, finite number", {
   skip_if_not_installed("kernelshap")
-  skip_on_cran()
 
-  rf <- randomForestSRC::rfsrc(Species ~ ., data = iris, ntree = 50)
+  # As above: validation-only, so no skip_on_cran() and a minimal ntree.
+  rf <- randomForestSRC::rfsrc(Species ~ ., data = iris, ntree = 10)
 
   # 2.9 passes a bare range check and then silently indexes column 2.
   expect_error(gg_shap(rf, bg_n = 20, which.class = 2.9), "single integer")
@@ -240,7 +243,7 @@ test_that("gg_shap rejects which.class that is not a whole, finite number", {
   # In-range check still applies.
   expect_error(gg_shap(rf, bg_n = 20, which.class = 99), "out of range")
 
-  rf_rf <- randomForest::randomForest(Species ~ ., data = iris, ntree = 50)
+  rf_rf <- randomForest::randomForest(Species ~ ., data = iris, ntree = 10)
   expect_error(gg_shap(rf_rf, bg_n = 20, which.class = 2.9), "single integer")
   expect_error(gg_shap(rf_rf, bg_n = 20, which.class = 99), "out of range")
 })


### PR DESCRIPTION
Fixes three input-validation defects Copilot flagged on #153. **The code is `main`’s** (added in #145) — #153 is a forward-merge that inherits `R/gg_shap.R` unchanged (`git diff main...merge-branch -- R/gg_shap.R` is empty), so the fix belongs here, not on the v4 line.

## The defects

Both arguments are documented as integers but were only loosely checked, so bad input was silently coerced rather than reported. Verified before fixing:

| Input | Was | Now |
| --- | --- | --- |
| `bg_n = 1.9` | truncated to `1` | error |
| `bg_n = Inf` | `as.integer()` → **`NA`** (+ coercion warning) | error |
| `bg_n = 1e10` | exceeds int range → **`NA`** | error |
| `which.class = 2.9` | passed the range check, then matrix indexing **truncated to column 2** — SHAP values for a class the caller never asked for | error |
| `which.class = NA` / `NaN` | opaque `missing value where TRUE/FALSE needed` | clear error |

The `which.class = 2.9` case is the one with teeth: it returns plausible-looking numbers for the wrong class, with no warning.

## The fix

Validate whole-number / finite / in-integer-range up front, and factor the duplicated `which.class` range check (`gg_shap.rfsrc` + `gg_shap.randomForest`) into one helper. **Valid input is unaffected** — every one of these is a garbage-input path.

## Verification

Tests written **first** and confirmed failing (7 failures + the `as.integer(Inf)` coercion warnings), then passing:

- `test_gg_shap.R`: 47/47 pass, coercion warnings gone.
- Full `devtools::test()` uncapped (`NOT_CRAN=true`, `TESTTHAT_MAX_FAILS=1000`): **zero** failures.

Note the new tests need `NOT_CRAN=true` to execute — `skip_on_cran()` otherwise skips them, which is how a plain `Rscript` run can look green while proving nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)