### PR TITLE
fix(varpro): warn when partialpro() drops variables you asked for

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,15 @@ ggRandomForests v3.5.0
   the reported ranking, `split.weight = FALSE` to widen the candidate set
   itself, and the two arguments (`nvar`, `sparse`) that look like they should
   help and don't.
+* `gg_partial_varpro()` now warns when a name passed in `xvar.names` is one the
+  `varpro` fit cannot reach, instead of letting it disappear. `partialpro()`
+  keeps only the names it finds in `object$xvar.names` and says nothing about
+  the rest, so a request for twelve variables could come back with ten. The
+  check runs before `partialpro()` does, so the warning arrives ahead of the
+  computation rather than after it; it names every dropped variable and points
+  at `split.weight = FALSE`. Supplying `part_dta` yourself is unchanged -- the
+  variables are already gone by then. The function's examples now cover the
+  object-driven path, which had none.
 * Added `gg_shap()` and `plot.gg_shap()` (with `shap_importance()`,
   `shap_beeswarm()`, `shap_dependence()`) for SHAP explanations of
   regression and classification forests, wrapping `kernelshap` (Suggests).

--- a/R/gg_partial_varpro.R
+++ b/R/gg_partial_varpro.R
@@ -132,7 +132,8 @@
 #' was dropped.  A quick \code{setdiff(my_names, object$xvar.names)} answers
 #' the same question before you spend the computation.
 #'
-#' To lift the ceiling, refit with \code{varpro(..., split.weight = FALSE)},
+#' To lift the ceiling, refit with
+#' \code{varPro::varpro(..., split.weight = FALSE)},
 #' which puts every predictor in \code{object$xvar.names}.  \code{nvar} and
 #' \code{sparse = FALSE} will not do it: \code{nvar} caps what gets reported,
 #' and \code{sparse} only deepens the topvars list.
@@ -317,8 +318,10 @@ gg_partial_varpro <- function(part_dta  = NULL,
   if (is.null(part_dta)) {
     ## Before the expensive call: partialpro() silently discards any requested
     ## name outside object$xvar.names, so flag it while we still know what was
-    ## asked for.
-    .warn_varpro_dropped_xvars(list(...)$xvar.names, object)
+    ## asked for.  [["..."]] rather than $: `$` partial-matches on a list, so a
+    ## dots argument merely *starting* with "xvar.names" would be picked up as
+    ## the variable request.
+    .warn_varpro_dropped_xvars(list(...)[["xvar.names"]], object)
     learner <- switch(scale,
       rmst = .rmst_learner(object, time),
       surv = .surv_learner(object, time),
@@ -460,7 +463,8 @@ gg_partial_varpro <- function(part_dta  = NULL,
     "fit's reachable set and are silently dropped by varPro::partialpro(): %s. ",
     "The fit reaches %d of %d predictors (object$xvar.names); varpro() screens ",
     "in two stages, so a variable can be in the data and still be unreachable. ",
-    "Refit with varpro(..., split.weight = FALSE) to reach every predictor."),
+    "Refit with varPro::varpro(..., split.weight = FALSE) to reach every ",
+    "predictor."),
     length(dropped), length(requested), paste(dropped, collapse = ", "),
     length(object$xvar.names), n_pred), call. = FALSE)
   invisible(NULL)

--- a/R/gg_partial_varpro.R
+++ b/R/gg_partial_varpro.R
@@ -101,12 +101,42 @@
 #'   object-driven path (when \code{part_dta} is \code{NULL}).  Use this to
 #'   control which variables are computed -- e.g. \code{xvar.names} or
 #'   \code{nvar} -- or to tune the isolation-forest UVT step (\code{cut},
-#'   \code{nsmp}, ...).  Without it, \code{partialpro} falls back to
+#'   \code{nsmp}).  Without it, \code{partialpro} falls back to
 #'   \code{varPro::get.topvars(object)}, which can return few or no variables
 #'   for some fits (yielding empty \code{continuous}/\code{categorical}
-#'   frames).  Ignored, with a warning, when \code{part_dta} is supplied.
+#'   frames).  A name you pass in \code{xvar.names} that the fit cannot reach
+#'   is dropped by \code{partialpro} without comment, so you can ask for twelve
+#'   variables and get ten; we warn and name the missing ones.  See
+#'   \strong{Details}.  Ignored, with a warning, when \code{part_dta} is
+#'   supplied.
 #'
 #' @details
+#' **Which variables you actually get:** \code{varpro} screens twice before
+#' anything reaches partial dependence.  The split-weight screen decides which
+#' predictors are worth guiding the trees with, and what survives it lands in
+#' \code{object$xvar.names}; \code{varPro::get.topvars} then ranks a shorter
+#' list out of that.  So the design matrix, the reachable set, and the default
+#' list are three different sizes -- a fit on 45 predictors might carry 26 in
+#' \code{object$xvar.names} and 15 in \code{get.topvars}.  \code{partialpro}
+#' can only reach the middle one.  How much gets screened off depends on the
+#' data and the fit, so check rather than assume: \code{length(object$xvar.names)}
+#' against \code{ncol(object$x)} tells you where you stand.
+#'
+#' This bites when you bring a variable list in from somewhere else, say the
+#' top names off an \code{rfsrc} VIMP ranking.  \code{partialpro} intersects
+#' your \code{xvar.names} with what it can reach and keeps the overlap without
+#' remarking on it, so a request for twelve variables can come back with ten
+#' and nothing in the result says so.  It is the intermittent kind of trap: a
+#' top-10 list may come back whole while a top-12 list quietly loses two.  We
+#' compare the two sets before calling \code{partialpro} and warn, naming what
+#' was dropped.  A quick \code{setdiff(my_names, object$xvar.names)} answers
+#' the same question before you spend the computation.
+#'
+#' To lift the ceiling, refit with \code{varpro(..., split.weight = FALSE)},
+#' which puts every predictor in \code{object$xvar.names}.  \code{nvar} and
+#' \code{sparse = FALSE} will not do it: \code{nvar} caps what gets reported,
+#' and \code{sparse} only deepens the topvars list.
+#'
 #' **Scale detection:** with \code{scale = "auto"} and an \code{object} in
 #' hand, the scale resolves to \code{"mortality"} for a survival forest and
 #' \code{"generic"} for a regression or classification forest.  The RMST
@@ -210,6 +240,34 @@
 #' head(result$continuous)
 #' head(result$categorical)
 #'
+#' \donttest{
+#' ## The object-driven path: hand gg_partial_varpro() the varpro fit and let
+#' ## it call partialpro() for you.  This is where the reachability ceiling
+#' ## shows up (see Details).
+#' set.seed(42)
+#' vp <- varPro::varpro(mpg ~ ., data = mtcars, ntree = 50)
+#'
+#' ## Three different sizes.  partialpro() can only reach the second.
+#' ncol(vp$x)                    # predictors in the data
+#' length(vp$xvar.names)         # what the fit reaches
+#' length(varPro::get.topvars(vp))   # the default when xvar.names is absent
+#'
+#' ## Say these came from an rfsrc VIMP ranking.  Check what the fit cannot
+#' ## reach before you spend the computation -- this is the habit worth having.
+#' wanted <- c("wt", "hp", "qsec", "vs")
+#' setdiff(wanted, vp$xvar.names)
+#'
+#' ## Ask anyway and we warn, naming what partialpro() would have dropped
+#' ## in silence.
+#' pd <- gg_partial_varpro(object = vp, xvar.names = wanted)
+#'
+#' ## Refitting without the split-weight screen reaches every predictor.
+#' vp_all <- varPro::varpro(mpg ~ ., data = mtcars, ntree = 50,
+#'                          split.weight = FALSE)
+#' length(vp_all$xvar.names)
+#' setdiff(wanted, vp_all$xvar.names)   # empty; nothing to drop
+#' }
+#'
 #' @importFrom varPro partialpro
 #' @export
 gg_partial_varpro <- function(part_dta  = NULL,
@@ -257,6 +315,10 @@ gg_partial_varpro <- function(part_dta  = NULL,
   ## object-driven path can select/limit variables the same way an explicit
   ## partialpro() call would -- otherwise it falls back to get.topvars(object).
   if (is.null(part_dta)) {
+    ## Before the expensive call: partialpro() silently discards any requested
+    ## name outside object$xvar.names, so flag it while we still know what was
+    ## asked for.
+    .warn_varpro_dropped_xvars(list(...)$xvar.names, object)
     learner <- switch(scale,
       rmst = .rmst_learner(object, time),
       surv = .surv_learner(object, time),
@@ -367,6 +429,40 @@ gg_partial_varpro <- function(part_dta  = NULL,
               "' (resolved to '", resolved, "').", call. = FALSE)
     }
   }
+  invisible(NULL)
+}
+
+## varPro::partialpro() selects variables with
+## object$xvar.names[na.omit(match(xvar.names, object$xvar.names))], so a
+## requested name outside the fit's reachable set is discarded with no error,
+## no warning, and nothing recorded on the return value -- asking for 12
+## variables can quietly return 10. varpro() screens in two stages, so
+## object$xvar.names is a strict subset of the design matrix, and an
+## externally-derived variable set (rfsrc VIMP names, say) can easily sit
+## outside it. Compare before calling partialpro(), so the warning arrives
+## ahead of the isolation-forest work rather than after it.
+##
+## Only meaningful when xvar.names was supplied: partialpro() applies its nvar
+## cap solely in the missing(xvar.names) branch, so a supplied vector is
+## filtered by reachability alone, and the get.topvars() fallback is documented
+## behaviour rather than a silent drop.
+#' @keywords internal
+.warn_varpro_dropped_xvars <- function(requested, object) {
+  if (is.null(requested) || is.null(object) || is.null(object$xvar.names))
+    return(invisible(NULL))
+  dropped <- setdiff(as.character(requested), object$xvar.names)
+  if (length(dropped) == 0L) return(invisible(NULL))
+  ## NA rather than a hard failure if 'x' is absent: a guard that errors is a
+  ## worse failure mode than the one it reports.
+  n_pred <- if (is.null(object$x)) NA_integer_ else ncol(object$x)
+  warning(sprintf(paste0(
+    "gg_partial_varpro: %d of %d requested 'xvar.names' are not in the varpro ",
+    "fit's reachable set and are silently dropped by varPro::partialpro(): %s. ",
+    "The fit reaches %d of %d predictors (object$xvar.names); varpro() screens ",
+    "in two stages, so a variable can be in the data and still be unreachable. ",
+    "Refit with varpro(..., split.weight = FALSE) to reach every predictor."),
+    length(dropped), length(requested), paste(dropped, collapse = ", "),
+    length(object$xvar.names), n_pred), call. = FALSE)
   invisible(NULL)
 }
 

--- a/man/gg_partial_varpro.Rd
+++ b/man/gg_partial_varpro.Rd
@@ -129,7 +129,8 @@ compare the two sets before calling \code{partialpro} and warn, naming what
 was dropped.  A quick \code{setdiff(my_names, object$xvar.names)} answers
 the same question before you spend the computation.
 
-To lift the ceiling, refit with \code{varpro(..., split.weight = FALSE)},
+To lift the ceiling, refit with
+\code{varPro::varpro(..., split.weight = FALSE)},
 which puts every predictor in \code{object$xvar.names}.  \code{nvar} and
 \code{sparse = FALSE} will not do it: \code{nvar} caps what gets reported,
 and \code{sparse} only deepens the topvars list.

--- a/man/gg_partial_varpro.Rd
+++ b/man/gg_partial_varpro.Rd
@@ -71,10 +71,14 @@ combining results from several models in one figure.}
 object-driven path (when \code{part_dta} is \code{NULL}).  Use this to
 control which variables are computed -- e.g. \code{xvar.names} or
 \code{nvar} -- or to tune the isolation-forest UVT step (\code{cut},
-\code{nsmp}, ...).  Without it, \code{partialpro} falls back to
+\code{nsmp}).  Without it, \code{partialpro} falls back to
 \code{varPro::get.topvars(object)}, which can return few or no variables
 for some fits (yielding empty \code{continuous}/\code{categorical}
-frames).  Ignored, with a warning, when \code{part_dta} is supplied.}
+frames).  A name you pass in \code{xvar.names} that the fit cannot reach
+is dropped by \code{partialpro} without comment, so you can ask for twelve
+variables and get ten; we warn and name the missing ones.  See
+\strong{Details}.  Ignored, with a warning, when \code{part_dta} is
+supplied.}
 }
 \value{
 A named list of class \code{"gg_partial_varpro"} with elements:
@@ -104,6 +108,32 @@ be removed in the release after \pkg{ggRandomForests} v3.0.0; use
 \code{\link{gg_partial_varpro}()} directly.
 }
 \details{
+\strong{Which variables you actually get:} \code{varpro} screens twice before
+anything reaches partial dependence.  The split-weight screen decides which
+predictors are worth guiding the trees with, and what survives it lands in
+\code{object$xvar.names}; \code{varPro::get.topvars} then ranks a shorter
+list out of that.  So the design matrix, the reachable set, and the default
+list are three different sizes -- a fit on 45 predictors might carry 26 in
+\code{object$xvar.names} and 15 in \code{get.topvars}.  \code{partialpro}
+can only reach the middle one.  How much gets screened off depends on the
+data and the fit, so check rather than assume: \code{length(object$xvar.names)}
+against \code{ncol(object$x)} tells you where you stand.
+
+This bites when you bring a variable list in from somewhere else, say the
+top names off an \code{rfsrc} VIMP ranking.  \code{partialpro} intersects
+your \code{xvar.names} with what it can reach and keeps the overlap without
+remarking on it, so a request for twelve variables can come back with ten
+and nothing in the result says so.  It is the intermittent kind of trap: a
+top-10 list may come back whole while a top-12 list quietly loses two.  We
+compare the two sets before calling \code{partialpro} and warn, naming what
+was dropped.  A quick \code{setdiff(my_names, object$xvar.names)} answers
+the same question before you spend the computation.
+
+To lift the ceiling, refit with \code{varpro(..., split.weight = FALSE)},
+which puts every predictor in \code{object$xvar.names}.  \code{nvar} and
+\code{sparse = FALSE} will not do it: \code{nvar} caps what gets reported,
+and \code{sparse} only deepens the topvars list.
+
 \strong{Scale detection:} with \code{scale = "auto"} and an \code{object} in
 hand, the scale resolves to \code{"mortality"} for a survival forest and
 \code{"generic"} for a regression or classification forest.  The RMST
@@ -247,6 +277,34 @@ mock_data <- list(
 result <- gg_partial_varpro(mock_data)
 head(result$continuous)
 head(result$categorical)
+
+\donttest{
+## The object-driven path: hand gg_partial_varpro() the varpro fit and let
+## it call partialpro() for you.  This is where the reachability ceiling
+## shows up (see Details).
+set.seed(42)
+vp <- varPro::varpro(mpg ~ ., data = mtcars, ntree = 50)
+
+## Three different sizes.  partialpro() can only reach the second.
+ncol(vp$x)                    # predictors in the data
+length(vp$xvar.names)         # what the fit reaches
+length(varPro::get.topvars(vp))   # the default when xvar.names is absent
+
+## Say these came from an rfsrc VIMP ranking.  Check what the fit cannot
+## reach before you spend the computation -- this is the habit worth having.
+wanted <- c("wt", "hp", "qsec", "vs")
+setdiff(wanted, vp$xvar.names)
+
+## Ask anyway and we warn, naming what partialpro() would have dropped
+## in silence.
+pd <- gg_partial_varpro(object = vp, xvar.names = wanted)
+
+## Refitting without the split-weight screen reaches every predictor.
+vp_all <- varPro::varpro(mpg ~ ., data = mtcars, ntree = 50,
+                         split.weight = FALSE)
+length(vp_all$xvar.names)
+setdiff(wanted, vp_all$xvar.names)   # empty; nothing to drop
+}
 
 }
 \references{

--- a/tests/testthat/test_gg_partial_varpro.R
+++ b/tests/testthat/test_gg_partial_varpro.R
@@ -593,3 +593,92 @@ test_that("gg_partial_varpro: C-path 'model' label is attached to the frames", {
   if (is.data.frame(result$continuous) && nrow(result$continuous) > 0)
     expect_equal(unique(result$continuous$model), "forestC")
 })
+
+## ── dropped xvar.names guard ─────────────────────────────────────────────────
+## varPro::partialpro() filters requested variables through
+## na.omit(match(xvar.names, object$xvar.names)), so any name outside the fit's
+## reachable set is discarded with no error, warning, or record on the return
+## value. These cover the guard that makes that loss loud.
+
+make_fake_varpro_fit <- function(reachable = c("wt", "hp", "drat"),
+                                 p = 10) {
+  structure(
+    list(xvar.names = reachable,
+         x = matrix(0, nrow = 2, ncol = p)),
+    class = "varpro"
+  )
+}
+
+test_that(".warn_varpro_dropped_xvars: warns and names unreachable variables", {
+  fake <- make_fake_varpro_fit()
+  expect_warning(
+    ggRandomForests:::.warn_varpro_dropped_xvars(
+      c("wt", "hp", "qsec", "vs"), fake),
+    regexp = "qsec"
+  )
+  # the warning names every dropped variable, not just the first
+  expect_warning(
+    ggRandomForests:::.warn_varpro_dropped_xvars(
+      c("wt", "hp", "qsec", "vs"), fake),
+    regexp = "vs"
+  )
+  # and reports the reachability ceiling (3 of 10 here)
+  expect_warning(
+    ggRandomForests:::.warn_varpro_dropped_xvars(
+      c("wt", "hp", "qsec", "vs"), fake),
+    regexp = "3 of 10|split\\.weight"
+  )
+})
+
+test_that(".warn_varpro_dropped_xvars: silent when every request is reachable", {
+  fake <- make_fake_varpro_fit()
+  expect_no_warning(
+    ggRandomForests:::.warn_varpro_dropped_xvars(c("wt", "hp"), fake)
+  )
+  expect_no_warning(
+    ggRandomForests:::.warn_varpro_dropped_xvars(c("wt", "hp", "drat"), fake)
+  )
+})
+
+test_that(".warn_varpro_dropped_xvars: silent when xvar.names is not supplied", {
+  # No xvar.names => partialpro falls back to get.topvars(), which is
+  # documented, expected behaviour rather than a silent drop.
+  expect_no_warning(
+    ggRandomForests:::.warn_varpro_dropped_xvars(NULL, make_fake_varpro_fit())
+  )
+})
+
+test_that(".warn_varpro_dropped_xvars: silent when object is unusable", {
+  expect_no_warning(
+    ggRandomForests:::.warn_varpro_dropped_xvars(c("wt", "qsec"), NULL)
+  )
+  # a fit with no xvar.names gives nothing to compare against
+  expect_no_warning(
+    ggRandomForests:::.warn_varpro_dropped_xvars(
+      c("wt", "qsec"), structure(list(x = matrix(0, 2, 3)), class = "varpro"))
+  )
+})
+
+test_that("gg_partial_varpro: object path warns on unreachable xvar.names", {
+  skip_if_not_installed("varPro")
+  skip_if_not_installed("randomForestSRC")
+  # A real fit, because the ceiling is what's being tested: varpro() screening
+  # on mtcars reaches 6 of 10 predictors, so qsec/vs are genuinely unreachable
+  # rather than made up. Cheap (~0.3 s).
+  set.seed(42)
+  vp <- varPro::varpro(mpg ~ ., data = mtcars, ntree = 50)
+  skip_if_not(length(vp$xvar.names) < ncol(vp$x),
+              "varpro screening retained every predictor; no ceiling to test")
+
+  unreachable <- setdiff(colnames(vp$x), vp$xvar.names)
+  reachable   <- vp$xvar.names[1:2]
+  expect_warning(
+    gg_partial_varpro(object = vp,
+                      xvar.names = c(reachable, unreachable[1])),
+    regexp = unreachable[1]
+  )
+  # asking only for reachable variables stays quiet
+  expect_no_warning(
+    gg_partial_varpro(object = vp, xvar.names = reachable)
+  )
+})

--- a/tests/testthat/test_gg_partial_varpro.R
+++ b/tests/testthat/test_gg_partial_varpro.R
@@ -667,11 +667,21 @@ test_that("gg_partial_varpro: object path warns on unreachable xvar.names", {
   # rather than made up. Cheap (~0.3 s).
   set.seed(42)
   vp <- varPro::varpro(mpg ~ ., data = mtcars, ntree = 50)
-  skip_if_not(length(vp$xvar.names) < ncol(vp$x),
-              "varpro screening retained every predictor; no ceiling to test")
 
   unreachable <- setdiff(colnames(vp$x), vp$xvar.names)
-  reachable   <- vp$xvar.names[1:2]
+  reachable   <- vp$xvar.names
+
+  # Assert the fixture, do not assume it. The split-weight screen is stochastic
+  # and colnames(vp$x) is not guaranteed, so both sets could come back empty on
+  # a different varPro/rfsrc. An NA reaching `regexp` below would be silent and
+  # inverting -- expect_warning(regexp = NA) asserts NO warning, so the test
+  # would pass while checking the opposite of what it claims.
+  skip_if_not(length(unreachable) >= 1L && !anyNA(unreachable),
+              "no unreachable variable on this fit; nothing to drop")
+  skip_if_not(length(reachable) >= 2L && !anyNA(reachable),
+              "need >= 2 reachable variables")
+  reachable <- reachable[1:2]
+
   expect_warning(
     gg_partial_varpro(object = vp,
                       xvar.names = c(reachable, unreachable[1])),


### PR DESCRIPTION
## What

`varPro::partialpro()` selects variables with

```r
variables <- object$xvar.names[as.numeric(na.omit(match(xvar.names,
    object$xvar.names)))]
```

The `na.omit()` on `match()` discards any requested name that isn't in the fit's reachable set — no error, no warning, nothing on the returned object. **Ask for twelve variables and ten come back, indistinguishable from having asked for ten.**

`varpro()` screens in two stages, so `object$xvar.names` is a strict subset of the design matrix. A variable list brought in from elsewhere — the top of an `rfsrc` VIMP ranking, say — has no reason to respect it. The failure presents as intermittent: a top-10 list may come back whole while a top-12 list quietly loses two.

Verified on stock `mtcars` (`set.seed(42)`, `ntree = 50`): the fit reaches 6 of 10 predictors, and asking for `c("wt","hp","qsec","vs")` returns only `wt` and `hp`.

## Why here

`gg_partial_varpro()` already calls `partialpro()` itself on the object-driven path, and its roxygen already advertises `xvar.names` as a `...` pass-through. **The lossy call is one this package makes and documents**, so the guard needs no change to our division of labour with varPro — it sits inside a path we already own.

`.warn_varpro_dropped_xvars()` compares the requested names against `object$xvar.names` and warns, naming what would be dropped and pointing at `split.weight = FALSE`. It runs *before* `partialpro()` does, so the warning arrives ahead of the isolation-forest work rather than after it.

This is the third `.warn_varpro_*` guard in this file, after `.warn_varpro_rmst()` for the silently-dropped RMST horizon. Same failure class, same doctrine.

## Scope

Object-driven path only. A caller-supplied `part_dta` has already lost the variables before we see it, and the existing "`...` is ignored" warning is the honest answer there. Provenance unchanged.

## Examples

The examples now cover the object-driven path, **which had none** — they only built a mock `part_dta`, the one path that structurally cannot hit this bug.

## Docs

`@param ...` and a new `@details` section. Note the reachability numbers are **seed-dependent** (the split-weight screen is stochastic — `set.seed(42)`+`ntree=50` gives 6 of 10, the default call gives 9 of 10), so the docs give the mechanism and tell you to check `length(object$xvar.names)` against `ncol(object$x)` rather than quoting a number that doesn't generalise.

The varpro vignette already documents the ceiling itself (#161) and is untouched here. It tells readers to run `setdiff(my_vars, names(pd))` by hand; this guard does that for them.

## Verification

- `R CMD check --as-cran` **with the manual build**: **Status: OK (0/0/0)**, 3:19 total, tarball 2.3M
- Full test suite: **1302 passing, 0 failures**
- Examples incl. `--run-donttest`: OK (35s)
- lintr clean

Version stays **3.5.0** — unreleased (no `v3.5.0` tag, `CRAN-SUBMISSION` records 3.4.0), so this rides along inside it. `NEWS.md` gains a bullet under the existing heading; `DESCRIPTION` untouched.

## Known, not fixed

- **The `na.omit` is upstream's.** This warns; it does not repair. Every other `partialpro()` caller is still exposed. Reported to the maintainers by email on 2026-07-16.
- **The `chf` C-path ignores `xvar.names` outright** (asked for 1, got 14) — ours, not varPro's, and the inverse of this bug. Follow-up PR stacked on this branch. Note this PR makes `chf` the only scale that *doesn't* warn.

---

*Rebased onto `main` after #161 merged. An earlier revision of this PR carried a duplicate of `0983daec` ("qualify the varPro API names") and claimed it was stranded — that was wrong; #161 landed it while this branch was in flight. The rebase dropped it, and this PR is now a single commit.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)