### PR TITLE
chore(release): v3.5.0 CRAN prep + shrink the vignette figures (4.7MB → 2.3MB)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: ggRandomForests
 Type: Package
 Title: Visually Exploring Random Forests
 Version: 3.5.0
-Date: 2026-07-12
+Date: 2026-07-16
 Authors@R: person("John", "Ehrlinger",
   role = c("aut", "cre"),
   email = "john.ehrlinger@gmail.com")

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,55 +1,60 @@
-## v3.4.0 — minor release (interpretable varPro partial scales; unsupervised varPro wrappers; factor partial-dependence fix)
+## v3.5.0 — minor release (SHAP explanations; default S3 methods; survival partial-dependence labelling)
 
 This is a minor feature-and-fix release. It consolidates the work developed
-since the CRAN 3.2.0 release (the 3.3.0 and 3.4.0 development cycles) into a
+since the CRAN 3.4.0 release (the 3.4.1 and 3.5.0 development cycles) into a
 single submission.
 
 ### What's new / fixed
 
-* **Interpretable varPro partial-plot scales.** `gg_partial_varpro()` now
-  defaults to bounded, interpretable y-axes: probability P(Y = target class)
-  for classification, and survival probability S(tau) for survival (via a
-  partialpro survival learner), with tau defaulting to the median follow-up
-  time when omitted. The unbounded ensemble-mortality scale remains available
-  via `scale = "mortality"`. The `causal` (virtual-twins) contrast is hidden on
-  the bounded scales and documented.
-* **Unsupervised varPro wrappers.** New `gg_beta_uvarpro()` (lasso-importance
-  ranking from `varPro::get.beta.entropy()`) and `gg_sdependent()`
-  (signal-variable detection from `varPro::sdependent()`), each with
-  `plot`/`print`/`summary`/`autoplot` methods, complementing the existing
-  `gg_udependent()` dependency graph. A new short "uvarpro" vignette walks the
-  three unsupervised views on a single `uvarpro()` fit.
-* **Bug fix: factor partial dependence in `gg_partial_rfsrc()`.** The wrapper
-  passed factor *labels* to `randomForestSRC::partial.rfsrc()`, which imposes a
-  level by its integer code; character labels became `NA` and numeric-looking
-  labels went out of range, collapsing every level to a single value (a flat
-  categorical partial plot). It now passes the integer codes and relabels the
-  output, matching `plot.variable(partial = TRUE)`. The categorical `x` is
-  returned as a factor in the model's level order.
-* Documentation: fixed the main vignette's `\VignetteIndexEntry` (it carried a
-  template placeholder); split the unsupervised varPro material out of the
-  varPro vignette into the new companion vignette.
+* **SHAP explanations.** New `gg_shap()` with `plot`/`autoplot`/`print`/
+  `summary` methods, plus `shap_importance()`, `shap_beeswarm()` and
+  `shap_dependence()`, giving SHAP explanations of regression and
+  classification forests by wrapping `kernelshap` (Suggests). `gg_shap()`
+  enforces the documented integer contract on `bg_n` and `which.class` rather
+  than silently coercing them: `bg_n = 1.9` was truncated to 1, `bg_n = Inf`
+  became `NA`, and `which.class = 2.9` passed the range check and then indexed
+  column 2 — returning SHAP values for a class the caller never asked for.
+  Non-whole, non-finite, out-of-range and non-scalar values now raise a clear
+  error; valid input is unaffected.
+* **Default S3 methods for the classic wrappers.** The remaining
+  `rfsrc`/`randomForest` wrappers — `gg_error()`, `gg_vimp()` and others —
+  gained `default` methods, so an unsupported object now produces an
+  informative error instead of dispatching somewhere unhelpful.
+* **Bug fix: survival partial dependence is no longer mistakable for a
+  probability.** `randomForestSRC::plot.variable()` defaults to
+  `surv.type = "mort"`, so `gg_partial()`'s `yhat` is *mortality* — an expected
+  event count, not a value on [0, 1] — and it only superficially resembles a
+  percentage. `yhat` is passed through unscaled (rescaling it would corrupt the
+  quantity); instead the label describing what was plotted is carried on the
+  object as `attr(x, "ylabel")` and used as the y-axis title by
+  `plot.gg_partial()`. Note that `gg_partial_rfsrc()` defaults to
+  `partial.type = "surv"` and so does report survival probabilities: the two
+  entry points report different quantities by default. (#15)
+* Documentation: the package help page (`?ggRandomForests`) now describes the
+  whole current surface — the SHAP, Brier, varPro and unsupervised-varPro
+  families were missing — and no longer claims that `plot()` methods may return
+  a *list* of `ggplot2` objects; each returns a single plottable object (a
+  `ggplot`, or a `patchwork` composite for the multi-panel methods).
 
 ### Test environments
 
 * **Local:** R 4.6.0 on macOS (aarch64-apple-darwin23).
   `R CMD check --as-cran` (with the manual) returns 0 errors, 0 warnings,
-  0 notes.
-* **win-builder:** R-devel (R 90199), R-release (4.6.1), and R-oldrelease
-  (4.5.3), Windows Server 2022, x86_64 — all Status: OK.
-* **macOS:** covered by the local aarch64-apple-darwin23 check above. The
-  mac.r-project.org macOS builder was unavailable at submission time
-  (HTTP 502), so no mac-builder result is included; the macOS platform is
-  also exercised by the macos-latest GitHub Actions job below.
-* **GitHub Actions matrix:** ubuntu-latest (R-devel / R-release /
-  R-oldrel-1), windows-latest (R-release), macos-latest (R-release).
+  0 notes; overall check time 3m31s.
 * **Reverse-dependency check:** 0 reverse dependencies on CRAN.
+* **URL check:** `urlchecker::url_check()` reports all URLs correct.
 
 ### NOTE disposition
 
-`R CMD check --as-cran` is clean (0/0/0) locally. The only note expected at
-incoming feasibility is the usual "days since last update" item (3.2.0 was
-published 2026-06-23).
+`R CMD check --as-cran` is clean (0/0/0) locally.
+
+The note expected at incoming feasibility is "Days since last update: 14"
+(3.4.0 was published 2026-07-02). The submission is deliberate rather than a
+correction to 3.4.0: it lands the SHAP family, a self-contained feature set
+developed and reviewed as a unit, together with the `gg_partial()` fix in #15,
+where the plotted quantity could be read as a probability when it is an
+expected event count. I am happy to hold this release and resubmit later if the
+cadence is unwelcome.
 
 The gcc-UBSAN guard from v3.1.1/v3.1.2 is unchanged: the single unsupervised
 `varPro::isopro(method = "unsupv")` test still calls `skip_on_cran()` to avoid


### PR DESCRIPTION
Prepares the 3.5.0 submission and fixes the tarball-size problem found while auditing it.

## 1. Submission paperwork

- **`cran-comments.md` rewritten for 3.5.0.** It was still the v3.4.0 text. `devtools::submit_cran()` sends this file verbatim in the submitter's comment field, so submitting as-is would have described the *previous* release, under the previous version number, to CRAN.
- **`DESCRIPTION` `Date:`** → 2026-07-16.

## 2. Vignette figures: 4.7 MB → 2.3 MB

The vignettes **never chose a graphics device**, so they fell through to the default `png()`, which writes **RGBA truecolor** — an alpha channel these opaque plots never use, over ~30,000 anti-aliased colours PNG can't compress. That's 3.5 MB of figures in `inst/doc` and a 4.7 MB tarball against CRAN's 5 MB ceiling. It's invisible in the source tree, because `inst/doc` only exists once `R CMD build` renders it.

New `vignettes/_fig_optim.R`, sourced from each vignette's setup chunk:

| Step | Saving |
|---|---|
| `ragg::agg_png` — writes RGB, drops the unused alpha channel | −20% |
| quantise to a 256-colour palette | −54% |

**Tarball 4.7 MB → 2.3 MB. `inst/doc` 5.3 MB → 1.9 MB**, which clears the installed-size INFO entirely.

### `colorspace = "sRGB"` is load-bearing

ImageMagick's `"RGB"` means **linear** RGB, so quantising in it — or relying on magick's default — silently undoes the sRGB gamma curve and shifts every pixel:

| | mean \|pixel diff\| (0–255) |
|---|---|
| `colorspace = "RGB"` (linear) or magick default | **24.46** — visibly darker, harsher curves |
| `colorspace = "sRGB"` | **1.55** — visually indistinguishable |

This was caught by sweeping the colour count: 256 and 65,536 colours produced *identical* error, and an error that ignores the knob you're turning is never the thing the knob controls. The figures with the most to lose are exactly the ones worth protecting — `gg_rfsrc()` and `gg_variable()` draw hundreds of alpha-blended curves whose opacity gradations *are* the density information.

### Fails safe

Both steps are build-time only and guarded by `requireNamespace()`. With `ragg` or `magick` absent, the figure is left exactly as rendered and the vignette still builds — at the old file size. Verified both paths: absent, `quantize_png()` returns the path and leaves the file **byte-identical**. CRAN rebuilds vignettes on machines whose ImageMagick we don't control, so a missing library must cost file size, never a failed check.

`ragg` and `magick` added to Suggests.

## Release gate (re-run on the optimized tarball)

| Gate item | Result |
|---|---|
| CRAN Cookbook audit | Clean |
| `R CMD check --as-cran` (**with** manual) | **Status: OK — 0/0/0**, PDF manual OK |
| Overall check time | **3m22s** (budget <10 min) |
| Installed package size | **OK** (was INFO at 6.2 MB) |
| Reverse dependencies | 0 |
| `urlchecker::url_check()` | All 16 URLs correct |
| NEWS ↔ DESCRIPTION sync | Both 3.5.0 |
| Figure fidelity | 66/66 figures, max quantization diff 1.55/255 |
| `lintr` on new file | No lints |

## Still outstanding

- **win-builder** — not run here; you're taking that.
- **Cadence** — 14 days since 3.4.0, 5th release in 5 weeks. `cran-comments.md` discloses the "Days since last update: 14" note up front and offers to hold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)