### PR TITLE
docs(cran): note the randomForest VIMP fixes in cran-comments

### DIFF
--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,4 +1,4 @@
-## v3.5.0 — minor release (SHAP explanations; default S3 methods; survival partial-dependence labelling)
+## v3.5.0 — minor release (SHAP explanations; default S3 methods; survival partial-dependence labelling; randomForest VIMP fixes)
 
 This is a minor feature-and-fix release. It consolidates the work developed
 since the CRAN 3.4.0 release (the 3.4.1 and 3.5.0 development cycles) into a
@@ -20,6 +20,20 @@ single submission.
   `rfsrc`/`randomForest` wrappers — `gg_error()`, `gg_vimp()` and others —
   gained `default` methods, so an unsupported object now produces an
   informative error instead of dispatching somewhere unhelpful.
+* **Bug fix: `gg_vimp()` reports the importance a `randomForest` fit actually
+  computed.** A `randomForest` importance matrix stores permutation importance
+  and node impurity side by side on incommensurable scales; `gg_vimp()` ranked
+  them together, so node impurity (thousands) swept the top and the permutation
+  values the caller asked for by passing `importance = TRUE` (tens) were
+  truncated away — `randomForest(medv ~ ., Boston, importance = TRUE)` showed
+  `lstat = 12576.7` where the permutation value is `62.4`. The permutation
+  measure is now reported and node impurity left out of the ranking, for both
+  regression and classification. Alongside: `which.outcome` resolves the class
+  column by name (a `randomForest` matrix has no overall-first column, so `0`
+  had returned the first class mislabelled as overall), `nvar` counts variables
+  and ranks before trimming (it had been keeping the least-important variables),
+  and the selected measure is named in the `set` column rather than the
+  literal `"vimp"`.
 * **Bug fix: survival partial dependence is no longer mistakable for a
   probability.** `randomForestSRC::plot.variable()` defaults to
   `surv.type = "mort"`, so `gg_partial()`'s `yhat` is *mortality* — an expected
@@ -48,7 +62,7 @@ single submission.
 
 * **Local:** R 4.6.0 on macOS (aarch64-apple-darwin23).
   `R CMD check --as-cran` (with the manual) returns 0 errors, 0 warnings,
-  0 notes; overall check time under 5 minutes.
+  0 notes; overall check time under 4 minutes.
 * **Reverse-dependency check:** 0 reverse dependencies on CRAN.
 * **URL check:** `urlchecker::url_check()` reports all URLs correct.
 
@@ -61,8 +75,10 @@ The note expected at incoming feasibility is "Days since last update: 14"
 correction to 3.4.0: it lands the SHAP family, a self-contained feature set
 developed and reviewed as a unit, together with the `gg_partial()` fix in #15,
 where the plotted quantity could be read as a probability when it is an
-expected event count. I am happy to hold this release and resubmit later if the
-cadence is unwelcome.
+expected event count, and the `gg_vimp()` fixes, where a `randomForest` fit
+reported node impurity in place of the permutation importance the caller
+requested. I am happy to hold this release and resubmit later if the cadence is
+unwelcome.
 
 The gcc-UBSAN guard from v3.1.1/v3.1.2 is unchanged: the single unsupervised
 `varPro::isopro(method = "unsupv")` test still calls `skip_on_cran()` to avoid


### PR DESCRIPTION
`submit_cran()` sends `cran-comments.md` verbatim, and it described 3.5.0 as SHAP + default methods + survival labelling only — the vimp fixes merged in #164/#165 were absent, so the submission text would not have matched the tarball.

- Adds a What's-new bullet: permutation VIMP reported instead of node impurity (`lstat` 62.4, not 12576.7), `which.outcome` resolved by name, `nvar` ranks before trimming, `set` names the measure.
- Names the fix in the deliberate-submission rationale.
- Title updated; check time tightened to "under 4 minutes" (measured 3m24s locally with the manual, pre-merge; the only thing merged since is roxygen-comment guards, which don't affect check time).

Docs only — no package code, no version change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)