### PR TITLE
Merge main (v3.5.1: gcc-UBSAN partialpro/isopro fix) into dev_rhf

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: ggRandomForests
 Type: Package
 Title: Visually Exploring Random Forests
-Version: 3.5.0
-Date: 2026-08-04
+Version: 3.5.1
+Date: 2026-08-05
 Authors@R: person("John", "Ehrlinger",
   role = c("aut", "cre"),
   email = "john.ehrlinger@gmail.com",

--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,20 @@ ggRandomForests v3.5.1
   rule about the package, which is why the `partialpro()` route went unnoticed.
   They now state the actual condition -- any `rfsrc` grow reached without a
   formula -- and name the paths that satisfy it.
+* An audit of the rest of the package found one more call on the same path:
+  the `\donttest` example in `?gg_partial_varpro` used the object path without
+  `method = "rnd"`. It did not fire on CRAN only because that check flavor did
+  not run `\donttest` code, which is CRAN's setting to change rather than ours,
+  so the example now passes `method = "rnd"` too. Every other varPro entry
+  point is clean: `gg_varpro()`, `gg_ivarpro()`, `gg_udependent()`,
+  `uvarpro()` (defaults to a formula-based `method = "auto"`) and every
+  `isopro()` call in the package, all of which name `method = "rnd"`.
+* `?gg_partial_varpro` now documents the underlying issue rather than leaving
+  it to the tests. Any `gg_partial_varpro(object = )` call reaches it, because
+  `partialpro()` grows its isolation forest with `isopro()`'s default
+  `method = "unsupv"`. It is benign -- the pointer is formed, never
+  dereferenced -- and the fix belongs upstream (`kogalur/randomForestSRC` PR
+  #478); `method = "rnd"` avoids it in the meantime.
 
 ggRandomForests v3.5.0
 ======================

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,13 +8,12 @@ ggRandomForests v3.5.1
   `randomForestSRC` hand `yvar.wt = numeric(0)` to its native code and
   decrement that zero-length pointer (`entry.c:184`). The route was indirect:
   `gg_partial_varpro()` calls `varPro::partialpro()`, which grows its own
-  `isopro()` forest and lets `method` default to `"unsupv"`. `partialpro()`
-  quietly downgrades to the safe `"rnd"` method when only one variable
-  survives its screen, so every test using `nvars = 1` was rescued by accident
-  and the one test that deliberately asks for two variables was not. That test
-  now requests `method = "rnd"` itself; it asserts the same warnings over the
-  same number of rows. No user-facing code changed -- `ggRandomForests` is pure
-  R, and the undefined behaviour is upstream.
+  `isopro()` forest and lets `method` default to `"unsupv"`. The other
+  live-`partialpro()` tests were already `skip_on_cran()`'d, which left this
+  one as the only one running on CRAN. It now requests `method = "rnd"`
+  itself; it asserts the same warnings over the same number of rows. No
+  user-facing code changed -- `ggRandomForests` is pure R, and the undefined
+  behaviour is upstream.
 * The comments in the varPro test fixtures claimed the report fires only for
   `isopro(method = "unsupv")`. That was true of direct calls and wrong as a
   rule about the package, which is why the `partialpro()` route went unnoticed.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,25 @@
 Package: ggRandomForests
-Version: 3.5.0
+Version: 3.5.1
+
+ggRandomForests v3.5.1
+======================
+* Test-only fix for the `gcc-UBSAN` additional issue reported against 3.5.0.
+  One test grew an isolation forest with no outcome, which makes
+  `randomForestSRC` hand `yvar.wt = numeric(0)` to its native code and
+  decrement that zero-length pointer (`entry.c:184`). The route was indirect:
+  `gg_partial_varpro()` calls `varPro::partialpro()`, which grows its own
+  `isopro()` forest and lets `method` default to `"unsupv"`. `partialpro()`
+  quietly downgrades to the safe `"rnd"` method when only one variable
+  survives its screen, so every test using `nvars = 1` was rescued by accident
+  and the one test that deliberately asks for two variables was not. That test
+  now requests `method = "rnd"` itself; it asserts the same warnings over the
+  same number of rows. No user-facing code changed -- `ggRandomForests` is pure
+  R, and the undefined behaviour is upstream.
+* The comments in the varPro test fixtures claimed the report fires only for
+  `isopro(method = "unsupv")`. That was true of direct calls and wrong as a
+  rule about the package, which is why the `partialpro()` route went unnoticed.
+  They now state the actual condition -- any `rfsrc` grow reached without a
+  formula -- and name the paths that satisfy it.
 
 ggRandomForests v3.5.0
 ======================

--- a/R/gg_partial_varpro.R
+++ b/R/gg_partial_varpro.R
@@ -21,6 +21,18 @@
 #' with others, the two methods can disagree, and \code{partialpro}'s
 #' curve is the one restricted to the data manifold.
 #'
+#' That isolation forest is worth one note. \code{partialpro} grows it with
+#' \code{varPro::isopro}, whose \code{method} defaults to \code{"unsupv"} --
+#' a forest with no outcome. \code{randomForestSRC} then passes a zero-length
+#' \code{yvar.wt} into its native code and decrements that pointer
+#' (\code{entry.c:184}), which is undefined behaviour and is reported by
+#' UBSAN builds. It is benign in practice -- the pointer is formed but never
+#' dereferenced -- and it is an upstream issue rather than one this package
+#' can fix (\code{ggRandomForests} is pure R); a one-line guard is proposed
+#' in \code{kogalur/randomForestSRC} PR #478. Passing \code{method = "rnd"}
+#' through to \code{partialpro} avoids the unsupervised grow entirely, which
+#' is what this package's own tests and examples do.
+#'
 #' Second, \code{partialpro} fits a local polynomial model to the
 #' predicted values rather than just plotting their mean. That gives
 #' three parallel curves per variable, stored as \code{yhat.par},
@@ -268,8 +280,10 @@
 #' setdiff(wanted, vp$xvar.names)
 #'
 #' ## Ask anyway and we warn, naming what partialpro() would have dropped
-#' ## in silence.
-#' pd <- gg_partial_varpro(object = vp, xvar.names = wanted)
+#' ## in silence.  (method = "rnd" is passed through to partialpro(); see
+#' ## the note on isolation-forest method in Details.)
+#' pd <- gg_partial_varpro(object = vp, xvar.names = wanted,
+#'                         method = "rnd")
 #'
 #' ## Refitting without the split-weight screen reaches every predictor.
 #' vp_all <- varPro::varpro(mpg ~ ., data = mtcars, ntree = 50,

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,3 +1,51 @@
+## v3.5.1 — patch release (fixes the gcc-UBSAN additional issue in 3.5.0)
+
+Submitted in response to the CRAN check request of 2026-08-05 (correct before
+2026-08-21). This release fixes only the `gcc-UBSAN` additional issue; all
+other flavors were OK on 3.5.0.
+
+### The report
+
+`entry.c:184` in `randomForestSRC`:
+
+```c
+RF_yWeight = REAL(yWeight);  RF_yWeight--;
+```
+
+`randomForestSRC` decrements the `yvar.wt` pointer to index from 1. A forest
+grown with no outcome makes `rfsrc` pass `yvar.wt = numeric(0)`, so the
+decrement runs off a zero-length allocation — the "use of 0x1" the report
+describes. `ggRandomForests` has no compiled code; the undefined behaviour is
+upstream, and this release removes the call path that reaches it.
+
+### The path, and the fix
+
+One test grew that forest indirectly. `gg_partial_varpro()` calls
+`varPro::partialpro()`, which grows its own isolation forest through
+`isopro()` and lets `method` default to `"unsupv"`. `partialpro()` downgrades
+to the safe `"rnd"` method when only one variable survives its screen, so the
+tests using `nvars = 1` were unaffected; the one test that deliberately
+requests two reachable variables was not, and it ran on CRAN.
+
+That test now passes `method = "rnd"` itself. Verified by tracing every
+`rfsrc` grow across the suite under CRAN skip semantics: 311 grows, 0 reached
+without a formula (previously 2, both in that one test). The test asserts the
+same warnings over the same number of rows, so CRAN coverage is unchanged.
+
+No user-facing code changed — the diff is five test files plus `DESCRIPTION`
+and `NEWS.md`.
+
+### Test environments
+
+* local macOS (darwin), R 4.6.1 — `R CMD check --as-cran` with the manual:
+  **0 ERRORs, 0 WARNINGs, 1 NOTE**. Total check time 4m11s.
+
+The one NOTE is `Days since last update: 1` / `Number of updates in past 6
+months: 7`. This submission is the requested fix for the 3.5.0 check failure,
+which is why it follows so closely.
+
+---
+
 ## v3.5.0 — minor release (SHAP explanations; default S3 methods; survival partial-dependence labeling; randomForest VIMP fixes)
 
 This is a minor feature-and-fix release. It consolidates the work developed

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -22,10 +22,9 @@ upstream, and this release removes the call path that reaches it.
 
 One test grew that forest indirectly. `gg_partial_varpro()` calls
 `varPro::partialpro()`, which grows its own isolation forest through
-`isopro()` and lets `method` default to `"unsupv"`. `partialpro()` downgrades
-to the safe `"rnd"` method when only one variable survives its screen, so the
-tests using `nvars = 1` were unaffected; the one test that deliberately
-requests two reachable variables was not, and it ran on CRAN.
+`isopro()` and lets `method` default to `"unsupv"`. The package's other
+live-`partialpro()` tests were already `skip_on_cran()`'d for runtime, which
+left this one as the only one running on CRAN — and so the only one reported.
 
 That test now passes `method = "rnd"` itself. Verified by tracing every
 `rfsrc` grow across the suite under CRAN skip semantics: 311 grows, 0 reached

--- a/man/gg_partial_varpro.Rd
+++ b/man/gg_partial_varpro.Rd
@@ -216,6 +216,18 @@ regardless of plausibility. So when a covariate is highly correlated
 with others, the two methods can disagree, and \code{partialpro}'s
 curve is the one restricted to the data manifold.
 
+That isolation forest is worth one note. \code{partialpro} grows it with
+\code{varPro::isopro}, whose \code{method} defaults to \code{"unsupv"} --
+a forest with no outcome. \code{randomForestSRC} then passes a zero-length
+\code{yvar.wt} into its native code and decrements that pointer
+(\code{entry.c:184}), which is undefined behaviour and is reported by
+UBSAN builds. It is benign in practice -- the pointer is formed but never
+dereferenced -- and it is an upstream issue rather than one this package
+can fix (\code{ggRandomForests} is pure R); a one-line guard is proposed
+in \code{kogalur/randomForestSRC} PR #478. Passing \code{method = "rnd"}
+through to \code{partialpro} avoids the unsupervised grow entirely, which
+is what this package's own tests and examples do.
+
 Second, \code{partialpro} fits a local polynomial model to the
 predicted values rather than just plotting their mean. That gives
 three parallel curves per variable, stored as \code{yhat.par},
@@ -306,8 +318,10 @@ wanted <- c("wt", "hp", "qsec", "vs")
 setdiff(wanted, vp$xvar.names)
 
 ## Ask anyway and we warn, naming what partialpro() would have dropped
-## in silence.
-pd <- gg_partial_varpro(object = vp, xvar.names = wanted)
+## in silence.  (method = "rnd" is passed through to partialpro(); see
+## the note on isolation-forest method in Details.)
+pd <- gg_partial_varpro(object = vp, xvar.names = wanted,
+                        method = "rnd")
 
 ## Refitting without the split-weight screen reaches every predictor.
 vp_all <- varPro::varpro(mpg ~ ., data = mtcars, ntree = 50,

--- a/tests/testthat/helper-varpro-fixtures.R
+++ b/tests/testthat/helper-varpro-fixtures.R
@@ -2,11 +2,22 @@
 # beta.varpro() is the expensive call (per-rule glmnet); compute once per R
 # session and reuse. In-memory only — no disk cache.
 #
-# These all grow *supervised* varpro/ivarpro/beta.varpro forests (a real Y), so
-# yvar.wt is non-empty and they do NOT trip randomForestSRC's gcc-UBSAN report
-# at entry.c:184 (that fires only for the unsupervised family — verified under
-# -fsanitize=undefined). They intentionally run on CRAN; do not skip_on_cran().
-# Only the unsupervised isopro grow is skipped (see test_gg_isopro.R).
+# randomForestSRC's gcc-UBSAN report at entry.c:184 fires for any rfsrc grow
+# with NO outcome: rfsrc passes yvar.wt = numeric(0) and the native code
+# decrements that zero-length pointer. The test is therefore not "is this
+# function unsupervised?" but "does this call reach rfsrc without a formula?",
+# which can happen several layers down:
+#   * varPro::isopro(method = "unsupv")   — direct; skipped (test_gg_isopro.R)
+#   * varPro::partialpro()                — calls isopro() internally and lets
+#     it default to "unsupv" whenever more than one variable survives, so
+#     gg_partial_varpro() reaches it without ever naming isopro. This is what
+#     escaped the 3.5.0 audit; see test_gg_partial_varpro.R.
+# uvarpro() defaults to method = "auto" and isopro(method = "rnd"/"auto") both
+# pass a formula, so those are supervised grows and are clean.
+#
+# The fixtures below all grow *supervised* varpro/ivarpro/beta.varpro forests
+# (a real Y), so yvar.wt is non-empty. They intentionally run on CRAN; do not
+# skip_on_cran().
 
 .varpro_cache <- new.env(parent = emptyenv())
 

--- a/tests/testthat/test_gg_isopro.R
+++ b/tests/testthat/test_gg_isopro.R
@@ -2,12 +2,16 @@
 # Phase 4 of the v2.8.0 varPro integration.
 
 make_iso_fit <- function(seed = 1L, method = "rnd", ntree = 25, sampsize = 16) {
-  # Only the *unsupervised* isopro grow (method = "unsupv") trips
-  # randomForestSRC's gcc-UBSAN report at entry.c:184 (length-0 yvar.wt
-  # decremented to an out-of-bounds pointer; upstream bug, ggRandomForests is
-  # pure R). The default method = "rnd" builds a synthetic-supervised forest and
-  # is UBSAN-clean — verified under -fsanitize=undefined. So skip_on_cran() only
-  # the unsupervised path; the rnd tests run on CRAN. Both run in CI and locally.
+  # Of the *direct* isopro grows only method = "unsupv" trips randomForestSRC's
+  # gcc-UBSAN report at entry.c:184 (length-0 yvar.wt decremented to an
+  # out-of-bounds pointer; upstream bug, ggRandomForests is pure R). The default
+  # method = "rnd" passes a formula and is UBSAN-clean — verified under
+  # -fsanitize=undefined. So skip_on_cran() only the unsupervised path; the rnd
+  # tests run on CRAN. Both run in CI and locally.
+  #
+  # This guard covers direct calls only. varPro::partialpro() also reaches
+  # isopro() and lets it default to "unsupv"; that path is guarded separately in
+  # test_gg_partial_varpro.R. See helper-varpro-fixtures.R for the full picture.
   if (identical(method, "unsupv")) testthat::skip_on_cran()
   testthat::skip_if_not_installed("varPro")
   set.seed(seed)

--- a/tests/testthat/test_gg_partial_varpro.R
+++ b/tests/testthat/test_gg_partial_varpro.R
@@ -682,14 +682,23 @@ test_that("gg_partial_varpro: object path warns on unreachable xvar.names", {
               "need >= 2 reachable variables")
   reachable <- reachable[1:2]
 
+  # method = "rnd" is required, not cosmetic. varPro::partialpro() grows an
+  # isolation forest via isopro(), and isopro()'s default method is "unsupv" --
+  # a forest with no y, so rfsrc sends yvar.wt = numeric(0) to the native code
+  # and entry.c:184 decrements that zero-length pointer (upstream rfsrc UB;
+  # ggRandomForests is pure R). partialpro() silently downgrades to "rnd" when
+  # only one variable survives, which is why the nvars = 1 tests above are
+  # unaffected -- but this test needs two, so it must ask for "rnd" itself.
+  # Asserted behavior is unchanged: same warnings, same rows.
   expect_warning(
     gg_partial_varpro(object = vp,
-                      xvar.names = c(reachable, unreachable[1])),
+                      xvar.names = c(reachable, unreachable[1]),
+                      method = "rnd"),
     regexp = unreachable[1]
   )
   # asking only for reachable variables stays quiet
   expect_no_warning(
-    gg_partial_varpro(object = vp, xvar.names = reachable)
+    gg_partial_varpro(object = vp, xvar.names = reachable, method = "rnd")
   )
 })
 

--- a/tests/testthat/test_gg_partial_varpro.R
+++ b/tests/testthat/test_gg_partial_varpro.R
@@ -686,9 +686,15 @@ test_that("gg_partial_varpro: object path warns on unreachable xvar.names", {
   # isolation forest via isopro(), and isopro()'s default method is "unsupv" --
   # a forest with no y, so rfsrc sends yvar.wt = numeric(0) to the native code
   # and entry.c:184 decrements that zero-length pointer (upstream rfsrc UB;
-  # ggRandomForests is pure R). partialpro() silently downgrades to "rnd" when
-  # only one variable survives, which is why the nvars = 1 tests above are
-  # unaffected -- but this test needs two, so it must ask for "rnd" itself.
+  # ggRandomForests is pure R).
+  #
+  # Note this is NOT specific to this test: every gg_partial_varpro(object=)
+  # call reaches it. partialpro() computes over all of the fit's topvars, and
+  # our nvars argument trims the returned list afterwards, so nvars never
+  # reaches partialpro() and cannot avoid the grow. The other live-partialpro
+  # blocks in this file are already skip_on_cran()'d, which left this one as
+  # the only one running on CRAN -- and so the only one that got reported.
+  # Any NEW test calling the object path on CRAN must pass method = "rnd" too.
   # Asserted behavior is unchanged: same warnings, same rows.
   expect_warning(
     gg_partial_varpro(object = vp,

--- a/tests/testthat/test_gg_udependent.R
+++ b/tests/testthat/test_gg_udependent.R
@@ -3,9 +3,10 @@
 ## ── Helpers ──────────────────────────────────────────────────────────────────
 
 make_uvp <- function(ntree = 25L) {
-  # uvarpro() grows a *synthetic-supervised* forest (yxyz123 ~ ., random Y), so
-  # yvar.wt is non-empty and it does NOT trip the entry.c:184 gcc-UBSAN report
-  # (only the truly-unsupervised isopro grow does). Runs on CRAN.
+  # uvarpro() defaults to method = "auto", which grows a multivariate forest
+  # from a real formula, so yvar.wt is non-empty and it does NOT trip the
+  # entry.c:184 gcc-UBSAN report. Runs on CRAN. See helper-varpro-fixtures.R
+  # for the calls that DO reach rfsrc without a formula.
   set.seed(42L)
   varPro::uvarpro(iris[, -5L], ntree = ntree)
 }

--- a/tests/testthat/test_gg_varpro.R
+++ b/tests/testthat/test_gg_varpro.R
@@ -5,7 +5,8 @@
 # Regression fit — fast, always available (mtcars is base R)
 make_vp_regr <- function(ntree = 25L) {
   # Supervised varpro grow (real Y) — UBSAN-clean; runs on CRAN. See
-  # helper-varpro-fixtures.R for why varPro grows are safe except isopro(unsupv).
+  # helper-varpro-fixtures.R for which varPro calls reach rfsrc without a
+  # formula and so trip entry.c:184.
   set.seed(42L)
   varPro::varpro(mpg ~ ., data = mtcars, ntree = ntree)
 }


### PR DESCRIPTION
Forward-merge #7. Brings the 3.5.1 CRAN patch ([#177](https://github.com/ehrlinger/ggRandomForests/pull/177)) onto the v4 line.

## ⚠️ Merge with a real merge commit — do NOT squash

Squashing collapses this to a single parent, so `main` stops being an ancestor of `dev_rhf` and the merge-base freezes. That is what previously pinned the base at v3.0.0 and made every later forward-merge re-diff from there, re-surfacing the same eight conflicts and turning shared files into bogus add/add collisions.

It's working: **this merge had 2 conflicts, not 8.**

## What arrives

The `gg_partial_varpro()` object path no longer reaches an unsupervised `isopro()` grow in either the test suite or the Rd example, and `?gg_partial_varpro` now documents the upstream `randomForestSRC` `entry.c:184` issue.

## Conflicts resolved

| File | Resolution |
|---|---|
| `DESCRIPTION` | keep dev's `Version: 4.0.0.9000`, take main's newer `Date` |
| `NEWS.md` | keep dev's `Version:` line and the `v4.0.0` section on top, splice main's `v3.5.1` section in above `v3.5.0` |

`NEWS.md` line 2 is greped against the exact `DESCRIPTION` version by `test_ggrandomforests_news.R`, so those two must stay in step.

## Ordering with #178

Merge **this PR first**, then [#178](https://github.com/ehrlinger/ggRandomForests/pull/178) (`4.0.0.9000 -> 4.0.0`). This branch deliberately keeps `4.0.0.9000`, so #178 then applies cleanly on top of it. The reverse order makes both PRs edit the same `DESCRIPTION`/`NEWS.md` lines and forces a second manual resolution.

## Verification

- `lintr::lint_package()` — 0 lints
- `NOT_CRAN=true devtools::test()` — `FAIL 0 | PASS 1513 | SKIP 6`
- Merge commit has 2 parents

🤖 Generated with [Claude Code](https://claude.com/claude-code)