### PR TITLE
docs(examples): guard MASS behind requireNamespace() consistently

### DIFF
--- a/R/gg_error.R
+++ b/R/gg_error.R
@@ -115,21 +115,23 @@
 #'
 #'
 #' ## ------------- Boston data
-#' data(Boston, package = "MASS")
-#' Boston$chas <- as.logical(Boston$chas)
-#' rfsrc_boston <- randomForestSRC::rfsrc(medv ~ .,
-#'   data = Boston,
-#'   forest = TRUE,
-#'   importance = TRUE,
-#'   tree.err = TRUE,
-#'   save.memory = TRUE
-#' )
+#' if (requireNamespace("MASS", quietly = TRUE)) {
+#'   data(Boston, package = "MASS")
+#'   Boston$chas <- as.logical(Boston$chas)
+#'   rfsrc_boston <- randomForestSRC::rfsrc(medv ~ .,
+#'     data = Boston,
+#'     forest = TRUE,
+#'     importance = TRUE,
+#'     tree.err = TRUE,
+#'     save.memory = TRUE
+#'   )
 #'
-#' # Get a data.frame containing error rates
-#' gg_dta <- gg_error(rfsrc_boston)
+#'   # Get a data.frame containing error rates
+#'   gg_dta <- gg_error(rfsrc_boston)
 #'
-#' # Plot the gg_error object
-#' plot(gg_dta)
+#'   # Plot the gg_error object
+#'   plot(gg_dta)
+#' }
 #'
 #'
 #' ## ------------- mtcars data

--- a/R/gg_vimp.R
+++ b/R/gg_vimp.R
@@ -114,19 +114,22 @@
 #'
 #'
 #' ## -------- Boston data
-#' data(Boston, package = "MASS")
-#' rfsrc_boston <- randomForestSRC::rfsrc(medv ~ ., Boston,
-#'   importance = TRUE
-#' )
-#' gg_dta <- gg_vimp(rfsrc_boston)
-#' plot(gg_dta)
+#' if (requireNamespace("MASS", quietly = TRUE)) {
+#'   data(Boston, package = "MASS")
+#'   rfsrc_boston <- randomForestSRC::rfsrc(medv ~ ., Boston,
+#'     importance = TRUE
+#'   )
+#'   gg_dta <- gg_vimp(rfsrc_boston)
+#'   plot(gg_dta)
 #'
-#' ## -------- Boston data
-#' ## importance = TRUE for permutation VIMP; without it randomForest stores
-#' ## only IncNodePurity, which is what you would be ranking (see Details).
-#' rf_boston <- randomForest::randomForest(medv ~ ., Boston, importance = TRUE)
-#' gg_dta <- gg_vimp(rf_boston)
-#' plot(gg_dta)
+#'   ## importance = TRUE for permutation VIMP; without it randomForest stores
+#'   ## only IncNodePurity, which is what you would be ranking (see Details).
+#'   rf_boston <- randomForest::randomForest(medv ~ ., Boston,
+#'     importance = TRUE
+#'   )
+#'   gg_dta <- gg_vimp(rf_boston)
+#'   plot(gg_dta)
+#' }
 #'
 #'
 #' ## -------- mtcars data

--- a/R/plot.gg_error.R
+++ b/R/plot.gg_error.R
@@ -100,21 +100,23 @@
 #'
 #'
 #' ## ------------- Boston data
-#' data(Boston, package = "MASS")
-#' Boston$chas <- as.logical(Boston$chas)
-#' rfsrc_boston <- randomForestSRC::rfsrc(medv ~ .,
-#'   data = Boston,
-#'   forest = TRUE,
-#'   importance = TRUE,
-#'   tree.err = TRUE,
-#'   save.memory = TRUE
-#' )
+#' if (requireNamespace("MASS", quietly = TRUE)) {
+#'   data(Boston, package = "MASS")
+#'   Boston$chas <- as.logical(Boston$chas)
+#'   rfsrc_boston <- randomForestSRC::rfsrc(medv ~ .,
+#'     data = Boston,
+#'     forest = TRUE,
+#'     importance = TRUE,
+#'     tree.err = TRUE,
+#'     save.memory = TRUE
+#'   )
 #'
-#' # Get a data.frame containing error rates
-#' gg_dta <- gg_error(rfsrc_boston)
+#'   # Get a data.frame containing error rates
+#'   gg_dta <- gg_error(rfsrc_boston)
 #'
-#' # Plot the gg_error object
-#' plot(gg_dta)
+#'   # Plot the gg_error object
+#'   plot(gg_dta)
+#' }
 #'
 #' ## ------------- mtcars data
 #' rfsrc_mtcars <- randomForestSRC::rfsrc(mpg ~ ., data = mtcars,

--- a/R/quantile_pts.R
+++ b/R/quantile_pts.R
@@ -37,17 +37,19 @@
 #' @importFrom stats quantile
 #'
 #' @examples
-#' data(Boston, package = "MASS")
-#' rfsrc_boston <- randomForestSRC::rfsrc(medv ~ ., Boston)
+#' if (requireNamespace("MASS", quietly = TRUE)) {
+#'   data(Boston, package = "MASS")
+#'   rfsrc_boston <- randomForestSRC::rfsrc(medv ~ ., Boston)
 #'
-#' # To create 6 intervals, we want 7 points.
-#' # quantile_pts will find balanced intervals
-#' rm_pts <- quantile_pts(rfsrc_boston$xvar$rm, groups = 6, intervals = TRUE)
+#'   # To create 6 intervals, we want 7 points.
+#'   # quantile_pts will find balanced intervals
+#'   rm_pts <- quantile_pts(rfsrc_boston$xvar$rm, groups = 6, intervals = TRUE)
 #'
-#' # Use cut to create the intervals
-#' rm_grp <- cut(rfsrc_boston$xvar$rm, breaks = rm_pts)
+#'   # Use cut to create the intervals
+#'   rm_grp <- cut(rfsrc_boston$xvar$rm, breaks = rm_pts)
 #'
-#' summary(rm_grp)
+#'   summary(rm_grp)
+#' }
 #'
 #' @export
 quantile_pts <- function(object, groups, intervals = FALSE) {

--- a/man/gg_error.Rd
+++ b/man/gg_error.Rd
@@ -95,21 +95,23 @@ plot(gg_dta)
 
 
 ## ------------- Boston data
-data(Boston, package = "MASS")
-Boston$chas <- as.logical(Boston$chas)
-rfsrc_boston <- randomForestSRC::rfsrc(medv ~ .,
-  data = Boston,
-  forest = TRUE,
-  importance = TRUE,
-  tree.err = TRUE,
-  save.memory = TRUE
-)
+if (requireNamespace("MASS", quietly = TRUE)) {
+  data(Boston, package = "MASS")
+  Boston$chas <- as.logical(Boston$chas)
+  rfsrc_boston <- randomForestSRC::rfsrc(medv ~ .,
+    data = Boston,
+    forest = TRUE,
+    importance = TRUE,
+    tree.err = TRUE,
+    save.memory = TRUE
+  )
 
-# Get a data.frame containing error rates
-gg_dta <- gg_error(rfsrc_boston)
+  # Get a data.frame containing error rates
+  gg_dta <- gg_error(rfsrc_boston)
 
-# Plot the gg_error object
-plot(gg_dta)
+  # Plot the gg_error object
+  plot(gg_dta)
+}
 
 
 ## ------------- mtcars data

--- a/man/gg_vimp.Rd
+++ b/man/gg_vimp.Rd
@@ -106,19 +106,22 @@ plot(gg_dta)
 
 
 ## -------- Boston data
-data(Boston, package = "MASS")
-rfsrc_boston <- randomForestSRC::rfsrc(medv ~ ., Boston,
-  importance = TRUE
-)
-gg_dta <- gg_vimp(rfsrc_boston)
-plot(gg_dta)
+if (requireNamespace("MASS", quietly = TRUE)) {
+  data(Boston, package = "MASS")
+  rfsrc_boston <- randomForestSRC::rfsrc(medv ~ ., Boston,
+    importance = TRUE
+  )
+  gg_dta <- gg_vimp(rfsrc_boston)
+  plot(gg_dta)
 
-## -------- Boston data
-## importance = TRUE for permutation VIMP; without it randomForest stores
-## only IncNodePurity, which is what you would be ranking (see Details).
-rf_boston <- randomForest::randomForest(medv ~ ., Boston, importance = TRUE)
-gg_dta <- gg_vimp(rf_boston)
-plot(gg_dta)
+  ## importance = TRUE for permutation VIMP; without it randomForest stores
+  ## only IncNodePurity, which is what you would be ranking (see Details).
+  rf_boston <- randomForest::randomForest(medv ~ ., Boston,
+    importance = TRUE
+  )
+  gg_dta <- gg_vimp(rf_boston)
+  plot(gg_dta)
+}
 
 
 ## -------- mtcars data

--- a/man/plot.gg_error.Rd
+++ b/man/plot.gg_error.Rd
@@ -84,21 +84,23 @@ plot(gg_dta)
 
 
 ## ------------- Boston data
-data(Boston, package = "MASS")
-Boston$chas <- as.logical(Boston$chas)
-rfsrc_boston <- randomForestSRC::rfsrc(medv ~ .,
-  data = Boston,
-  forest = TRUE,
-  importance = TRUE,
-  tree.err = TRUE,
-  save.memory = TRUE
-)
+if (requireNamespace("MASS", quietly = TRUE)) {
+  data(Boston, package = "MASS")
+  Boston$chas <- as.logical(Boston$chas)
+  rfsrc_boston <- randomForestSRC::rfsrc(medv ~ .,
+    data = Boston,
+    forest = TRUE,
+    importance = TRUE,
+    tree.err = TRUE,
+    save.memory = TRUE
+  )
 
-# Get a data.frame containing error rates
-gg_dta <- gg_error(rfsrc_boston)
+  # Get a data.frame containing error rates
+  gg_dta <- gg_error(rfsrc_boston)
 
-# Plot the gg_error object
-plot(gg_dta)
+  # Plot the gg_error object
+  plot(gg_dta)
+}
 
 ## ------------- mtcars data
 rfsrc_mtcars <- randomForestSRC::rfsrc(mpg ~ ., data = mtcars,

--- a/man/quantile_pts.Rd
+++ b/man/quantile_pts.Rd
@@ -30,17 +30,19 @@ The output can be passed directly into the breaks argument of the
 \code{cut} function for creating groups for coplots.
 }
 \examples{
-data(Boston, package = "MASS")
-rfsrc_boston <- randomForestSRC::rfsrc(medv ~ ., Boston)
+if (requireNamespace("MASS", quietly = TRUE)) {
+  data(Boston, package = "MASS")
+  rfsrc_boston <- randomForestSRC::rfsrc(medv ~ ., Boston)
 
-# To create 6 intervals, we want 7 points.
-# quantile_pts will find balanced intervals
-rm_pts <- quantile_pts(rfsrc_boston$xvar$rm, groups = 6, intervals = TRUE)
+  # To create 6 intervals, we want 7 points.
+  # quantile_pts will find balanced intervals
+  rm_pts <- quantile_pts(rfsrc_boston$xvar$rm, groups = 6, intervals = TRUE)
 
-# Use cut to create the intervals
-rm_grp <- cut(rfsrc_boston$xvar$rm, breaks = rm_pts)
+  # Use cut to create the intervals
+  rm_grp <- cut(rfsrc_boston$xvar$rm, breaks = rm_pts)
 
-summary(rm_grp)
+  summary(rm_grp)
+}
 
 }
 \seealso{


### PR DESCRIPTION
MASS is in `Suggests`, and the CRAN Cookbook wants Suggests used conditionally in examples. This package did it both ways:

| guarded | unguarded |
|---|---|
| `gg_rfsrc.R`, `gg_variable.R`, `gg_ivarpro.R`, `plot.gg_ivarpro.R` | `gg_vimp.R`, `gg_error.R`, `plot.gg_error.R`, `quantile_pts.R` |

**Not a check failure.** MASS is `Priority: recommended`, so it is always installed and `R CMD check` passes either way. This is consistency, not a fix — found during the 3.5.0 release sweep.

Wraps the remaining four in `if (requireNamespace("MASS", quietly = TRUE)) { ... }`, matching the existing pattern. Every `Boston` reference now sits inside its guard — verified; the only `Boston` text outside one is a `## -------- Boston data` comment header.

## Verification

- `R CMD check --as-cran` with the manual: `Status: OK` (0/0/0) — examples still run.
- `lintr`: 0 lints.

Retargeted to `main` now that #164 has merged; this is a single commit on top of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)