### PR TITLE
fix(varpro): honour xvar.names on the chf path instead of ignoring it

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -29,6 +29,16 @@ ggRandomForests v3.5.0
   at `split.weight = FALSE`. Supplying `part_dta` yourself is unchanged -- the
   variables are already gone by then. The function's examples now cover the
   object-driven path, which had none.
+* `gg_partial_varpro(scale = "chf")` now computes the variables you name in
+  `xvar.names` instead of every variable the fit can reach. The `chf` path
+  routes through `gg_partial_rfsrc()` rather than `partialpro()`, and it had
+  never been given the variable list -- so asking for one variable quietly did
+  the work for all fourteen. This is the mirror image of the `partialpro()` bug
+  above: that one returns fewer variables than you asked for, this one returned
+  all of them. Naming a variable the forest does not carry has always been an
+  error and still is. The `partialpro`-only arguments (`cut`, `nsmp`) mean
+  nothing on this path and are now ignored with a warning rather than in
+  silence.
 * Added `gg_shap()` and `plot.gg_shap()` (with `shap_importance()`,
   `shap_beeswarm()`, `shap_dependence()`) for SHAP explanations of
   regression and classification forests, wrapping `kernelshap` (Suggests).

--- a/R/gg_partial_varpro.R
+++ b/R/gg_partial_varpro.R
@@ -108,7 +108,10 @@
 #'   is dropped by \code{partialpro} without comment, so you can ask for twelve
 #'   variables and get ten; we warn and name the missing ones.  See
 #'   \strong{Details}.  Ignored, with a warning, when \code{part_dta} is
-#'   supplied.
+#'   supplied.  With \code{scale = "chf"} the work goes through
+#'   \code{\link{gg_partial_rfsrc}} rather than \code{partialpro}, so
+#'   \code{xvar.names} is honoured but the \code{partialpro}-only arguments
+#'   (\code{cut}, \code{nsmp}) do not apply and are ignored with a warning.
 #'
 #' @details
 #' **Which variables you actually get:** \code{varpro} screens twice before
@@ -297,8 +300,13 @@ gg_partial_varpro <- function(part_dta  = NULL,
 
   ## ---- C-path: route CHF through gg_partial_rfsrc ------------------------
   ## (surv now uses the partialpro S(t) learner on path A, below.)
+  ## 'xvar.names' is honoured here as it is on path A; the rest of '...' is
+  ## partialpro's own vocabulary and means nothing to gg_partial_rfsrc(), which
+  ## has no '...' to absorb it.
   if (!is.null(object) && scale == "chf") {
-    return(.gg_partial_varpro_cpath(object, scale, time, model))
+    .warn_varpro_cpath_dots(list(...))
+    return(.gg_partial_varpro_cpath(object, scale, time, model,
+                                    xvar.names = list(...)$xvar.names))
   }
 
   ## ---- Survival default horizon: surv/rmst fill tau from the data --------
@@ -700,8 +708,27 @@ gg_partial_varpro <- function(part_dta  = NULL,
   plt.df
 }
 
+## The C-path reaches gg_partial_rfsrc(), whose signature is fixed -- it takes
+## no '...'. So only the arguments it actually understands can be forwarded;
+## anything else in '...' is partialpro vocabulary (cut, nsmp, ...) that would
+## error as an unused argument. Warn rather than error: these were silently
+## accepted before, and a hard failure on a previously-working call is a worse
+## trade than a warning.
 #' @keywords internal
-.gg_partial_varpro_cpath <- function(object, scale, time, model) {
+.warn_varpro_cpath_dots <- function(dots) {
+  extra <- setdiff(names(dots), "xvar.names")
+  extra <- extra[nzchar(extra)]
+  if (length(extra) == 0L) return(invisible(NULL))
+  warning("gg_partial_varpro: scale = 'chf' computes partial dependence from ",
+          "the rfsrc forest rather than varPro::partialpro(), so these ",
+          "arguments do not apply and are ignored: ",
+          paste(extra, collapse = ", "), ".", call. = FALSE)
+  invisible(NULL)
+}
+
+#' @keywords internal
+.gg_partial_varpro_cpath <- function(object, scale, time, model,
+                                     xvar.names = NULL) {
   rf           <- object$rf
   partial_type <- if (scale == "surv") "surv" else "chf"
 
@@ -711,8 +738,13 @@ gg_partial_varpro <- function(part_dta  = NULL,
     partial_time <- ti[which.min(abs(ti - time))]
   }
 
+  ## Default to every reachable variable, as before; honour a requested subset
+  ## when one is given. gg_partial_rfsrc() errors on a name the forest does not
+  ## carry, so a bad request fails loudly here rather than being dropped.
+  if (is.null(xvar.names)) xvar.names <- object$xvar.names
+
   pd <- gg_partial_rfsrc(rf,
-                          xvar.names   = object$xvar.names,
+                          xvar.names   = xvar.names,
                           partial.time = partial_time,
                           partial.type = partial_type)
 

--- a/R/gg_partial_varpro.R
+++ b/R/gg_partial_varpro.R
@@ -304,9 +304,13 @@ gg_partial_varpro <- function(part_dta  = NULL,
   ## partialpro's own vocabulary and means nothing to gg_partial_rfsrc(), which
   ## has no '...' to absorb it.
   if (!is.null(object) && scale == "chf") {
-    .warn_varpro_cpath_dots(list(...))
+    ## Capture dots once. [["..."]] rather than $: `$` partial-matches on a
+    ## list, so a dots argument merely starting with "xvar.names" would be
+    ## taken as the variable request.
+    dots <- list(...)
+    .warn_varpro_cpath_dots(dots)
     return(.gg_partial_varpro_cpath(object, scale, time, model,
-                                    xvar.names = list(...)$xvar.names))
+                                    xvar.names = dots[["xvar.names"]]))
   }
 
   ## ---- Survival default horizon: surv/rmst fill tau from the data --------
@@ -716,13 +720,22 @@ gg_partial_varpro <- function(part_dta  = NULL,
 ## trade than a warning.
 #' @keywords internal
 .warn_varpro_cpath_dots <- function(dots) {
-  extra <- setdiff(names(dots), "xvar.names")
-  extra <- extra[nzchar(extra)]
-  if (length(extra) == 0L) return(invisible(NULL))
+  nm <- names(dots)
+  if (is.null(nm)) nm <- rep("", length(dots))
+  ## Count the unnamed ones rather than filtering them away: an unnamed
+  ## positional argument is still an argument we are ignoring, and a guard
+  ## against silent drops must not itself drop silently.
+  named   <- setdiff(nm[nzchar(nm)], "xvar.names")
+  unnamed <- sum(!nzchar(nm))
+  if (length(named) == 0L && unnamed == 0L) return(invisible(NULL))
+  what <- c(named,
+            if (unnamed > 0L)
+              sprintf("%d unnamed argument%s", unnamed,
+                      if (unnamed > 1L) "s" else ""))
   warning("gg_partial_varpro: scale = 'chf' computes partial dependence from ",
           "the rfsrc forest rather than varPro::partialpro(), so these ",
           "arguments do not apply and are ignored: ",
-          paste(extra, collapse = ", "), ".", call. = FALSE)
+          paste(what, collapse = ", "), ".", call. = FALSE)
   invisible(NULL)
 }
 

--- a/man/gg_partial_varpro.Rd
+++ b/man/gg_partial_varpro.Rd
@@ -78,7 +78,10 @@ frames).  A name you pass in \code{xvar.names} that the fit cannot reach
 is dropped by \code{partialpro} without comment, so you can ask for twelve
 variables and get ten; we warn and name the missing ones.  See
 \strong{Details}.  Ignored, with a warning, when \code{part_dta} is
-supplied.}
+supplied.  With \code{scale = "chf"} the work goes through
+\code{\link{gg_partial_rfsrc}} rather than \code{partialpro}, so
+\code{xvar.names} is honoured but the \code{partialpro}-only arguments
+(\code{cut}, \code{nsmp}) do not apply and are ignored with a warning.}
 }
 \value{
 A named list of class \code{"gg_partial_varpro"} with elements:

--- a/tests/testthat/test_gg_partial_varpro.R
+++ b/tests/testthat/test_gg_partial_varpro.R
@@ -692,3 +692,52 @@ test_that("gg_partial_varpro: object path warns on unreachable xvar.names", {
     gg_partial_varpro(object = vp, xvar.names = reachable)
   )
 })
+
+## ── chf C-path honours xvar.names ────────────────────────────────────────────
+## The C-path routes through gg_partial_rfsrc() rather than partialpro(). It
+## used to hardcode xvar.names = object$xvar.names and never see '...', so a
+## requested subset was ignored and every reachable variable was computed --
+## the inverse of the partialpro drop above.
+
+test_that("gg_partial_varpro: chf C-path honours a requested xvar.names", {
+  skip_on_cran()                      # varpro fit + rfsrc partial (~10 s)
+  skip_if_not_installed("varPro")
+  skip_if_not_installed("randomForestSRC")
+  set.seed(42)
+  pbc <- get(utils::data("pbc", package = "randomForestSRC",
+                         envir = environment()))
+  pbc <- pbc[stats::complete.cases(pbc), ]
+  vp  <- varPro::varpro(Surv(days, status) ~ ., pbc, ntree = 30)
+  skip_if_not(length(vp$xvar.names) > 2, "need >2 reachable variables")
+
+  want <- vp$xvar.names[1]
+  pd <- gg_partial_varpro(object = vp, scale = "chf", xvar.names = want)
+  got <- unique(c(pd$continuous$name, pd$categorical$name))
+  expect_setequal(got, want)
+
+  # default (no xvar.names) still computes the full reachable set
+  pd_all <- gg_partial_varpro(object = vp, scale = "chf")
+  got_all <- unique(c(pd_all$continuous$name, pd_all$categorical$name))
+  expect_gt(length(got_all), length(want))
+})
+
+test_that("gg_partial_varpro: chf C-path warns on partialpro-only dots", {
+  # 'cut' is a partialpro UVT knob; it means nothing on the rfsrc C-path, and
+  # gg_partial_rfsrc() has no '...' to absorb it. Warn rather than error.
+  fake <- structure(
+    list(family = "surv", xvar.names = c("age", "bili"),
+         x = matrix(0, 2, 2),
+         rf = structure(list(time.interest = c(1, 2)), class = "rfsrc")),
+    class = "varpro")
+  expect_warning(
+    ggRandomForests:::.warn_varpro_cpath_dots(list(cut = 0.5, nsmp = 10)),
+    regexp = "cut|ignored"
+  )
+  # xvar.names is honoured, not ignored -- it must not trigger the warning
+  expect_no_warning(
+    ggRandomForests:::.warn_varpro_cpath_dots(list(xvar.names = "age"))
+  )
+  expect_no_warning(
+    ggRandomForests:::.warn_varpro_cpath_dots(list())
+  )
+})

--- a/tests/testthat/test_gg_partial_varpro.R
+++ b/tests/testthat/test_gg_partial_varpro.R
@@ -741,3 +741,34 @@ test_that("gg_partial_varpro: chf C-path warns on partialpro-only dots", {
     ggRandomForests:::.warn_varpro_cpath_dots(list())
   )
 })
+
+test_that(".warn_varpro_cpath_dots: unnamed dots are reported, not swallowed", {
+  # An unnamed positional argument reaching the chf path is still an argument
+  # we ignore. A guard against silent drops must not silently drop.
+  expect_warning(
+    ggRandomForests:::.warn_varpro_cpath_dots(list(0.5)),
+    regexp = "unnamed"
+  )
+  # mixed named + unnamed: both are surfaced
+  expect_warning(
+    ggRandomForests:::.warn_varpro_cpath_dots(list(0.5, cut = 1)),
+    regexp = "cut"
+  )
+  expect_warning(
+    ggRandomForests:::.warn_varpro_cpath_dots(list(0.5, cut = 1)),
+    regexp = "unnamed"
+  )
+  # xvar.names alone is honoured on this path, so it is not "ignored"
+  expect_no_warning(
+    ggRandomForests:::.warn_varpro_cpath_dots(list(xvar.names = "age"))
+  )
+  expect_no_warning(ggRandomForests:::.warn_varpro_cpath_dots(list()))
+})
+
+test_that("gg_partial_varpro: chf xvar.names extraction is an exact match", {
+  # `$` partial-matches on a list, so a dots argument merely starting with
+  # "xvar.names" must not be taken as the variable request.
+  fake_dots <- list(xvar.names.bogus = "qsec")
+  expect_null(fake_dots[["xvar.names"]])
+  expect_identical(fake_dots$xvar.names, "qsec")   # documents why [[ is required
+})


### PR DESCRIPTION
**Stacked on #162.** Base is `fix/varpro-xvar-drop-guard`; retarget to `main` once that merges.

## What

```r
gg_partial_varpro(object = vp, scale = "chf", xvar.names = "age")
#> computes all 14 variables. No warning.
```

Asking for one variable did the work for fourteen — silently, with nothing in the result saying the request had been disregarded.

**This is the mirror image of #162.** That one returns *fewer* variables than you asked for (varPro's `na.omit` drop); this one returned *all* of them. And this one is ours — there's no upstream to blame.

## Cause

Three things lined up in `R/gg_partial_varpro.R`:

1. The C-path early-returns *before* `.warn_varpro_dropped_xvars()`, so `chf` was the one scale with no guard on `xvar.names` at all.
2. `.gg_partial_varpro_cpath()` never took `...` — it hardcoded `xvar.names = object$xvar.names`.
3. The top-of-function "`...` is ignored" warning only fires when `part_dta` is supplied, so `object` + `chf` + `xvar.names` was silent.

## Why not just forward `...`

That was the obvious fix and it's wrong. `gg_partial_rfsrc()` has a **fixed signature with no `...`**, so a `partialpro`-only argument like `cut` would go from silently ignored to a hard `unused argument (cut = 0.5)` error — breaking a call that works today.

So only `xvar.names` crosses over. `.warn_varpro_cpath_dots()` handles the rest, explaining *why* they don't apply (this path uses the rfsrc forest, not `partialpro`) rather than just announcing they're ignored.

## Behaviour

| call | before | after |
|---|---|---|
| `scale="chf", xvar.names="age"` | 14 vars, silent | **1 var** |
| `scale="chf"` (no `xvar.names`) | 14 vars | 14 vars (unchanged) |
| `scale="chf", cut=0.5` | silently ignored | **warns**, explains why |
| `scale="chf", xvar.names="nonesuch"` | error | error (unchanged) |

Bad names have always errored inside `gg_partial_rfsrc()` and still do — that path was already loud, and I left it alone.

Verified on a pbc survival fit (14 reachable).

## Verification

- `R CMD check --as-cran` with the manual: **Status: OK (0/0/0)**
- Full suite: **1361 passing, 5 named skips**, `NOT_CRAN=true`

> **Note on that test count.** It's higher than the 1302 reported on #162 because `skip_on_cran()` only runs when `NOT_CRAN=true` — `devtools::test()` sets it, a bare `Rscript` doesn't. **59 tests had been skipping silently** and counting as passes in the summary line. This bug's own test passed before the fix existed for exactly that reason, which is what caught it. Worth knowing for anyone verifying locally.

## Scope

Provenance unchanged (still records `object$xvar.names`, consistent with the A-path). `cat_limit` is *also* dropped on this path — same mechanism, not fixed here, not reported anywhere yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)