### PR TITLE
fix(varpro): drop phantom "NA" category in plot.gg_varpro when nvar < p

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,13 @@ Version: 3.5.0
 
 ggRandomForests v3.5.0
 ======================
+* `plot.gg_varpro()` no longer draws a phantom "NA" category when `nvar` is
+  smaller than the number of variables the fit reports. `$imp`/`$stats` are
+  truncated to `nvar`, but the per-tree overlay (`$imp.tree`) and the
+  class-conditional data (`$conditional`) still carry every variable;
+  re-levelling those to the truncated `$imp` levels orphaned the extras to
+  `NA`, which rendered as an empty box/bar. Those rows are now dropped, so only
+  the displayed variables appear.
 * The vignettes now render their figures with `ragg` and quantise them to a
   256-colour palette, cutting the source tarball from 4.7 MB to 2.3 MB. The
   vignettes had never chosen a graphics device, so they fell through to the

--- a/R/plot.gg_varpro.R
+++ b/R/plot.gg_varpro.R
@@ -165,6 +165,10 @@ plot.gg_varpro <- function(x, type, ...) {
     long_df <- tidyr::pivot_longer(long_df, !"tree",
                                    names_to = "variable", values_to = "imp_raw")
     long_df$variable <- factor(long_df$variable, levels = levels(x$imp$variable))
+    ## imp is truncated to the displayed variables (e.g. nvar); the per-tree
+    ## matrix still carries every variable, so re-levelling orphans the rest to
+    ## NA. Drop them -- otherwise geom_jitter renders a phantom "NA" category.
+    long_df <- long_df[!is.na(long_df$variable), , drop = FALSE]
 
     ## Overlay y-values match the box scale (type-aware) --------------------
     if (identical(type, "z")) {
@@ -208,6 +212,9 @@ plot.gg_varpro <- function(x, type, ...) {
   ## Replace NA/NaN z with 0 to suppress geom_col remove_missing warnings
   cond_df$z[!is.finite(cond_df$z)] <- 0
   cond_df$variable <- factor(cond_df$variable, levels = levels(x$imp$variable))
+  ## Drop conditional rows for variables outside the displayed set (same
+  ## truncation as the faithful overlay) so no phantom "NA" bar appears.
+  cond_df <- cond_df[!is.na(cond_df$variable), , drop = FALSE]
   cutoff    <- prov$cutoff %||% 0.79
 
   ggplot2::ggplot(cond_df,

--- a/tests/testthat/test_gg_varpro.R
+++ b/tests/testthat/test_gg_varpro.R
@@ -222,36 +222,31 @@ test_that("plot.gg_varpro type='raw' with local.std=TRUE -> stop", {
 ## those to the truncated $imp levels orphaned the extras to NA, which rendered
 ## as an empty "NA" box/bar. plot.gg_varpro must drop them.
 
-## The orphaned rows land in a real "NA" category on the *variable* (discrete)
-## axis, so inspect that axis's break labels. Identify it as the axis whose
-## non-"NA" labels are non-numeric (the value axis is numeric).
-.varpro_discrete_labels <- function(p) {
-  pp   <- ggplot2::ggplot_build(p)$layout$panel_params[[1]]
-  grab <- function(ax) if (!is.null(ax) && !is.null(ax$get_labels)) ax$get_labels() else character()
-  cand <- list(grab(pp$x), grab(pp$y))
-  is_disc <- vapply(cand, function(l) {
-    l <- l[!is.na(l) & l != "NA"]
-    length(l) > 0 && all(is.na(suppressWarnings(as.numeric(l))))
-  }, logical(1))
-  unlist(cand[is_disc])
+## The `variable` scale is mapped to x (aes(x = variable)); coord_flip() flips
+## the rendering, not the aesthetic-to-scale mapping, so the variable categories
+## are always the trained x-scale range. Reading them there needs no guessing
+## about which rendered axis is discrete, and the phantom NA appears directly as
+## an NA category in that range.
+.varpro_variable_cats <- function(p) {
+  ggplot2::ggplot_build(p)$layout$panel_scales_x[[1]]$range$range
 }
 
 test_that("plot.gg_varpro faithful: no phantom 'NA' variable when nvar < p", {
-  vp   <- make_vp_regr()                  # mtcars: 10 predictors
-  gg   <- gg_varpro(vp, faithful = TRUE, nvar = 3L)
-  labs <- .varpro_discrete_labels(plot(gg))
-  expect_gt(length(labs), 0L)             # we did find the variable axis
-  expect_false(any(is.na(labs)))
-  expect_false(any(labs == "NA"))
+  # imp.tree keeps every variable, so nvar = 3 (< 10 predictors) orphans the
+  # rest -- they would collapse into an NA category without the fix.
+  vp   <- make_vp_regr()
+  cats <- .varpro_variable_cats(plot(gg_varpro(vp, faithful = TRUE, nvar = 3L)))
+  expect_gt(length(cats), 0L)
+  expect_false(anyNA(cats))
 })
 
 test_that("plot.gg_varpro conditional: no phantom 'NA' variable when nvar < p", {
-  vp   <- make_vp_class()                 # iris: 4 predictors, 3 classes
-  gg   <- gg_varpro(vp, conditional = TRUE, nvar = 2L)
-  labs <- .varpro_discrete_labels(plot(gg))
-  expect_gt(length(labs), 0L)
-  expect_false(any(is.na(labs)))
-  expect_false(any(labs == "NA"))
+  # nvar = 1 truncates below the conditional table's variable count, which is
+  # what orphans a variable to NA in the buggy path.
+  vp   <- make_vp_class()
+  cats <- .varpro_variable_cats(plot(gg_varpro(vp, conditional = TRUE, nvar = 1L)))
+  expect_gt(length(cats), 0L)
+  expect_false(anyNA(cats))
 })
 
 test_that("plot.gg_varpro type='z' with local.std=FALSE -> stop", {

--- a/tests/testthat/test_gg_varpro.R
+++ b/tests/testthat/test_gg_varpro.R
@@ -216,6 +216,44 @@ test_that("plot.gg_varpro type='raw' with local.std=TRUE -> stop", {
   expect_error(plot(gg, type = "raw"), regexp = "local\\.std")
 })
 
+## ── Regression: no phantom "NA" category when nvar < p ───────────────────────
+## gg_varpro(nvar = k) truncates $imp/$stats to k variables, but $imp.tree (the
+## per-tree matrix) and $conditional still carry every variable. Re-levelling
+## those to the truncated $imp levels orphaned the extras to NA, which rendered
+## as an empty "NA" box/bar. plot.gg_varpro must drop them.
+
+## The orphaned rows land in a real "NA" category on the *variable* (discrete)
+## axis, so inspect that axis's break labels. Identify it as the axis whose
+## non-"NA" labels are non-numeric (the value axis is numeric).
+.varpro_discrete_labels <- function(p) {
+  pp   <- ggplot2::ggplot_build(p)$layout$panel_params[[1]]
+  grab <- function(ax) if (!is.null(ax) && !is.null(ax$get_labels)) ax$get_labels() else character()
+  cand <- list(grab(pp$x), grab(pp$y))
+  is_disc <- vapply(cand, function(l) {
+    l <- l[!is.na(l) & l != "NA"]
+    length(l) > 0 && all(is.na(suppressWarnings(as.numeric(l))))
+  }, logical(1))
+  unlist(cand[is_disc])
+}
+
+test_that("plot.gg_varpro faithful: no phantom 'NA' variable when nvar < p", {
+  vp   <- make_vp_regr()                  # mtcars: 10 predictors
+  gg   <- gg_varpro(vp, faithful = TRUE, nvar = 3L)
+  labs <- .varpro_discrete_labels(plot(gg))
+  expect_gt(length(labs), 0L)             # we did find the variable axis
+  expect_false(any(is.na(labs)))
+  expect_false(any(labs == "NA"))
+})
+
+test_that("plot.gg_varpro conditional: no phantom 'NA' variable when nvar < p", {
+  vp   <- make_vp_class()                 # iris: 4 predictors, 3 classes
+  gg   <- gg_varpro(vp, conditional = TRUE, nvar = 2L)
+  labs <- .varpro_discrete_labels(plot(gg))
+  expect_gt(length(labs), 0L)
+  expect_false(any(is.na(labs)))
+  expect_false(any(labs == "NA"))
+})
+
 test_that("plot.gg_varpro type='z' with local.std=FALSE -> stop", {
   vp <- make_vp_regr()
   gg <- gg_varpro(vp, local.std = FALSE)


### PR DESCRIPTION
## Problem

`plot.gg_varpro()` draws an empty **"NA"** category (box in the faithful view, bar in the conditional view) whenever `nvar` is smaller than the number of variables the fit reports.

`gg_varpro(nvar = k)` truncates `$imp`/`$stats` to `k` variables, but the per-tree overlay (`$imp.tree`) and the class-conditional data (`$conditional`) still carry **every** variable. `plot.gg_varpro()` re-levels those to the truncated `$imp` levels, so the out-of-display variables become `NA` and render as a phantom category on the variable axis.

It surfaces readily with `varpro(sparse = FALSE)`, which reports more variables than a typical `nvar` display cap.

## Fix

Drop the orphaned (`NA`) rows after re-levelling, at both sites (faithful overlay and conditional bars), so only the displayed variables appear. Two-line change; no API or output change for the displayed variables.

## Tests

Adds regression tests for both views that assert the **variable (discrete) axis** carries no `NA` category when `nvar < p`. Verified they fail on `main` and pass with the fix. Full suite: 502 tests, 0 failures.

## Version

No version bump — the changelog entry is folded into the **unreleased v3.5.0** section, since 3.5.0 is being prepped for CRAN and this fix ships in it. DESCRIPTION and NEWS stay in sync at 3.5.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)