### PR TITLE
chore(version): drop the .9000 dev suffix (4.0.0.9000 -> 4.0.0)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: ggRandomForests
 Type: Package
 Title: Visually Exploring Random Forests
-Version: 4.0.0.9000
-Date: 2026-07-12
+Version: 4.0.0
+Date: 2026-08-05
 Authors@R: person("John", "Ehrlinger",
   role = c("aut", "cre"),
   email = "john.ehrlinger@gmail.com",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,10 @@
 Package: ggRandomForests
-Version: 4.0.0.9000
+Version: 4.0.0
 
 ggRandomForests v4.0.0 (development)
 ====================================
-* Development version 4.0.0.9000, opened after the v3.2.0 CRAN release
-  (forward-merged the v3.2.0 RMST/varPro fixes onto the dev line).
+* Development line opened after the v3.2.0 CRAN release (forward-merged the
+  v3.2.0 RMST/varPro fixes onto the dev line).
 * Begin the v4.0.0 development line: a Random Hazard Forests (RHF)
   visualization layer wrapping the 'randomForestRHF' package (added to
   Suggests). RHF support is gated — every gg_rhf* entry point checks


### PR DESCRIPTION
Brings the v4 development line in line with the repo's versioning rule: straight three-digit semver, no `.9000` dev suffix, no fourth digit. Increments go on the patch digit as work lands.

## Changes

| File | Change |
|---|---|
| `DESCRIPTION` | `Version: 4.0.0.9000` -> `4.0.0`; `Date` refreshed to the bump date |
| `NEWS.md` | `Version:` line to match (a test greps NEWS for the exact DESCRIPTION version) |
| `NEWS.md` | the bullet that spelled out "Development version 4.0.0.9000" reworded |

The NEWS heading already reads `ggRandomForests v4.0.0 (development)`, so `test_ggrandomforests_news.R`'s grep still matches.

## Verification

- `devtools::test(filter = "news|namespace_hygiene")` — `FAIL 0 | PASS 6 | SKIP 1` (the skip is the clean-session test, which only runs under `R CMD check`)
- No remaining `4.0.0.9000` outside `docs/`

## Not changed

`docs/` still carries `4.0.0.9000` in the generated pkgdown site. That's build output and the pkgdown workflow regenerates it — hand-editing it would just create drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)