### PR TITLE
docs(cran): pre-submission polish — Description spelling+ORCID+Date, LICENSE, example

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,10 +2,11 @@ Package: ggRandomForests
 Type: Package
 Title: Visually Exploring Random Forests
 Version: 3.5.0
-Date: 2026-07-16
+Date: 2026-07-17
 Authors@R: person("John", "Ehrlinger",
   role = c("aut", "cre"),
-  email = "john.ehrlinger@gmail.com")
+  email = "john.ehrlinger@gmail.com",
+  comment = c(ORCID = "0000-0002-5340-5154"))
 License: MIT + file LICENSE
 Encoding: UTF-8
 Language: en-US
@@ -14,7 +15,7 @@ BugReports: https://github.com/ehrlinger/ggRandomForests/issues
 Description: Graphic elements for exploring Random Forests using the
     'randomForest' or 'randomForestSRC' package for survival, regression
     and classification forests and 'ggplot2' package plotting. Implements
-    visualisations of the methods described in Breiman (2001)
+    visualizations of the methods described in Breiman (2001)
     <doi:10.1023/A:1010933404324> and Ishwaran, Kogalur, Blackstone, and
     Lauer (2008) <doi:10.1214/08-AOAS169>.
 Depends:

--- a/LICENSE
+++ b/LICENSE
@@ -1,2 +1,2 @@
-YEAR: 2025
-COPYRIGHT HOLDER: ggRandomForests authors
+YEAR: 2026
+COPYRIGHT HOLDER: John Ehrlinger

--- a/R/plot.gg_variable.R
+++ b/R/plot.gg_variable.R
@@ -77,7 +77,7 @@
 #'                     na.action = "na.impute", ntree = 50)
 #' gg_dta <- gg_variable(rfsrc_airq)
 #'
-#' # Treat Month as an ordinal factor for better visualisation
+#' # Treat Month as an ordinal factor for better visualization
 #' gg_dta[, "Month"] <- factor(gg_dta[, "Month"])
 #'
 #' plot(gg_dta, xvar = "Wind")

--- a/man/plot.gg_variable.Rd
+++ b/man/plot.gg_variable.Rd
@@ -77,7 +77,7 @@ rfsrc_airq <- randomForestSRC::rfsrc(Ozone ~ ., data = airquality,
                     na.action = "na.impute", ntree = 50)
 gg_dta <- gg_variable(rfsrc_airq)
 
-# Treat Month as an ordinal factor for better visualisation
+# Treat Month as an ordinal factor for better visualization
 gg_dta[, "Month"] <- factor(gg_dta[, "Month"])
 
 plot(gg_dta, xvar = "Wind")


### PR DESCRIPTION
Pre-submission polish from the 3.5.0 CRAN Cookbook audit. Two commits, all changes intentional and requested.

**Commit 1 — DESCRIPTION:**
- `visualisations` → `visualizations` (British under declared `Language: en-US`; not confirmable locally, no aspell on this machine, so reasoned not measured).
- ORCID `0000-0002-5340-5154` added to `Authors@R`; parses and renders as `https://orcid.org/…`.
- `Date` `2026-07-16` → `2026-07-17`.

**Commit 2 — LICENSE + example (added on request):**
- LICENSE `COPYRIGHT HOLDER: ggRandomForests authors` → `John Ehrlinger` (matches the sole `aut`/`cre`), `YEAR` `2025` → `2026` (matches `Date`).
- `visualisation` → `visualization` in the `plot.gg_variable` example comment; `.Rd` regenerated to match.

> Note: an earlier version of this description said LICENSE and the example were "deliberately not touched." That was true of commit 1; commit 2 changed them intentionally at the maintainer's request. Description updated to match. (Copilot flagged the mismatch — the code was intended; the stale description was the defect.)

Remaining British spellings are `colouring`/`coloured` in R code comments, which CRAN's spell check doesn't read; left as-is rather than sweeping style.