### PR TITLE
docs(cran-comments): record win-builder R-devel and R-release results

### DIFF
--- a/cran-comments.md
+++ b/cran-comments.md
@@ -61,8 +61,9 @@ months: 7`. This submission is the fix you requested on 2026-08-05 for the
 why it follows the previous release so closely. I would not otherwise submit
 on this cadence.
 
-The change is deliberately narrow: five test files, one roxygen block, and the
-version metadata. There is **no executable R code change** in this release --
+The change is deliberately narrow: five test files, one roxygen block with its
+regenerated `.Rd`, and the version metadata (`DESCRIPTION`, `NEWS.md`) -- the
+same list given above. There is **no executable R code change** in this release --
 the diff over `R/` between v3.5.0 and v3.5.1 is comments only -- so the
 runtime profile is identical to the 3.5.0 you accepted on 2026-08-04.
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -31,8 +31,14 @@ That test now passes `method = "rnd"` itself. Verified by tracing every
 without a formula (previously 2, both in that one test). The test asserts the
 same warnings over the same number of rows, so CRAN coverage is unchanged.
 
-No user-facing code changed — the diff is five test files plus `DESCRIPTION`
-and `NEWS.md`.
+No user-facing code changed — the diff is five test files, one roxygen block
+documenting the issue (with its regenerated `.Rd`), `DESCRIPTION` and
+`NEWS.md`. Nothing executable in `R/` changed.
+
+The same audit found the `\donttest` example in `?gg_partial_varpro` on that
+same path; it did not fire under gcc-UBSAN because that flavor did not run
+`\donttest` code, but it is fixed here too rather than left to a future
+check-flavor change.
 
 ### Test environments
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -36,12 +36,29 @@ and `NEWS.md`.
 
 ### Test environments
 
-* local macOS (darwin), R 4.6.1 — `R CMD check --as-cran` with the manual:
-  **0 ERRORs, 0 WARNINGs, 1 NOTE**. Total check time 4m11s.
+* **Local:** macOS (darwin), R 4.6.1 — `R CMD check --as-cran` with the
+  manual, built from a clean `git archive` export: **0 ERRORs, 0 WARNINGs,
+  1 NOTE**. Total check time 4m44s.
+* **win-builder:** x86_64-w64-mingw32, Windows Server 2022.
+  * R-devel (2026-08-04 r90350 ucrt) — **0 ERRORs, 0 WARNINGs, 1 NOTE**.
+  * R-release (R 4.6.1) — **0 ERRORs, 0 WARNINGs, 1 NOTE**.
+  * PDF and HTML manuals build on both; vignettes re-build on both.
+
+Both win-builder runs report the same single NOTE as the local check, and
+nothing else.
+
+### NOTE disposition
 
 The one NOTE is `Days since last update: 1` / `Number of updates in past 6
-months: 7`. This submission is the requested fix for the 3.5.0 check failure,
-which is why it follows so closely.
+months: 7`. This submission is the fix you requested on 2026-08-05 for the
+`gcc-UBSAN` additional issue in 3.5.0, with a 2026-08-21 deadline, which is
+why it follows the previous release so closely. I would not otherwise submit
+on this cadence.
+
+The change is deliberately narrow: five test files, one roxygen block, and the
+version metadata. There is **no executable R code change** in this release --
+the diff over `R/` between v3.5.0 and v3.5.1 is comments only -- so the
+runtime profile is identical to the 3.5.0 you accepted on 2026-08-04.
 
 ---
 


### PR DESCRIPTION
Records the win-builder results for the 3.5.1 submission, matching the practice from `938aae1f` (the equivalent step for 3.5.0).

## Results

| Environment | R | Status |
|---|---|---|
| Local macOS, `--as-cran` with manual, from clean `git archive` | 4.6.1 | 0 / 0 / **1 NOTE** |
| win-builder | R-devel (r90350 ucrt) | 0 / 0 / **1 NOTE** |
| win-builder | R-release (4.6.1) | 0 / 0 / **1 NOTE** |

All three report the *same* NOTE — `Days since last update: 1` / `Number of updates in past 6 months: 7` — and nothing else. PDF and HTML manuals build on both win-builder runs; vignettes re-build on both.

R-oldrelease had not come back yet and is deliberately not recorded rather than guessed at.

## Also in this change

- Corrects the local check time to **4m44s**. The 4m11s recorded earlier was from the run *before* the Rd/roxygen changes landed, so it described a tarball that was never submitted.
- Splits NOTE disposition into its own section, matching the shape of the 3.5.0 entry.
- The disposition now names the 2026-08-05 request and 2026-08-21 deadline as the reason for the cadence, and states that `R/` carries **no executable change** between v3.5.0 and v3.5.1 (the diff is comments only) — so the runtime profile is identical to the 3.5.0 CRAN accepted on 2026-08-04. That is the specific fact that answers "why another release one day later".

## Follow-up

Once this merges, the `dev_rhf` forward-merge gets re-cut from current `dev_rhf` (which is now `4.0.0` after #178) and [#179](https://github.com/ehrlinger/ggRandomForests/pull/179) closed — it went `CONFLICTING` on the same two files when #178 landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)