### PR TITLE
docs(cran-comments): record win-builder R-oldrelease; disclose check times

### DIFF
--- a/cran-comments.md
+++ b/cran-comments.md
@@ -45,13 +45,22 @@ check-flavor change.
 * **Local:** macOS (darwin), R 4.6.1 — `R CMD check --as-cran` with the
   manual, built from a clean `git archive` export: **0 ERRORs, 0 WARNINGs,
   1 NOTE**. Total check time 4m44s.
-* **win-builder:** x86_64-w64-mingw32, Windows Server 2022.
-  * R-devel (2026-08-04 r90350 ucrt) — **0 ERRORs, 0 WARNINGs, 1 NOTE**.
-  * R-release (R 4.6.1) — **0 ERRORs, 0 WARNINGs, 1 NOTE**.
-  * PDF and HTML manuals build on both; vignettes re-build on both.
+* **win-builder:** x86_64-w64-mingw32, Windows Server 2022 — all three
+  branches, each **0 ERRORs, 0 WARNINGs, 1 NOTE**:
+  * R-devel (2026-08-04 r90350 ucrt)
+  * R-release (R 4.6.1)
+  * R-oldrelease (R 4.5.3)
+  * PDF and HTML manuals build on all three; vignettes re-build on all three.
 
-Both win-builder runs report the same single NOTE as the local check, and
-nothing else.
+All four checks report the same single NOTE and nothing else.
+
+On check time: the win-builder totals are roughly 8 minutes (R-release),
+10 minutes (R-devel) and 12 minutes (R-oldrelease), with the vignette rebuild
+the dominant term in each. I want to flag rather than hide that: this release
+contains **no executable R code change**, so the runtime is unchanged from the
+3.5.0 your own check farm ran and accepted on 2026-08-04. If check time is a
+concern, the vignette rebuild is the lever and I am glad to precompute further,
+as I did for 3.1.0.
 
 ### NOTE disposition
 


### PR DESCRIPTION
Completes the win-builder record for 3.5.1. R-oldrelease came back after [#180](https://github.com/ehrlinger/ggRandomForests/pull/180) merged.

## All four checks

| Environment | R | Status | Examples | Tests | Vignettes | Timed total |
|---|---|---|---|---|---|---|
| Local macOS `--as-cran` + manual | 4.6.1 | 0 / 0 / **1 NOTE** | | | | 4m44s |
| win-builder R-release | 4.6.1 | 0 / 0 / **1 NOTE** | 49s | 124s | 236s | ~8m15s |
| win-builder R-devel | r90350 | 0 / 0 / **1 NOTE** | 52s | 188s | 289s | ~10m01s |
| win-builder R-oldrelease | 4.5.3 | 0 / 0 / **1 NOTE** | 73s | 178s | **379s** | ~12m15s |

Same single NOTE everywhere (`Days since last update: 1` / `7 updates in past 6 months`). PDF and HTML manuals build on all three win-builder branches.

## Why the check times are now disclosed in cran-comments

R-oldrelease is ~12m15s, with the vignette rebuild alone at 379s — over half the total. That is above the ~10 minute guidance, and **CRAN archived ggRandomForests 3.1.0 over exactly this**. Better to state it with the mitigation on offer than to have it raised.

The reason it isn't a regression is the same fact that answers the cadence NOTE: **no executable R change** between 3.5.0 and 3.5.1, so the runtime is identical to the 3.5.0 CRAN's own check farm ran and accepted on 2026-08-04. win-builder's oldrelease box is slower than CRAN's farm; this is a property of the measuring machine, not of the package.

The comments now offer to precompute the vignettes further if check time is a concern — the same fix applied for 3.1.0, and the pattern is already in the package.

## Note for 2026-08-19

All four results will be ~2 weeks stale when submissions reopen. Per [the task note](../blob/main/README.md), re-run win-builder **R-devel** at minimum before submitting and refresh these numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)