### PR TITLE
fix(vimp): report the permutation importance randomForest fits actually stored

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -79,6 +79,18 @@ ggRandomForests v3.5.0
   `k`, and `which.outcome = 1` agrees with `which.outcome = "setosa"`. Fits
   grown with `importance = FALSE` keep no `MeanDecreaseAccuracy` column and
   their single measure answers to `0` as before.
+* `which.outcome` now names the measure it selected in the `set` column, for
+  both `rfsrc` and `randomForest` fits. Asking for one measure reported `set`
+  as the literal `"vimp"` -- the pivot takes `set` from the source column name,
+  and the selected column was named after the `vimp` column it was about to be
+  written into rather than after the measure it held. So the one path where you
+  have to say which measure you want was the one path that would not tell you
+  which measure you got. `gg_vimp(rfsrc_iris, which.outcome = 0)` now reports
+  `set == "all"`, `gg_vimp(rf_iris, which.outcome = 0)` reports
+  `set == "MeanDecreaseAccuracy"`, and both agree with the names the unfiltered
+  pivot has always used. Values and ordering are unchanged, and plots are
+  unaffected: `plot.gg_vimp()` only facets on `set` when there is more than one
+  of them, and selecting a measure leaves exactly one.
 * `nvar` counts variables again for `randomForest` fits, not rows. It was
   applied after the multiclass pivot, where a frame holds one row per
   variable *per measure*, so it lopped whole measures off the end of the

--- a/NEWS.md
+++ b/NEWS.md
@@ -64,6 +64,21 @@ ggRandomForests v3.5.0
   `MeanDecreaseAccuracy` are all permutation measures on one scale, so they are
   now kept together and named in the `set` column, the way an `rfsrc` fit's
   `all`/`<class>` columns already were; only `MeanDecreaseGini` is dropped.
+* Fix: `which.outcome` now selects the column you asked for on a `randomForest`
+  classification fit. `which.outcome = 0` documented itself as overall
+  importance and took column 1 to get it, and `which.outcome = k` took column
+  `k + 1` for class `k`. Both are right for an `rfsrc` fit, whose `$importance`
+  leads with an `all` column, and neither is right here: a `randomForest`
+  matrix opens on the classes and keeps the overall permutation measure in
+  `MeanDecreaseAccuracy`, near the end. So `0` returned the first class
+  labelled as overall -- on `randomForest(Species ~ ., iris, importance =
+  TRUE)` it handed back setosa's values, ranking `Petal.Width` above
+  `Petal.Length` where the overall measure has them the other way round -- and
+  every class index was shifted by one, `1` giving versicolor. The columns are
+  now resolved by name: `0` reaches `MeanDecreaseAccuracy`, `k` reaches class
+  `k`, and `which.outcome = 1` agrees with `which.outcome = "setosa"`. Fits
+  grown with `importance = FALSE` keep no `MeanDecreaseAccuracy` column and
+  their single measure answers to `0` as before.
 * `nvar` counts variables again for `randomForest` fits, not rows. It was
   applied after the multiclass pivot, where a frame holds one row per
   variable *per measure*, so it lopped whole measures off the end of the

--- a/NEWS.md
+++ b/NEWS.md
@@ -39,6 +39,39 @@ ggRandomForests v3.5.0
   error and still is. The `partialpro`-only arguments (`cut`, `nsmp`) mean
   nothing on this path and are now ignored with a warning rather than in
   silence.
+* Fix: `gg_vimp()` on a `randomForest` fit grown with `importance = TRUE` now
+  reports the permutation importance you asked for. It was reporting node
+  purity instead, and silently: `randomForest` stores `%IncMSE` and
+  `IncNodePurity` side by side, and `gg_vimp()` stacked both into one `vimp`
+  column and ranked them together. The two are not commensurable -- node purity
+  runs in the thousands where `%IncMSE` runs in the tens -- so every impurity
+  row outranked every permutation row, and the truncation to `nvar` cut the
+  permutation values away entirely. On `randomForest(medv ~ ., Boston,
+  importance = TRUE)` the plot showed `lstat = 12576.7` (node purity) where the
+  permutation value is `lstat = 62.4`. Node purity is now left out of the
+  ranking; read `randomForest::importance(object)` if you want both. Fits grown
+  without `importance = TRUE` are unaffected -- they only ever stored node
+  purity, and that is still what you get.
+* `gg_vimp()` now says in `?gg_vimp` that a `randomForest` fit without
+  `importance = TRUE` stores only `IncNodePurity`, so the ranking is node
+  purity rather than permutation VIMP, and nothing in the plot marks the
+  difference. The example now passes `importance = TRUE`.
+* `gg_error()` now explains that the error trajectory is `randomForestSRC`'s to
+  record, not ours: `rfsrc()`'s `block.size` defaults to `NULL` unless you
+  request importance, which stores the error at the final tree only, so a
+  default fit gives `gg_error()` a single point rather than a curve --
+  `tree.err = TRUE` alone does not change that. Grow with `block.size = 1` for
+  an error at every tree. The examples do this now; they had all been plotting
+  one dot.
+* `gg_beta_varpro()`: the `imp` column is documented as the *absolute*
+  coefficient. `varPro::beta.varpro()` wraps every coefficient it returns in
+  `abs()`, so the sign is discarded upstream and never reaches us -- the docs
+  had said "Sign is real (direction of local association)", which cannot be
+  read off this output. Use `gg_ivarpro()` for a signed local estimator.
+* `gg_isopro()`: the "What's in the output" section now says the polarity flip
+  is ours. `varPro::isopro()`'s `howbad` is *lower* = more anomalous; we return
+  `1 - howbad` so that higher = more anomalous. The section had credited that
+  to the fit, contradicting this function's own `@return`.
 * Added `gg_shap()` and `plot.gg_shap()` (with `shap_importance()`,
   `shap_beeswarm()`, `shap_dependence()`) for SHAP explanations of
   regression and classification forests, wrapping `kernelshap` (Suggests).

--- a/NEWS.md
+++ b/NEWS.md
@@ -52,6 +52,22 @@ ggRandomForests v3.5.0
   ranking; read `randomForest::importance(object)` if you want both. Fits grown
   without `importance = TRUE` are unaffected -- they only ever stored node
   purity, and that is still what you get.
+* Fix: `gg_vimp()` on a `randomForest` *classification* fit grown with
+  `importance = TRUE` now reports permutation importance as well. That matrix
+  mixes the same two scales -- a permutation column per class plus
+  `MeanDecreaseAccuracy`, alongside `MeanDecreaseGini` -- but it is wider than
+  the single-outcome branch that picks one measure, so it skipped that branch
+  and every column was ranked together. `MeanDecreaseGini` came out the sole
+  survivor: on `randomForest(Species ~ ., iris, importance = TRUE)`,
+  `gg_vimp()` returned 4 rows of node purity where 16 rows of permutation
+  importance were there to report. The per-class columns and
+  `MeanDecreaseAccuracy` are all permutation measures on one scale, so they are
+  now kept together and named in the `set` column, the way an `rfsrc` fit's
+  `all`/`<class>` columns already were; only `MeanDecreaseGini` is dropped.
+* `nvar` counts variables again for `randomForest` fits, not rows. It was
+  applied after the multiclass pivot, where a frame holds one row per
+  variable *per measure*, so it lopped whole measures off the end of the
+  ranking instead of trimming the ranking itself.
 * `gg_vimp()` now says in `?gg_vimp` that a `randomForest` fit without
   `importance = TRUE` stores only `IncNodePurity`, so the ranking is node
   purity rather than permutation VIMP, and nothing in the plot marks the

--- a/R/gg_beta_varpro.R
+++ b/R/gg_beta_varpro.R
@@ -38,12 +38,15 @@
 #'   selects \eqn{\lambda}{lambda} by 10-fold CV (default `nfolds = 10`);
 #'   `use.1se = TRUE` (default) picks `lambda.1se`. `use.cv = FALSE` uses the
 #'   full \eqn{\lambda}{lambda} path.
-#' - `imp` is the **fitted coefficient** \eqn{\hat{\beta}}{beta hat} at the
-#'   chosen \eqn{\lambda}{lambda}. **Sign is
-#'   real** (direction of local association). **Magnitude depends on
-#'   the predictor's units** (raw `x`, no standardisation); a predictor
-#'   in millimetres has a smaller \eqn{|\hat{\beta}|}{|beta hat|} than the
-#'   same predictor in metres.
+#' - `imp` is the **absolute** fitted coefficient
+#'   \eqn{|\hat{\beta}|}{|beta hat|} at the chosen \eqn{\lambda}{lambda}.
+#'   **There is no direction here**: `varPro::beta.varpro()` wraps every
+#'   coefficient it returns in `abs()`, so the sign is discarded upstream and
+#'   never reaches us. Read `imp` as strength of local association, not its
+#'   direction. (For a signed local estimator, see [gg_ivarpro()], where the
+#'   sign does survive.) **Magnitude depends on the predictor's units** (raw
+#'   `x`, no standardisation); a predictor in millimetres has a smaller
+#'   \eqn{|\hat{\beta}|}{|beta hat|} than the same predictor in metres.
 #' - Lasso shrinkage can drive \eqn{\hat{\beta}}{beta hat} to **exactly zero**.
 #'   Those zeros are
 #'   data, not missingness, and are kept in the aggregation. Convergence

--- a/R/gg_error.R
+++ b/R/gg_error.R
@@ -18,8 +18,21 @@
 #' \code{randomForestSRC} and \code{randomForest} fits as a function of the
 #' number of grown trees.
 #'
-#' @details For \code{randomForestSRC} objects the function reshapes the
-#' \code{\link[randomForestSRC]{rfsrc}$err.rate} matrix and annotates it with
+#' @details
+#' \strong{You have to ask rfsrc for the trajectory.}  How many trees you get
+#' a curve over is decided by \code{randomForestSRC::rfsrc()}, not here.  Its
+#' \code{block.size} argument controls how often the error is recorded, and it
+#' defaults to \code{NULL} unless you request importance -- which records the
+#' error at the \emph{final tree only}.  So a default fit gives
+#' \code{gg_error()} a single point, not a curve, and \code{tree.err = TRUE}
+#' on its own does not change that.  Grow the forest with
+#' \code{block.size = 1} for an error recorded at every tree, or a larger
+#' \code{block.size} for every \emph{n}th.  If a \code{plot.gg_error()} figure
+#' comes back as one dot, this is why.
+#'
+#' For \code{randomForestSRC} objects the function reshapes the
+#' \code{\link[randomForestSRC]{rfsrc}$err.rate} matrix, drops the trees where
+#' rfsrc recorded nothing, and annotates the rest with
 #' the tree index required by \code{\link{plot.gg_error}}. When supplied a
 #' \code{\link[randomForest]{randomForest}} object, the method inspects either
 #' the \code{$mse} or \code{$err.rate} component and, when
@@ -65,7 +78,8 @@
 #' ## ------------------------------------------------------------
 #' ## ------------- iris data
 #' ## You can build a randomForest
-#' rfsrc_iris <- randomForestSRC::rfsrc(Species ~ ., data = iris, tree.err = TRUE)
+#' rfsrc_iris <- randomForestSRC::rfsrc(Species ~ ., data = iris,
+#'   tree.err = TRUE, block.size = 1)
 #'
 #' # Get a data.frame containing error rates
 #' gg_dta <- gg_error(rfsrc_iris)
@@ -90,7 +104,7 @@
 #' ## ------------- airq data
 #' rfsrc_airq <- randomForestSRC::rfsrc(Ozone ~ .,
 #'   data = airquality,
-#'   na.action = "na.impute", tree.err = TRUE,
+#'   na.action = "na.impute", tree.err = TRUE, block.size = 1,
 #' )
 #'
 #' # Get a data.frame containing error rates
@@ -119,7 +133,8 @@
 #'
 #'
 #' ## ------------- mtcars data
-#' rfsrc_mtcars <- randomForestSRC::rfsrc(mpg ~ ., data = mtcars, tree.err = TRUE)
+#' rfsrc_mtcars <- randomForestSRC::rfsrc(mpg ~ ., data = mtcars,
+#'   tree.err = TRUE, block.size = 1)
 #'
 
 #' # Get a data.frame containing error rates
@@ -136,7 +151,7 @@
 #' ## randomized trial of two treatment regimens for lung cancer
 #' data(veteran, package = "randomForestSRC")
 #' rfsrc_veteran <- randomForestSRC::rfsrc(Surv(time, status) ~ ., data = veteran,
-#'                        tree.err = TRUE)
+#'                        tree.err = TRUE, block.size = 1)
 #'
 #' gg_dta <- gg_error(rfsrc_veteran)
 #' plot(gg_dta)

--- a/R/gg_isopro.R
+++ b/R/gg_isopro.R
@@ -47,12 +47,19 @@
 #' @section What's in the output:
 #' The fit gives back two parallel per-observation vectors:
 #' \code{case.depth} is the raw mean isolation depth (units of "splits",
-#' lower = more anomalous) and \code{howbad} is the same information
-#' transformed onto a \code{[0, 1]} scale via the empirical CDF of
-#' \code{case.depth} (higher = more anomalous). Both columns are kept so
-#' you can plot in either space and have the raw depth on hand for
-#' diagnostics; \code{howbad} is the canonical score and is what the plot
-#' method uses by default.
+#' lower = more anomalous) and \code{howbad} is the same information on a
+#' \code{[0, 1]} scale, the empirical CDF of \code{case.depth}. On the fit
+#' those two run the same way: \code{varPro::isopro()}'s \code{howbad} is
+#' \emph{lower} = more anomalous, like the depth it came from.
+#'
+#' We flip it. \code{gg_isopro()} returns \code{1 - object$howbad}, so the
+#' column you get is \strong{higher = more anomalous} and reads the way a
+#' score should. That is our transformation, not the fit's, and it means
+#' \code{gg$howbad} is \code{1 - fit$howbad} rather than a copy of it -- worth
+#' knowing if you compare the two side by side. Both columns are kept so you
+#' can plot in either space and have the raw depth on hand for diagnostics;
+#' \code{howbad} is the canonical score and is what the plot method uses by
+#' default.
 #'
 #' @section What you use this for:
 #' This is screening, not inference. Reach for it when you want to:

--- a/R/gg_vimp.R
+++ b/R/gg_vimp.R
@@ -367,6 +367,62 @@ gg_vimp.rfsrc <- function(object, nvar, ...) {
   invisible(gg_dta)
 }
 
+# Resolve a which.outcome request against the columns of a randomForest
+# importance frame, returning the name of the column it selects. Both the
+# name and the index form resolve to a name, which then labels the measure in
+# `set` once the caller pivots.
+#
+# randomForest's importance matrix has no overall-first column: it runs one
+# permutation column per class, then MeanDecreaseAccuracy (the overall
+# permutation measure). rfsrc leads with an "all" column instead, so
+# gg_vimp.rfsrc's index arithmetic -- 0 for column 1, k for column k + 1 --
+# does not carry over here: applied to a randomForest fit it hands back the
+# first class for 0 and shifts every class by one.
+#   which.outcome = 0 gives overall (MeanDecreaseAccuracy)
+#   which.outcome = k gives class k
+# A fit grown with importance = FALSE keeps no MeanDecreaseAccuracy column;
+# its sole surviving measure is the overall one by default.
+.rf_which_outcome_col <- function(gg_dta, which_outcome) {
+  if (!is.numeric(which_outcome)) {
+    if (!which_outcome %in% colnames(gg_dta)) {
+      stop(
+        paste(
+          "which.outcome naming is incorrect.",
+          which_outcome,
+          "\nis not in",
+          colnames(gg_dta)
+        )
+      )
+    }
+    return(which_outcome)
+  }
+
+  if (which_outcome < 0) {
+    stop("which.outcome must be a non-negative integer or a class name.")
+  }
+
+  measures <- setdiff(colnames(gg_dta), "vars")
+  classes <- setdiff(measures, "MeanDecreaseAccuracy")
+
+  if (which_outcome == 0) {
+    if ("MeanDecreaseAccuracy" %in% measures) {
+      return("MeanDecreaseAccuracy")
+    }
+    return(measures[1])
+  }
+
+  if (which_outcome > length(classes)) {
+    stop(
+      paste0(
+        "which.outcome (", which_outcome, ") is out of range. ",
+        "Valid values are 0 (overall) to ", length(classes),
+        " (number of classes)."
+      )
+    )
+  }
+  classes[which_outcome]
+}
+
 #' @export
 gg_vimp.randomForest <- function(object, nvar, ...) {
   ## Check that the input object is of the correct type.
@@ -468,58 +524,7 @@ gg_vimp.randomForest <- function(object, nvar, ...) {
     arg_set <- list(...)
 
     if (!is.null(arg_set$which.outcome)) {
-      # test which.outcome specification. Both paths resolve the request to a
-      # column name, which then names the measure in `set` below, the way the
-      # unfiltered pivot in the else branch already does.
-      if (!is.numeric(arg_set$which.outcome)) {
-        if (arg_set$which.outcome %in% colnames(gg_dta)) {
-          which_col <- arg_set$which.outcome
-        } else {
-          stop(
-            paste(
-              "which.outcome naming is incorrect.",
-              arg_set$which.outcome,
-              "\nis not in",
-              colnames(gg_dta)
-            )
-          )
-        }
-      } else {
-        # Resolve the column by name rather than by offset. randomForest's
-        # importance matrix has no overall-first column: it runs one
-        # permutation column per class, then MeanDecreaseAccuracy (the overall
-        # permutation measure), then MeanDecreaseGini. rfsrc leads with an
-        # "all" column instead, so gg_vimp.rfsrc's index arithmetic -- 0 for
-        # column 1, k for column k+1 -- does not carry over here. Applied to a
-        # randomForest fit it silently hands back the first class for 0 and
-        # shifts every class by one.
-        #   which.outcome = 0 gives overall (MeanDecreaseAccuracy)
-        #   which.outcome = k gives class k
-        # A fit grown with importance = FALSE keeps no MeanDecreaseAccuracy
-        # column; the sole surviving measure is the overall one by default.
-        if (arg_set$which.outcome < 0) {
-          stop("which.outcome must be a non-negative integer or a class name.")
-        }
-        measures <- setdiff(colnames(gg_dta), "vars")
-        classes <- setdiff(measures, "MeanDecreaseAccuracy")
-        if (arg_set$which.outcome == 0) {
-          which_col <- if ("MeanDecreaseAccuracy" %in% measures) {
-            "MeanDecreaseAccuracy"
-          } else {
-            measures[1]
-          }
-        } else if (arg_set$which.outcome <= length(classes)) {
-          which_col <- classes[arg_set$which.outcome]
-        } else {
-          stop(
-            paste0(
-              "which.outcome (", arg_set$which.outcome, ") is out of range. ",
-              "Valid values are 0 (overall) to ", length(classes),
-              " (number of classes)."
-            )
-          )
-        }
-      }
+      which_col <- .rf_which_outcome_col(gg_dta, arg_set$which.outcome)
       gg_v <- data.frame(vimp = sort(gg_dta[, which_col],
         decreasing = TRUE
       ))

--- a/R/gg_vimp.R
+++ b/R/gg_vimp.R
@@ -27,13 +27,34 @@
 #' importance information.
 #'
 #' @details
-#' \code{gg_vimp()} shows \strong{permutation (Breiman-Cutler) variable
-#' importance}: the forest permutes a variable's observed values across the
-#' out-of-bag (OOB) cases, runs those perturbed cases down the already-grown
-#' trees, and measures how much the OOB prediction error climbs.  That
-#' perturbation is synthetic (the variable's link to the response is broken
-#' on purpose) so a large increase means the variable was carrying genuine
-#' signal; near-zero or negative values mean it added noise or nothing at all.
+#' \code{gg_vimp()} reports whatever importance the forest stored; it computes
+#' nothing itself.  Usually that is \strong{permutation (Breiman-Cutler)
+#' variable importance}: the forest permutes a variable's observed values
+#' across the out-of-bag (OOB) cases, runs those perturbed cases down the
+#' already-grown trees, and measures how much the OOB prediction error climbs.
+#' That perturbation is synthetic (the variable's link to the response is
+#' broken on purpose) so a large increase means the variable was carrying
+#' genuine signal; near-zero or negative values mean it added noise or nothing
+#' at all.
+#'
+#' \strong{A \code{randomForest} fit needs \code{importance = TRUE} to give you
+#' this.}  \code{randomForest::randomForest()} defaults to
+#' \code{importance = FALSE}, and that fit stores only \code{IncNodePurity} --
+#' a node-impurity (RSS or Gini) measure, which is not a permutation quantity
+#' and is not comparable to one.  It is the only importance the forest kept, so
+#' it is what \code{gg_vimp()} reports, in the \code{vimp} column, same as any
+#' other.  Nothing marks the difference in the plot.  So
+#' \code{gg_vimp(randomForest(y ~ ., data))} ranks by node purity; pass
+#' \code{importance = TRUE} and you get permutation VIMP (\code{\%IncMSE}), and
+#' \code{colnames(object$importance)} tells you which one you have.
+#' \code{randomForestSRC::rfsrc()} has no such trap: its \code{importance}
+#' argument yields permutation VIMP.
+#'
+#' When a \code{randomForest} fit carries both measures, \code{gg_vimp()}
+#' reports the permutation one and leaves node purity out of the ranking --
+#' the two run on different scales and mean different things, so putting them
+#' in one ordering would be meaningless.  Read
+#' \code{randomForest::importance(object)} if you want both.
 #'
 #' \code{\link{gg_varpro}()} takes the opposite route, comparing local
 #' estimators on real observed data through varPro's release rules, with no
@@ -97,7 +118,9 @@
 #' plot(gg_dta)
 #'
 #' ## -------- Boston data
-#' rf_boston <- randomForest::randomForest(medv ~ ., Boston)
+#' ## importance = TRUE for permutation VIMP; without it randomForest stores
+#' ## only IncNodePurity, which is what you would be ranking (see Details).
+#' rf_boston <- randomForest::randomForest(medv ~ ., Boston, importance = TRUE)
 #' gg_dta <- gg_vimp(rf_boston)
 #' plot(gg_dta)
 #'
@@ -400,6 +423,14 @@ gg_vimp.randomForest <- function(object, nvar, ...) {
       # plot.gg_vimp both work regardless of what randomForest named the column.
       colnames(gg_dta)[1] <- "vimp"
     }
+    # With importance = TRUE, randomForest stores a node-impurity measure
+    # (IncNodePurity / MeanDecreaseGini) alongside the permutation one, and the
+    # multiclass pivot below would stack both into `vimp` and rank them
+    # together. They are not commensurable -- node purity runs in the thousands
+    # where %IncMSE runs in the tens -- so the impurity rows would sweep the top
+    # of the ranking and the permutation values the caller asked for would be
+    # truncated away entirely. Keep only the measure chosen above.
+    gg_dta <- gg_dta[, c("vimp", "vars"), drop = FALSE]
   }
   if (missing(nvar)) {
     nvar <- nrow(gg_dta)

--- a/R/gg_vimp.R
+++ b/R/gg_vimp.R
@@ -539,6 +539,20 @@ gg_vimp.randomForest <- function(object, nvar, ...) {
       gg_dta <- gg_v
     } else {
       gg_dta$vars <- rownames(gg_dta)
+      # Rank before trimming. randomForest hands back $importance in
+      # model-matrix order, so the frame reaching here is unsorted, and the
+      # sort below runs after the pivot -- too late to decide which variables
+      # survive. Trimming now without ordering would keep the first nvar
+      # variables and hence, on iris, the two *least* important ones. Rank on
+      # the overall permutation measure where the fit has one; a single-measure
+      # frame has only the one column to rank on.
+      primary <- colnames(gg_dta)[1]
+      if ("MeanDecreaseAccuracy" %in% colnames(gg_dta)) {
+        primary <- "MeanDecreaseAccuracy"
+      }
+      gg_dta <- gg_dta[order(gg_dta[[primary]], decreasing = TRUE), ,
+        drop = FALSE
+      ]
     }
 
     # Trim while the frame is still one row per variable: nvar counts

--- a/R/gg_vimp.R
+++ b/R/gg_vimp.R
@@ -54,7 +54,11 @@
 #' reports the permutation one and leaves node purity out of the ranking --
 #' the two run on different scales and mean different things, so putting them
 #' in one ordering would be meaningless.  Read
-#' \code{randomForest::importance(object)} if you want both.
+#' \code{randomForest::importance(object)} if you want both.  A classification
+#' fit names that pair \code{MeanDecreaseAccuracy} and \code{MeanDecreaseGini},
+#' and stores a permutation column per class besides.  Those per-class columns
+#' are all permutation measures on one scale, so \code{gg_vimp()} keeps them
+#' together, names each in the \code{set} column, and drops only the Gini one.
 #'
 #' \code{\link{gg_varpro}()} takes the opposite route, comparing local
 #' estimators on real observed data through varPro's release rules, with no
@@ -409,6 +413,22 @@ gg_vimp.randomForest <- function(object, nvar, ...) {
   } else {
     gg_dta <- data.frame(object$importance)
   }
+  # Drop the node-impurity measure up front, for the same reason the
+  # single-outcome branch below keeps only one measure: impurity is not a
+  # permutation quantity and runs orders of magnitude larger, so it cannot
+  # share a ranking with the permutation measures. Classification skips that
+  # branch entirely (its importance matrix is wider than 2 columns), which
+  # left MeanDecreaseGini as the sole survivor of the pivot. What remains for
+  # a classification fit is the per-class columns plus MeanDecreaseAccuracy --
+  # all permutation measures, mutually commensurable, and the direct analogue
+  # of the all/<class> columns gg_vimp.rfsrc pivots together. Forests grown
+  # with importance = FALSE store impurity alone, so keep it in that case.
+  impurity <- c("IncNodePurity", "MeanDecreaseGini")
+  measures <- setdiff(colnames(gg_dta), impurity)
+  if (length(measures) > 0) {
+    gg_dta <- gg_dta[, measures, drop = FALSE]
+  }
+
   if (ncol(gg_dta) < 3) {
     gg_dta$vars <- rownames(gg_dta)
     colnames(gg_dta)[which(colnames(gg_dta) == "X.IncMSE")] <-
@@ -494,6 +514,11 @@ gg_vimp.randomForest <- function(object, nvar, ...) {
       gg_dta$vars <- rownames(gg_dta)
     }
 
+    # Trim while the frame is still one row per variable: nvar counts
+    # variables, so truncating the pivoted frame would instead lop whole
+    # measures off the end of the ranking. gg_vimp.rfsrc trims here too.
+    gg_dta <- gg_dta[seq_len(nvar), , drop = FALSE]
+
     pivot_cols <-
       colnames(gg_dta)[-which(colnames(gg_dta) == "vars")]
     gg_dta <- tidyr::pivot_longer(
@@ -507,8 +532,8 @@ gg_vimp.randomForest <- function(object, nvar, ...) {
   } else {
     gg_dta$vars[which(is.na(gg_dta$vars))] <-
       rownames(gg_dta)[which(is.na(gg_dta$vars))]
+    gg_dta <- gg_dta[seq_len(nvar), ]
   }
-  gg_dta <- gg_dta[seq_len(nvar), ]
 
   gg_dta$vars <-
     factor(gg_dta$vars, levels = rev(unique(gg_dta$vars)))

--- a/R/gg_vimp.R
+++ b/R/gg_vimp.R
@@ -267,17 +267,14 @@ gg_vimp.rfsrc <- function(object, nvar, ...) {
     arg_set <- list(...)
 
     if (!is.null(arg_set$which.outcome)) {
-      # Caller requested importance for one specific class only.
+      # Caller requested importance for one specific class only. Resolve the
+      # request to a column name, then carry that name through to `set` below:
+      # naming the measure is the whole point of the `set` column, and the
+      # unfiltered pivot in the else branch already does it.
       if (!is.numeric(arg_set$which.outcome)) {
         # Look up by class name (column name).
         if (arg_set$which.outcome %in% colnames(gg_dta)) {
-          gg_v <- data.frame(vimp = sort(gg_dta[, arg_set$which.outcome],
-            decreasing = TRUE
-          ))
-          gg_v$vars <-
-            rownames(gg_dta)[order(gg_dta[, arg_set$which.outcome],
-              decreasing = TRUE
-            )]
+          which_col <- arg_set$which.outcome
         } else {
           stop(
             paste(
@@ -289,20 +286,15 @@ gg_vimp.rfsrc <- function(object, nvar, ...) {
           )
         }
       } else {
-        # Look up by integer index.
+        # Look up by integer index. rfsrc's $importance leads with an "all"
+        # column, so the overall measure really is column 1 here.
         # which.outcome = 0  gives overall (across-class) importance, column 1
         # which.outcome = k  gives importance for class k, column k+1
-        if (!is.numeric(arg_set$which.outcome) || arg_set$which.outcome < 0) {
+        if (arg_set$which.outcome < 0) {
           stop("which.outcome must be a non-negative integer or a class name.")
         }
         if (arg_set$which.outcome < ncol(gg_dta)) {
-          gg_v <- data.frame(vimp = sort(gg_dta[, arg_set$which.outcome + 1],
-            decreasing = TRUE
-          ))
-          gg_v$vars <-
-            rownames(gg_dta)[order(gg_dta[, arg_set$which.outcome + 1],
-              decreasing = TRUE
-            )]
+          which_col <- colnames(gg_dta)[arg_set$which.outcome + 1]
         } else {
           stop(
             paste0(
@@ -313,6 +305,17 @@ gg_vimp.rfsrc <- function(object, nvar, ...) {
           )
         }
       }
+      gg_v <- data.frame(vimp = sort(gg_dta[, which_col],
+        decreasing = TRUE
+      ))
+      gg_v$vars <-
+        rownames(gg_dta)[order(gg_dta[, which_col],
+          decreasing = TRUE
+        )]
+      # Name the column after the measure it holds, not after the "vimp"
+      # column the pivot below writes it into -- pivot_longer() takes `set`
+      # from the source column name.
+      colnames(gg_v)[1] <- which_col
       gg_dta <- gg_v
     } else {
       # No specific class requested: attach variable names and pivot.
@@ -465,16 +468,12 @@ gg_vimp.randomForest <- function(object, nvar, ...) {
     arg_set <- list(...)
 
     if (!is.null(arg_set$which.outcome)) {
-      # test which.outcome specification
+      # test which.outcome specification. Both paths resolve the request to a
+      # column name, which then names the measure in `set` below, the way the
+      # unfiltered pivot in the else branch already does.
       if (!is.numeric(arg_set$which.outcome)) {
         if (arg_set$which.outcome %in% colnames(gg_dta)) {
-          gg_v <- data.frame(vimp = sort(gg_dta[, arg_set$which.outcome],
-            decreasing = TRUE
-          ))
-          gg_v$vars <-
-            rownames(gg_dta)[order(gg_dta[, arg_set$which.outcome],
-              decreasing = TRUE
-            )]
+          which_col <- arg_set$which.outcome
         } else {
           stop(
             paste(
@@ -520,14 +519,18 @@ gg_vimp.randomForest <- function(object, nvar, ...) {
             )
           )
         }
-        gg_v <- data.frame(vimp = sort(gg_dta[, which_col],
-          decreasing = TRUE
-        ))
-        gg_v$vars <-
-          rownames(gg_dta)[order(gg_dta[, which_col],
-            decreasing = TRUE
-          )]
       }
+      gg_v <- data.frame(vimp = sort(gg_dta[, which_col],
+        decreasing = TRUE
+      ))
+      gg_v$vars <-
+        rownames(gg_dta)[order(gg_dta[, which_col],
+          decreasing = TRUE
+        )]
+      # Name the column after the measure it holds, not after the "vimp"
+      # column the pivot below writes it into -- pivot_longer() takes `set`
+      # from the source column name.
+      colnames(gg_v)[1] <- which_col
       gg_dta <- gg_v
     } else {
       gg_dta$vars <- rownames(gg_dta)

--- a/R/gg_vimp.R
+++ b/R/gg_vimp.R
@@ -486,28 +486,47 @@ gg_vimp.randomForest <- function(object, nvar, ...) {
           )
         }
       } else {
-        # which.outcome = 0 gives overall importance (column 1)
-        # which.outcome = k gives class k importance (column k+1)
-        if (!is.numeric(arg_set$which.outcome) || arg_set$which.outcome < 0) {
+        # Resolve the column by name rather than by offset. randomForest's
+        # importance matrix has no overall-first column: it runs one
+        # permutation column per class, then MeanDecreaseAccuracy (the overall
+        # permutation measure), then MeanDecreaseGini. rfsrc leads with an
+        # "all" column instead, so gg_vimp.rfsrc's index arithmetic -- 0 for
+        # column 1, k for column k+1 -- does not carry over here. Applied to a
+        # randomForest fit it silently hands back the first class for 0 and
+        # shifts every class by one.
+        #   which.outcome = 0 gives overall (MeanDecreaseAccuracy)
+        #   which.outcome = k gives class k
+        # A fit grown with importance = FALSE keeps no MeanDecreaseAccuracy
+        # column; the sole surviving measure is the overall one by default.
+        if (arg_set$which.outcome < 0) {
           stop("which.outcome must be a non-negative integer or a class name.")
         }
-        if (arg_set$which.outcome < ncol(gg_dta)) {
-          gg_v <- data.frame(vimp = sort(gg_dta[, arg_set$which.outcome + 1],
-            decreasing = TRUE
-          ))
-          gg_v$vars <-
-            rownames(gg_dta)[order(gg_dta[, arg_set$which.outcome + 1],
-              decreasing = TRUE
-            )]
+        measures <- setdiff(colnames(gg_dta), "vars")
+        classes <- setdiff(measures, "MeanDecreaseAccuracy")
+        if (arg_set$which.outcome == 0) {
+          which_col <- if ("MeanDecreaseAccuracy" %in% measures) {
+            "MeanDecreaseAccuracy"
+          } else {
+            measures[1]
+          }
+        } else if (arg_set$which.outcome <= length(classes)) {
+          which_col <- classes[arg_set$which.outcome]
         } else {
           stop(
             paste0(
               "which.outcome (", arg_set$which.outcome, ") is out of range. ",
-              "Valid values are 0 (overall) to ", ncol(gg_dta) - 1,
+              "Valid values are 0 (overall) to ", length(classes),
               " (number of classes)."
             )
           )
         }
+        gg_v <- data.frame(vimp = sort(gg_dta[, which_col],
+          decreasing = TRUE
+        ))
+        gg_v$vars <-
+          rownames(gg_dta)[order(gg_dta[, which_col],
+            decreasing = TRUE
+          )]
       }
       gg_dta <- gg_v
     } else {

--- a/man/gg_beta_varpro.Rd
+++ b/man/gg_beta_varpro.Rd
@@ -84,12 +84,15 @@ the released variable inside the rule's OOB region. \code{use.cv = TRUE}
 selects \eqn{\lambda}{lambda} by 10-fold CV (default \code{nfolds = 10});
 \code{use.1se = TRUE} (default) picks \code{lambda.1se}. \code{use.cv = FALSE} uses the
 full \eqn{\lambda}{lambda} path.
-\item \code{imp} is the \strong{fitted coefficient} \eqn{\hat{\beta}}{beta hat} at the
-chosen \eqn{\lambda}{lambda}. \strong{Sign is
-real} (direction of local association). \strong{Magnitude depends on
-the predictor's units} (raw \code{x}, no standardisation); a predictor
-in millimetres has a smaller \eqn{|\hat{\beta}|}{|beta hat|} than the
-same predictor in metres.
+\item \code{imp} is the \strong{absolute} fitted coefficient
+\eqn{|\hat{\beta}|}{|beta hat|} at the chosen \eqn{\lambda}{lambda}.
+\strong{There is no direction here}: \code{varPro::beta.varpro()} wraps every
+coefficient it returns in \code{abs()}, so the sign is discarded upstream and
+never reaches us. Read \code{imp} as strength of local association, not its
+direction. (For a signed local estimator, see \code{\link[=gg_ivarpro]{gg_ivarpro()}}, where the
+sign does survive.) \strong{Magnitude depends on the predictor's units} (raw
+\code{x}, no standardisation); a predictor in millimetres has a smaller
+\eqn{|\hat{\beta}|}{|beta hat|} than the same predictor in metres.
 \item Lasso shrinkage can drive \eqn{\hat{\beta}}{beta hat} to \strong{exactly zero}.
 Those zeros are
 data, not missingness, and are kept in the aggregation. Convergence

--- a/man/gg_error.Rd
+++ b/man/gg_error.Rd
@@ -29,8 +29,20 @@ Extract the cumulative out-of-bag (OOB) or in-bag training error rate from
 number of grown trees.
 }
 \details{
+\strong{You have to ask rfsrc for the trajectory.}  How many trees you get
+a curve over is decided by \code{randomForestSRC::rfsrc()}, not here.  Its
+\code{block.size} argument controls how often the error is recorded, and it
+defaults to \code{NULL} unless you request importance -- which records the
+error at the \emph{final tree only}.  So a default fit gives
+\code{gg_error()} a single point, not a curve, and \code{tree.err = TRUE}
+on its own does not change that.  Grow the forest with
+\code{block.size = 1} for an error recorded at every tree, or a larger
+\code{block.size} for every \emph{n}th.  If a \code{plot.gg_error()} figure
+comes back as one dot, this is why.
+
 For \code{randomForestSRC} objects the function reshapes the
-\code{\link[randomForestSRC]{rfsrc}$err.rate} matrix and annotates it with
+\code{\link[randomForestSRC]{rfsrc}$err.rate} matrix, drops the trees where
+rfsrc recorded nothing, and annotates the rest with
 the tree index required by \code{\link{plot.gg_error}}. When supplied a
 \code{\link[randomForest]{randomForest}} object, the method inspects either
 the \code{$mse} or \code{$err.rate} component and, when
@@ -46,7 +58,8 @@ predictions. Training curves are only available when the forest was stored
 ## ------------------------------------------------------------
 ## ------------- iris data
 ## You can build a randomForest
-rfsrc_iris <- randomForestSRC::rfsrc(Species ~ ., data = iris, tree.err = TRUE)
+rfsrc_iris <- randomForestSRC::rfsrc(Species ~ ., data = iris,
+  tree.err = TRUE, block.size = 1)
 
 # Get a data.frame containing error rates
 gg_dta <- gg_error(rfsrc_iris)
@@ -71,7 +84,7 @@ plot(gg_dta)
 ## ------------- airq data
 rfsrc_airq <- randomForestSRC::rfsrc(Ozone ~ .,
   data = airquality,
-  na.action = "na.impute", tree.err = TRUE,
+  na.action = "na.impute", tree.err = TRUE, block.size = 1,
 )
 
 # Get a data.frame containing error rates
@@ -100,7 +113,8 @@ plot(gg_dta)
 
 
 ## ------------- mtcars data
-rfsrc_mtcars <- randomForestSRC::rfsrc(mpg ~ ., data = mtcars, tree.err = TRUE)
+rfsrc_mtcars <- randomForestSRC::rfsrc(mpg ~ ., data = mtcars,
+  tree.err = TRUE, block.size = 1)
 
 # Get a data.frame containing error rates
 gg_dta<- gg_error(rfsrc_mtcars)
@@ -116,7 +130,7 @@ plot(gg_dta)
 ## randomized trial of two treatment regimens for lung cancer
 data(veteran, package = "randomForestSRC")
 rfsrc_veteran <- randomForestSRC::rfsrc(Surv(time, status) ~ ., data = veteran,
-                       tree.err = TRUE)
+                       tree.err = TRUE, block.size = 1)
 
 gg_dta <- gg_error(rfsrc_veteran)
 plot(gg_dta)

--- a/man/gg_isopro.Rd
+++ b/man/gg_isopro.Rd
@@ -83,12 +83,19 @@ colours per-method curves automatically when you stack the results.
 
 The fit gives back two parallel per-observation vectors:
 \code{case.depth} is the raw mean isolation depth (units of "splits",
-lower = more anomalous) and \code{howbad} is the same information
-transformed onto a \code{[0, 1]} scale via the empirical CDF of
-\code{case.depth} (higher = more anomalous). Both columns are kept so
-you can plot in either space and have the raw depth on hand for
-diagnostics; \code{howbad} is the canonical score and is what the plot
-method uses by default.
+lower = more anomalous) and \code{howbad} is the same information on a
+\code{[0, 1]} scale, the empirical CDF of \code{case.depth}. On the fit
+those two run the same way: \code{varPro::isopro()}'s \code{howbad} is
+\emph{lower} = more anomalous, like the depth it came from.
+
+We flip it. \code{gg_isopro()} returns \code{1 - object$howbad}, so the
+column you get is \strong{higher = more anomalous} and reads the way a
+score should. That is our transformation, not the fit's, and it means
+\code{gg$howbad} is \code{1 - fit$howbad} rather than a copy of it -- worth
+knowing if you compare the two side by side. Both columns are kept so you
+can plot in either space and have the raw depth on hand for diagnostics;
+\code{howbad} is the canonical score and is what the plot method uses by
+default.
 }
 
 \section{What you use this for}{

--- a/man/gg_vimp.Rd
+++ b/man/gg_vimp.Rd
@@ -61,7 +61,11 @@ When a \code{randomForest} fit carries both measures, \code{gg_vimp()}
 reports the permutation one and leaves node purity out of the ranking --
 the two run on different scales and mean different things, so putting them
 in one ordering would be meaningless.  Read
-\code{randomForest::importance(object)} if you want both.
+\code{randomForest::importance(object)} if you want both.  A classification
+fit names that pair \code{MeanDecreaseAccuracy} and \code{MeanDecreaseGini},
+and stores a permutation column per class besides.  Those per-class columns
+are all permutation measures on one scale, so \code{gg_vimp()} keeps them
+together, names each in the \code{set} column, and drops only the Gini one.
 
 \code{\link{gg_varpro}()} takes the opposite route, comparing local
 estimators on real observed data through varPro's release rules, with no

--- a/man/gg_vimp.Rd
+++ b/man/gg_vimp.Rd
@@ -34,13 +34,34 @@ reproducible.
 object and reshapes it into a tidy data set.
 }
 \details{
-\code{gg_vimp()} shows \strong{permutation (Breiman-Cutler) variable
-importance}: the forest permutes a variable's observed values across the
-out-of-bag (OOB) cases, runs those perturbed cases down the already-grown
-trees, and measures how much the OOB prediction error climbs.  That
-perturbation is synthetic (the variable's link to the response is broken
-on purpose) so a large increase means the variable was carrying genuine
-signal; near-zero or negative values mean it added noise or nothing at all.
+\code{gg_vimp()} reports whatever importance the forest stored; it computes
+nothing itself.  Usually that is \strong{permutation (Breiman-Cutler)
+variable importance}: the forest permutes a variable's observed values
+across the out-of-bag (OOB) cases, runs those perturbed cases down the
+already-grown trees, and measures how much the OOB prediction error climbs.
+That perturbation is synthetic (the variable's link to the response is
+broken on purpose) so a large increase means the variable was carrying
+genuine signal; near-zero or negative values mean it added noise or nothing
+at all.
+
+\strong{A \code{randomForest} fit needs \code{importance = TRUE} to give you
+this.}  \code{randomForest::randomForest()} defaults to
+\code{importance = FALSE}, and that fit stores only \code{IncNodePurity} --
+a node-impurity (RSS or Gini) measure, which is not a permutation quantity
+and is not comparable to one.  It is the only importance the forest kept, so
+it is what \code{gg_vimp()} reports, in the \code{vimp} column, same as any
+other.  Nothing marks the difference in the plot.  So
+\code{gg_vimp(randomForest(y ~ ., data))} ranks by node purity; pass
+\code{importance = TRUE} and you get permutation VIMP (\code{\%IncMSE}), and
+\code{colnames(object$importance)} tells you which one you have.
+\code{randomForestSRC::rfsrc()} has no such trap: its \code{importance}
+argument yields permutation VIMP.
+
+When a \code{randomForest} fit carries both measures, \code{gg_vimp()}
+reports the permutation one and leaves node purity out of the ranking --
+the two run on different scales and mean different things, so putting them
+in one ordering would be meaningless.  Read
+\code{randomForest::importance(object)} if you want both.
 
 \code{\link{gg_varpro}()} takes the opposite route, comparing local
 estimators on real observed data through varPro's release rules, with no
@@ -89,7 +110,9 @@ gg_dta <- gg_vimp(rfsrc_boston)
 plot(gg_dta)
 
 ## -------- Boston data
-rf_boston <- randomForest::randomForest(medv ~ ., Boston)
+## importance = TRUE for permutation VIMP; without it randomForest stores
+## only IncNodePurity, which is what you would be ranking (see Details).
+rf_boston <- randomForest::randomForest(medv ~ ., Boston, importance = TRUE)
 gg_dta <- gg_vimp(rf_boston)
 plot(gg_dta)
 

--- a/tests/testthat/_snaps/snapshots/gg-vimp-classification-rf.svg
+++ b/tests/testthat/_snaps/snapshots/gg-vimp-classification-rf.svg
@@ -21,43 +21,157 @@
 <rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
 </g>
 <defs>
-  <clipPath id='cpNzQuODh8NjU2Ljg0fDIyLjc4fDU0NS4xMQ=='>
-    <rect x='74.88' y='22.78' width='581.97' height='522.33' />
+  <clipPath id='cpNzQuODh8MjE1LjI4fDM5LjQzfDU0NS4xMQ=='>
+    <rect x='74.88' y='39.43' width='140.40' height='505.68' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpNzQuODh8NjU2Ljg0fDIyLjc4fDU0NS4xMQ==)'>
-<rect x='74.88' y='22.78' width='581.97' height='522.33' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='101.33' y='66.31' width='529.06' height='62.18' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt; stroke-linejoin: miter; fill: #F8766D;' />
-<rect x='101.33' y='190.67' width='528.99' height='62.18' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt; stroke-linejoin: miter; fill: #F8766D;' />
-<rect x='101.33' y='315.04' width='111.81' height='62.18' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt; stroke-linejoin: miter; fill: #F8766D;' />
-<rect x='101.33' y='439.40' width='26.27' height='62.18' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt; stroke-linejoin: miter; fill: #F8766D;' />
-<rect x='74.88' y='22.78' width='581.97' height='522.33' style='stroke-width: 1.07; stroke: #333333;' />
+<g clip-path='url(#cpNzQuODh8MjE1LjI4fDM5LjQzfDU0NS4xMQ==)'>
+<rect x='74.88' y='39.43' width='140.40' height='505.68' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<rect x='81.28' y='201.97' width='119.33' height='60.20' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt; stroke-linejoin: miter; fill: #00BFC4;' />
+<rect x='81.28' y='81.57' width='113.72' height='60.20' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt; stroke-linejoin: miter; fill: #00BFC4;' />
+<rect x='81.28' y='322.37' width='11.76' height='60.20' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt; stroke-linejoin: miter; fill: #00BFC4;' />
+<rect x='81.28' y='442.77' width='2.13' height='60.20' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt; stroke-linejoin: miter; fill: #00BFC4;' />
+<rect x='74.88' y='39.43' width='140.40' height='505.68' style='stroke-width: 1.07; stroke: #333333;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
-<text x='69.94' y='473.52' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='47.45px' lengthAdjust='spacingAndGlyphs'>Sepal.Width</text>
-<text x='69.94' y='349.16' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='51.87px' lengthAdjust='spacingAndGlyphs'>Sepal.Length</text>
-<text x='69.94' y='224.79' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='49.42px' lengthAdjust='spacingAndGlyphs'>Petal.Length</text>
-<text x='69.94' y='100.43' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='45.00px' lengthAdjust='spacingAndGlyphs'>Petal.Width</text>
-<polyline points='72.14,470.49 74.88,470.49 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='72.14,346.13 74.88,346.13 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='72.14,221.77 74.88,221.77 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='72.14,97.40 74.88,97.40 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='101.33,547.85 101.33,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='221.90,547.85 221.90,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='342.47,547.85 342.47,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='463.04,547.85 463.04,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='583.61,547.85 583.61,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<text x='101.33' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>0</text>
-<text x='221.90' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>10</text>
-<text x='342.47' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>20</text>
-<text x='463.04' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>30</text>
-<text x='583.61' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>40</text>
-<text x='365.86' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='23.23px' lengthAdjust='spacingAndGlyphs'>vimp</text>
-<rect x='667.80' y='267.64' width='46.72' height='32.61' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<text x='667.80' y='276.35' style='font-size: 11.00px; font-family: sans;' textLength='45.56px' lengthAdjust='spacingAndGlyphs'>VIMP &gt; 0</text>
-<rect x='667.80' y='282.97' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<rect x='668.51' y='283.68' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt; stroke-linejoin: miter; fill: #F8766D;' />
-<text x='690.56' y='294.64' style='font-size: 8.80px; font-family: sans;' textLength='23.96px' lengthAdjust='spacingAndGlyphs'>TRUE</text>
+</g>
+<defs>
+  <clipPath id='cpMjIwLjc2fDM2MS4xNnwzOS40M3w1NDUuMTE='>
+    <rect x='220.76' y='39.43' width='140.40' height='505.68' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMjIwLjc2fDM2MS4xNnwzOS40M3w1NDUuMTE=)'>
+<rect x='220.76' y='39.43' width='140.40' height='505.68' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<rect x='227.16' y='81.57' width='127.61' height='60.20' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt; stroke-linejoin: miter; fill: #00BFC4;' />
+<rect x='227.16' y='201.97' width='125.72' height='60.20' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt; stroke-linejoin: miter; fill: #00BFC4;' />
+<rect x='227.16' y='322.37' width='11.80' height='60.20' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt; stroke-linejoin: miter; fill: #00BFC4;' />
+<rect x='227.16' y='442.77' width='3.12' height='60.20' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt; stroke-linejoin: miter; fill: #00BFC4;' />
+<rect x='220.76' y='39.43' width='140.40' height='505.68' style='stroke-width: 1.07; stroke: #333333;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMzY2LjY0fDUwNy4wNHwzOS40M3w1NDUuMTE='>
+    <rect x='366.64' y='39.43' width='140.40' height='505.68' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMzY2LjY0fDUwNy4wNHwzOS40M3w1NDUuMTE=)'>
+<rect x='366.64' y='39.43' width='140.40' height='505.68' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<rect x='373.04' y='201.97' width='118.66' height='60.20' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt; stroke-linejoin: miter; fill: #00BFC4;' />
+<rect x='373.04' y='81.57' width='116.10' height='60.20' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt; stroke-linejoin: miter; fill: #00BFC4;' />
+<rect x='373.04' y='322.37' width='9.42' height='60.20' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt; stroke-linejoin: miter; fill: #00BFC4;' />
+<rect x='373.02' y='442.77' width='0.026' height='60.20' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt; stroke-linejoin: miter; fill: #F8766D;' />
+<rect x='366.64' y='39.43' width='140.40' height='505.68' style='stroke-width: 1.07; stroke: #333333;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNTEyLjUyfDY1Mi45MnwzOS40M3w1NDUuMTE='>
+    <rect x='512.52' y='39.43' width='140.40' height='505.68' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTEyLjUyfDY1Mi45MnwzOS40M3w1NDUuMTE=)'>
+<rect x='512.52' y='39.43' width='140.40' height='505.68' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<rect x='518.93' y='201.97' width='116.67' height='60.20' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt; stroke-linejoin: miter; fill: #00BFC4;' />
+<rect x='518.93' y='81.57' width='101.64' height='60.20' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt; stroke-linejoin: miter; fill: #00BFC4;' />
+<rect x='518.93' y='322.37' width='13.78' height='60.20' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt; stroke-linejoin: miter; fill: #00BFC4;' />
+<rect x='518.93' y='442.77' width='3.36' height='60.20' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt; stroke-linejoin: miter; fill: #00BFC4;' />
+<rect x='512.52' y='39.43' width='140.40' height='505.68' style='stroke-width: 1.07; stroke: #333333;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNzQuODh8MjE1LjI4fDIyLjc4fDM5LjQz'>
+    <rect x='74.88' y='22.78' width='140.40' height='16.65' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNzQuODh8MjE1LjI4fDIyLjc4fDM5LjQz)'>
+<rect x='74.88' y='22.78' width='140.40' height='16.65' style='stroke-width: 1.07; stroke: #333333; fill: #D9D9D9;' />
+<text x='145.08' y='34.14' text-anchor='middle' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='95.90px' lengthAdjust='spacingAndGlyphs'>MeanDecreaseAccuracy</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMjIwLjc2fDM2MS4xNnwyMi43OHwzOS40Mw=='>
+    <rect x='220.76' y='22.78' width='140.40' height='16.65' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMjIwLjc2fDM2MS4xNnwyMi43OHwzOS40Mw==)'>
+<rect x='220.76' y='22.78' width='140.40' height='16.65' style='stroke-width: 1.07; stroke: #333333; fill: #D9D9D9;' />
+<text x='290.96' y='34.14' text-anchor='middle' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='25.94px' lengthAdjust='spacingAndGlyphs'>setosa</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMzY2LjY0fDUwNy4wNHwyMi43OHwzOS40Mw=='>
+    <rect x='366.64' y='22.78' width='140.40' height='16.65' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMzY2LjY0fDUwNy4wNHwyMi43OHwzOS40Mw==)'>
+<rect x='366.64' y='22.78' width='140.40' height='16.65' style='stroke-width: 1.07; stroke: #333333; fill: #D9D9D9;' />
+<text x='436.84' y='34.14' text-anchor='middle' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='37.66px' lengthAdjust='spacingAndGlyphs'>versicolor</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNTEyLjUyfDY1Mi45MnwyMi43OHwzOS40Mw=='>
+    <rect x='512.52' y='22.78' width='140.40' height='16.65' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTEyLjUyfDY1Mi45MnwyMi43OHwzOS40Mw==)'>
+<rect x='512.52' y='22.78' width='140.40' height='16.65' style='stroke-width: 1.07; stroke: #333333; fill: #D9D9D9;' />
+<text x='582.72' y='34.14' text-anchor='middle' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='32.28px' lengthAdjust='spacingAndGlyphs'>virginica</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<polyline points='81.28,547.85 81.28,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='119.44,547.85 119.44,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='157.60,547.85 157.60,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='195.75,547.85 195.75,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='81.28' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.0</text>
+<text x='119.44' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.1</text>
+<text x='157.60' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.2</text>
+<text x='195.75' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.3</text>
+<polyline points='227.16,547.85 227.16,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='265.32,547.85 265.32,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='303.48,547.85 303.48,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='341.64,547.85 341.64,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='227.16' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.0</text>
+<text x='265.32' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.1</text>
+<text x='303.48' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.2</text>
+<text x='341.64' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.3</text>
+<polyline points='373.04,547.85 373.04,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='411.20,547.85 411.20,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='449.36,547.85 449.36,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='487.52,547.85 487.52,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='373.04' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.0</text>
+<text x='411.20' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.1</text>
+<text x='449.36' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.2</text>
+<text x='487.52' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.3</text>
+<polyline points='518.93,547.85 518.93,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='557.08,547.85 557.08,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='595.24,547.85 595.24,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='633.40,547.85 633.40,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='518.93' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.0</text>
+<text x='557.08' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.1</text>
+<text x='595.24' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.2</text>
+<text x='633.40' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.3</text>
+<text x='69.94' y='475.90' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='47.45px' lengthAdjust='spacingAndGlyphs'>Sepal.Width</text>
+<text x='69.94' y='355.50' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='51.87px' lengthAdjust='spacingAndGlyphs'>Sepal.Length</text>
+<text x='69.94' y='235.10' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='49.42px' lengthAdjust='spacingAndGlyphs'>Petal.Length</text>
+<text x='69.94' y='114.70' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='45.00px' lengthAdjust='spacingAndGlyphs'>Petal.Width</text>
+<polyline points='72.14,472.87 74.88,472.87 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='72.14,352.47 74.88,352.47 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='72.14,232.07 74.88,232.07 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='72.14,111.67 74.88,111.67 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='363.90' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='23.23px' lengthAdjust='spacingAndGlyphs'>vimp</text>
+<rect x='663.88' y='267.33' width='50.64' height='49.89' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<text x='663.88' y='276.04' style='font-size: 11.00px; font-family: sans;' textLength='45.56px' lengthAdjust='spacingAndGlyphs'>VIMP &gt; 0</text>
+<rect x='663.88' y='282.66' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<rect x='664.59' y='283.37' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt; stroke-linejoin: miter; fill: #F8766D;' />
+<rect x='663.88' y='299.94' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<rect x='664.59' y='300.65' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: #00BFC4; stroke-linecap: butt; stroke-linejoin: miter; fill: #00BFC4;' />
+<text x='686.64' y='294.33' style='font-size: 8.80px; font-family: sans;' textLength='27.88px' lengthAdjust='spacingAndGlyphs'>FALSE</text>
+<text x='686.64' y='311.61' style='font-size: 8.80px; font-family: sans;' textLength='23.96px' lengthAdjust='spacingAndGlyphs'>TRUE</text>
 <text x='74.88' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='140.14px' lengthAdjust='spacingAndGlyphs'>gg_vimp classification rf</text>
 </g>
 </svg>

--- a/tests/testthat/_snaps/snapshots/gg-vimp-regression-rf.svg
+++ b/tests/testthat/_snaps/snapshots/gg-vimp-regression-rf.svg
@@ -28,24 +28,24 @@
 <g clip-path='url(#cpNDEuNjB8NjU2Ljg0fDIyLjc4fDU0NS4xMQ==)'>
 <rect x='41.60' y='22.78' width='615.24' height='522.33' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
 <rect x='69.57' y='40.71' width='559.31' height='25.60' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt; stroke-linejoin: miter; fill: #F8766D;' />
-<rect x='69.57' y='91.92' width='542.35' height='25.60' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt; stroke-linejoin: miter; fill: #F8766D;' />
-<rect x='69.57' y='143.12' width='426.50' height='25.60' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt; stroke-linejoin: miter; fill: #F8766D;' />
-<rect x='69.57' y='194.33' width='408.90' height='25.60' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt; stroke-linejoin: miter; fill: #F8766D;' />
-<rect x='69.57' y='245.54' width='111.61' height='25.60' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt; stroke-linejoin: miter; fill: #F8766D;' />
-<rect x='69.57' y='296.75' width='84.57' height='25.60' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt; stroke-linejoin: miter; fill: #F8766D;' />
-<rect x='69.57' y='347.96' width='57.72' height='25.60' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt; stroke-linejoin: miter; fill: #F8766D;' />
-<rect x='69.57' y='399.17' width='50.44' height='25.60' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt; stroke-linejoin: miter; fill: #F8766D;' />
-<rect x='69.57' y='450.38' width='42.94' height='25.60' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt; stroke-linejoin: miter; fill: #F8766D;' />
-<rect x='69.57' y='501.59' width='34.52' height='25.60' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt; stroke-linejoin: miter; fill: #F8766D;' />
+<rect x='69.57' y='91.92' width='524.61' height='25.60' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt; stroke-linejoin: miter; fill: #F8766D;' />
+<rect x='69.57' y='143.12' width='424.38' height='25.60' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt; stroke-linejoin: miter; fill: #F8766D;' />
+<rect x='69.57' y='194.33' width='386.64' height='25.60' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt; stroke-linejoin: miter; fill: #F8766D;' />
+<rect x='69.57' y='245.54' width='79.14' height='25.60' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt; stroke-linejoin: miter; fill: #F8766D;' />
+<rect x='69.57' y='296.75' width='55.52' height='25.60' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt; stroke-linejoin: miter; fill: #F8766D;' />
+<rect x='69.57' y='347.96' width='43.18' height='25.60' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt; stroke-linejoin: miter; fill: #F8766D;' />
+<rect x='69.57' y='399.17' width='28.34' height='25.60' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt; stroke-linejoin: miter; fill: #F8766D;' />
+<rect x='69.57' y='450.38' width='24.85' height='25.60' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt; stroke-linejoin: miter; fill: #F8766D;' />
+<rect x='69.57' y='501.59' width='19.09' height='25.60' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt; stroke-linejoin: miter; fill: #F8766D;' />
 <rect x='41.60' y='22.78' width='615.24' height='522.33' style='stroke-width: 1.07; stroke: #333333;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 <text x='36.67' y='517.42' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>am</text>
-<text x='36.67' y='466.21' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.61px' lengthAdjust='spacingAndGlyphs'>gear</text>
-<text x='36.67' y='415.00' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='8.81px' lengthAdjust='spacingAndGlyphs'>vs</text>
-<text x='36.67' y='363.79' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='18.60px' lengthAdjust='spacingAndGlyphs'>qsec</text>
-<text x='36.67' y='312.58' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.12px' lengthAdjust='spacingAndGlyphs'>carb</text>
-<text x='36.67' y='261.37' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='15.16px' lengthAdjust='spacingAndGlyphs'>drat</text>
+<text x='36.67' y='466.21' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='18.60px' lengthAdjust='spacingAndGlyphs'>qsec</text>
+<text x='36.67' y='415.00' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.61px' lengthAdjust='spacingAndGlyphs'>gear</text>
+<text x='36.67' y='363.79' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='8.81px' lengthAdjust='spacingAndGlyphs'>vs</text>
+<text x='36.67' y='312.58' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='15.16px' lengthAdjust='spacingAndGlyphs'>drat</text>
+<text x='36.67' y='261.37' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.12px' lengthAdjust='spacingAndGlyphs'>carb</text>
 <text x='36.67' y='210.16' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='10.76px' lengthAdjust='spacingAndGlyphs'>cyl</text>
 <text x='36.67' y='158.95' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>hp</text>
 <text x='36.67' y='107.75' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='8.80px' lengthAdjust='spacingAndGlyphs'>wt</text>
@@ -61,17 +61,15 @@
 <polyline points='38.86,104.72 41.60,104.72 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
 <polyline points='38.86,53.51 41.60,53.51 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
 <polyline points='69.57,547.85 69.57,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='181.14,547.85 181.14,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='292.72,547.85 292.72,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='404.30,547.85 404.30,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='515.87,547.85 515.87,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='627.45,547.85 627.45,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<text x='69.57' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>0</text>
-<text x='181.14' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>50</text>
-<text x='292.72' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>100</text>
-<text x='404.30' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>150</text>
-<text x='515.87' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>200</text>
-<text x='627.45' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='14.68px' lengthAdjust='spacingAndGlyphs'>250</text>
+<polyline points='206.52,547.85 206.52,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='343.46,547.85 343.46,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='480.41,547.85 480.41,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='617.36,547.85 617.36,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='69.57' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.0</text>
+<text x='206.52' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>2.5</text>
+<text x='343.46' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>5.0</text>
+<text x='480.41' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>7.5</text>
+<text x='617.36' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='17.13px' lengthAdjust='spacingAndGlyphs'>10.0</text>
 <text x='349.22' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='23.23px' lengthAdjust='spacingAndGlyphs'>vimp</text>
 <rect x='667.80' y='267.64' width='46.72' height='32.61' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
 <text x='667.80' y='276.35' style='font-size: 11.00px; font-family: sans;' textLength='45.56px' lengthAdjust='spacingAndGlyphs'>VIMP &gt; 0</text>

--- a/tests/testthat/test_gg_vimp.R
+++ b/tests/testthat/test_gg_vimp.R
@@ -424,3 +424,67 @@ test_that("gg_vimp: randomForest importance=FALSE reports node purity, labelled"
   inc <- rf$importance[, "IncNodePurity"]
   expect_equal(gg$vimp[1], unname(max(inc)))
 })
+
+## The classification matrix mixes the same two scales: the per-class columns
+## and MeanDecreaseAccuracy are permutation measures, MeanDecreaseGini is node
+## impurity. Ranking them together left MeanDecreaseGini as the only survivor.
+## The permutation columns are mutually commensurable, so they are kept and
+## pivoted together, mirroring gg_vimp.rfsrc's all/<class> columns.
+
+test_that("gg_vimp: randomForest classification importance=TRUE keeps the
+          permutation block", {
+  skip_on_cran()
+  skip_if_not_installed("randomForest")
+  set.seed(1)
+  rf <- randomForest::randomForest(Species ~ ., iris, importance = TRUE)
+  skip_if_not("MeanDecreaseGini" %in% colnames(rf$importance),
+              "randomForest did not store node impurity")
+
+  gg <- as.data.frame(gg_vimp(rf))
+
+  # node impurity is incommensurable with the permutation columns, so it goes
+  expect_false(any(grepl("Gini", gg$set)))
+  # every permutation measure survives: one per class, plus the overall
+  expect_setequal(
+    unique(gg$set),
+    c(levels(iris$Species), "MeanDecreaseAccuracy")
+  )
+  # and every variable is reported for every measure
+  expect_equal(nrow(gg), 16L)
+
+  # values are carried through untouched
+  acc <- rf$importance[, "MeanDecreaseAccuracy"]
+  got <- gg[gg$set == "MeanDecreaseAccuracy", ]
+  expect_equal(
+    got$vimp[order(as.character(got$vars))],
+    unname(acc[order(names(acc))])
+  )
+})
+
+test_that("gg_vimp: randomForest classification nvar counts variables, not rows", {
+  skip_on_cran()
+  skip_if_not_installed("randomForest")
+  set.seed(1)
+  rf <- randomForest::randomForest(Species ~ ., iris, importance = TRUE)
+
+  gg <- as.data.frame(gg_vimp(rf, nvar = 2))
+
+  # 2 variables x 4 permutation measures -- nvar truncates before the pivot,
+  # so it never eats whole measures off the end of the ranking.
+  expect_length(unique(as.character(gg$vars)), 2L)
+  expect_equal(nrow(gg), 8L)
+})
+
+test_that("gg_vimp: randomForest classification importance=FALSE falls back to
+          node purity", {
+  skip_on_cran()
+  skip_if_not_installed("randomForest")
+  set.seed(1)
+  rf <- randomForest::randomForest(Species ~ ., iris)
+  expect_equal(colnames(rf$importance), "MeanDecreaseGini")
+
+  gg <- as.data.frame(gg_vimp(rf))
+  expect_length(unique(gg$set), 1L)
+  gini <- rf$importance[, "MeanDecreaseGini"]
+  expect_equal(gg$vimp[1], unname(max(gini)))
+})

--- a/tests/testthat/test_gg_vimp.R
+++ b/tests/testthat/test_gg_vimp.R
@@ -380,3 +380,47 @@ test_that("gg_vimp.randomForest regression: vimp column present even when import
   expect_true("positive" %in% colnames(gg_dta))
   expect_s3_class(plot(gg_dta), "ggplot")
 })
+
+## ── randomForest: one importance measure per ranking ─────────────────────────
+## gg_vimp used to pivot every column of randomForest's $importance into a
+## single `vimp` column and rank them together. %IncMSE (tens) and
+## IncNodePurity (thousands) are incommensurable, so node purity swept the top
+## of the ranking and the permutation values the user asked for by passing
+## importance = TRUE were truncated off the end and never shown.
+
+test_that("gg_vimp: randomForest importance=TRUE reports permutation VIMP", {
+  skip_on_cran()
+  skip_if_not_installed("randomForest")
+  skip_if_not_installed("MASS")
+  data(Boston, package = "MASS")
+  set.seed(1)
+  rf <- randomForest::randomForest(medv ~ ., Boston, importance = TRUE)
+  skip_if_not(all(c("%IncMSE", "IncNodePurity") %in% colnames(rf$importance)),
+              "randomForest did not store both measures")
+
+  gg <- as.data.frame(gg_vimp(rf))
+
+  # one measure only -- never both stacked in the same column
+  expect_length(unique(gg$set), 1L)
+  # and it is the permutation measure, not node purity
+  expect_false(any(grepl("Purity", gg$set)))
+
+  pct <- rf$importance[, "%IncMSE"]
+  expect_equal(gg$vimp[1], unname(max(pct)))
+  expect_equal(as.character(gg$vars[1]), names(which.max(pct)))
+})
+
+test_that("gg_vimp: randomForest importance=FALSE reports node purity, labelled", {
+  skip_on_cran()
+  skip_if_not_installed("randomForest")
+  skip_if_not_installed("MASS")
+  data(Boston, package = "MASS")
+  set.seed(1)
+  rf <- randomForest::randomForest(medv ~ ., Boston)
+  expect_equal(colnames(rf$importance), "IncNodePurity")
+
+  gg <- as.data.frame(gg_vimp(rf))
+  expect_length(unique(gg$set), 1L)
+  inc <- rf$importance[, "IncNodePurity"]
+  expect_equal(gg$vimp[1], unname(max(inc)))
+})

--- a/tests/testthat/test_gg_vimp.R
+++ b/tests/testthat/test_gg_vimp.R
@@ -156,6 +156,38 @@ test_that("gg_vimp randomForest which.outcome maps to the right column", {
   expect_error(gg_vimp(rf_iris, which.outcome = -1))
 })
 
+test_that("gg_vimp which.outcome names the measure in set", {
+  data(iris, package = "datasets")
+  set.seed(1)
+
+  # Selecting one measure must name it in `set`, the way the unfiltered
+  # pivot already does -- not report the literal "vimp".
+  rfsrc_iris <- randomForestSRC::rfsrc(Species ~ .,
+                                       data = iris,
+                                       importance = TRUE)
+
+  expect_equal(unique(gg_vimp(rfsrc_iris, which.outcome = 0)$set), "all")
+  expect_equal(unique(gg_vimp(rfsrc_iris, which.outcome = 2)$set), "versicolor")
+  expect_equal(unique(gg_vimp(rfsrc_iris, which.outcome = "setosa")$set),
+               "setosa")
+  expect_equal(unique(gg_vimp(rfsrc_iris, which.outcome = "all")$set), "all")
+
+  rf_iris <- randomForest::randomForest(Species ~ .,
+                                        data = iris,
+                                        importance = TRUE)
+
+  expect_equal(unique(gg_vimp(rf_iris, which.outcome = 0)$set),
+               "MeanDecreaseAccuracy")
+  expect_equal(unique(gg_vimp(rf_iris, which.outcome = 1)$set), "setosa")
+  expect_equal(unique(gg_vimp(rf_iris, which.outcome = "virginica")$set),
+               "virginica")
+
+  # Naming the measure must not disturb the values it labels.
+  expect_equal(gg_vimp(rf_iris, which.outcome = 0)$vimp,
+               unname(sort(rf_iris$importance[, "MeanDecreaseAccuracy"],
+                           decreasing = TRUE)))
+})
+
 
 test_that("gg_vimp survival", {
   dta <- new.env()

--- a/tests/testthat/test_gg_vimp.R
+++ b/tests/testthat/test_gg_vimp.R
@@ -121,6 +121,41 @@ test_that("gg_vimp classifications", {
   gg_dta <- gg_vimp(rf_iris, which.outcome = NULL)
 })
 
+test_that("gg_vimp randomForest which.outcome maps to the right column", {
+  data(iris, package = "datasets")
+  set.seed(1)
+  rf_iris <- randomForest::randomForest(Species ~ .,
+                                        data = iris,
+                                        importance = TRUE)
+
+  # randomForest's importance matrix leads with the per-class columns, so
+  # which.outcome = 0 must reach MeanDecreaseAccuracy, not column 1 (setosa).
+  overall <- sort(rf_iris$importance[, "MeanDecreaseAccuracy"],
+                  decreasing = TRUE)
+  gg_dta <- gg_vimp(rf_iris, which.outcome = 0)
+
+  expect_equal(gg_dta$vimp, unname(overall))
+  expect_equal(as.character(gg_dta$vars), names(overall))
+
+  # which.outcome = k stays class k, counting from the first class.
+  for (k in seq_len(3)) {
+    class_k <- sort(rf_iris$importance[, levels(iris$Species)[k]],
+                    decreasing = TRUE)
+    gg_k <- gg_vimp(rf_iris, which.outcome = k)
+
+    expect_equal(gg_k$vimp, unname(class_k))
+    expect_equal(as.character(gg_k$vars), names(class_k))
+  }
+
+  # Naming a class must agree with the equivalent index.
+  expect_equal(gg_vimp(rf_iris, which.outcome = "setosa")$vimp,
+               gg_vimp(rf_iris, which.outcome = 1)$vimp)
+
+  # Three classes, so 0:3 is the valid range.
+  expect_error(gg_vimp(rf_iris, which.outcome = 4))
+  expect_error(gg_vimp(rf_iris, which.outcome = -1))
+})
+
 
 test_that("gg_vimp survival", {
   dta <- new.env()

--- a/tests/testthat/test_gg_vimp.R
+++ b/tests/testthat/test_gg_vimp.R
@@ -540,6 +540,14 @@ test_that("gg_vimp: randomForest classification nvar counts variables, not rows"
   # so it never eats whole measures off the end of the ranking.
   expect_length(unique(as.character(gg$vars)), 2L)
   expect_equal(nrow(gg), 8L)
+
+  # ... and it keeps the top nvar, not the first nvar. randomForest's
+  # importance matrix arrives in model-matrix order, which is nothing to do
+  # with rank, so trimming it unsorted would return the *least* important
+  # variables while `@return` promises rank order.
+  top2 <- names(sort(rf$importance[, "MeanDecreaseAccuracy"],
+                     decreasing = TRUE))[1:2]
+  expect_setequal(unique(as.character(gg$vars)), top2)
 })
 
 test_that("gg_vimp: randomForest classification importance=FALSE falls back to


### PR DESCRIPTION
`gg_vimp()` on a `randomForest` fit reported node purity where it should have reported permutation VIMP, and did it silently. Four commits, one chain, each with a regression test.

## The bug

`randomForest` stores incommensurable measures side by side in `$importance`: permutation importance (`%IncMSE`; the per-class columns and `MeanDecreaseAccuracy` for classification) and node impurity (`IncNodePurity`, `MeanDecreaseGini`). `gg_vimp()` pivoted every column into one `vimp` column and ranked them together. Impurity runs in the thousands where `%IncMSE` runs in the tens, so every impurity row outranked every permutation row and the truncation to `nvar` cut the permutation values away entirely.

```r
randomForest(medv ~ ., Boston, importance = TRUE)
#  was: lstat = 12576.7  (node purity)
#  now: lstat = 62.4     (%IncMSE -- the measure importance = TRUE computes)
```

`rfsrc` was never affected: its multiclass columns (`all`, `<class>`, ...) are *all* permutation VIMP on one scale, so pivoting them together is legitimate. Mixing two mechanisms in one matrix is `randomForest`-specific, and that asymmetry is what the fix turns on.

## What changed

- **29a88682** — regression path: keep only the selected measure before the pivot can restack it. Plus four doc corrections (`gg_error` `block.size`, `gg_beta_varpro` absolute `imp`, `gg_isopro` polarity flip).
- **565f25ed** — classification path. The single-outcome branch is guarded by `ncol(gg_dta) < 3`; a classification matrix is wider, so it skipped that branch and `MeanDecreaseGini` swept the ranking — iris returned 4 rows of node purity where 16 rows of permutation importance were available. Drop impurity up front instead; what remains is all permutation measures on one scale, kept together and named in `set`, the direct analogue of `rfsrc`'s `all`/`<class>` columns. Also fixes `nvar`, which was applied *after* the pivot and so lopped whole measures off the end rather than trimming variables.
- **db20ee30** — `which.outcome` resolved by name, not by offset. `0` took column 1 to mean "overall", correct for `rfsrc` (which leads with `all`) but not here: a `randomForest` matrix opens on the classes and keeps the overall measure in `MeanDecreaseAccuracy`. `0` returned setosa labelled as overall, and every class index was shifted by one.
- **b8693669** — `which.outcome` names the measure in `set` rather than the literal `"vimp"`, for both backends. The one path where you must say which measure you want was the one path that would not tell you which measure you got.

Fits grown with `importance = FALSE` store impurity alone and are unaffected — that is still what you get.

## Verification

- `R CMD check --as-cran` **with the manual**: `Status: OK` (0/0/0), overall **3m24s**, tarball 2.3 MB.
- `devtools::test()`: `FAIL 0 | PASS 1452`.
- Two vdiffr baselines regenerated (`gg-vimp-classification-rf`, `gg-vimp-regression-rf`) — both plots legitimately changed.

Note the `importance = TRUE` regression test already existed and was **red, not green**: `skip_on_cran()` had been skipping it absent `NOT_CRAN=true`, so `R CMD check` alone does not exercise these fixes. They were verified with `NOT_CRAN=true` separately.

The branch name predates the work — it is the vimp fix chain, not docs attribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)