### PR TITLE
chore: regenerate with roxygen2 8.1.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -51,5 +51,5 @@ Suggests:
     testthat,
     vdiffr
 VignetteBuilder: quarto
-Config/roxygen2/version: 8.0.0
+Config/roxygen2/version: 8.1.0
 Roxygen: list(markdown = TRUE)

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -144,61 +144,79 @@ export(shap_dependence)
 export(shap_importance)
 export(surv_partial.rfsrc)
 export(varpro_feature_names)
-importFrom(dplyr,all_of)
-importFrom(dplyr,filter)
-importFrom(dplyr,mutate)
-importFrom(dplyr,select)
-importFrom(ggplot2,.data)
-importFrom(ggplot2,aes)
-importFrom(ggplot2,autoplot)
-importFrom(ggplot2,coord_flip)
-importFrom(ggplot2,facet_wrap)
-importFrom(ggplot2,geom_boxplot)
-importFrom(ggplot2,geom_col)
-importFrom(ggplot2,geom_hline)
-importFrom(ggplot2,geom_jitter)
-importFrom(ggplot2,geom_line)
-importFrom(ggplot2,geom_point)
-importFrom(ggplot2,geom_ribbon)
-importFrom(ggplot2,geom_segment)
-importFrom(ggplot2,geom_vline)
-importFrom(ggplot2,ggplot)
-importFrom(ggplot2,labs)
-importFrom(ggplot2,scale_color_manual)
-importFrom(ggplot2,scale_fill_manual)
-importFrom(ggplot2,theme)
-importFrom(ggplot2,theme_minimal)
-importFrom(ggplot2,theme_void)
-importFrom(igraph,E)
-importFrom(igraph,V)
-importFrom(igraph,as_data_frame)
-importFrom(igraph,degree)
-importFrom(igraph,delete_vertices)
-importFrom(igraph,edge_attr)
-importFrom(igraph,graph_from_adjacency_matrix)
-importFrom(igraph,vertex_attr)
+importFrom(dplyr,
+  all_of,
+  filter,
+  mutate,
+  select
+)
+importFrom(ggplot2,
+  .data,
+  aes,
+  autoplot,
+  coord_flip,
+  facet_wrap,
+  geom_boxplot,
+  geom_col,
+  geom_hline,
+  geom_jitter,
+  geom_line,
+  geom_point,
+  geom_ribbon,
+  geom_segment,
+  geom_vline,
+  ggplot,
+  labs,
+  scale_color_manual,
+  scale_fill_manual,
+  theme,
+  theme_minimal,
+  theme_void
+)
+importFrom(igraph,
+  E,
+  V,
+  as_data_frame,
+  degree,
+  delete_vertices,
+  edge_attr,
+  graph_from_adjacency_matrix,
+  vertex_attr
+)
 importFrom(patchwork,wrap_plots)
 importFrom(randomForest,randomForest)
-importFrom(randomForestSRC,partial.rfsrc)
-importFrom(randomForestSRC,vimp)
-importFrom(stats,as.formula)
-importFrom(stats,median)
-importFrom(stats,model.frame)
-importFrom(stats,model.response)
-importFrom(stats,na.omit)
-importFrom(stats,predict)
-importFrom(stats,qnorm)
-importFrom(stats,quantile)
-importFrom(stats,xtabs)
+importFrom(randomForestSRC,
+  partial.rfsrc,
+  vimp
+)
+importFrom(stats,
+  as.formula,
+  median,
+  model.frame,
+  model.response,
+  na.omit,
+  predict,
+  qnorm,
+  quantile,
+  xtabs
+)
 importFrom(stringr,str_sub)
-importFrom(survival,Surv)
-importFrom(survival,strata)
-importFrom(survival,survfit)
-importFrom(tidyr,all_of)
-importFrom(tidyr,pivot_longer)
-importFrom(utils,head)
-importFrom(utils,tail)
-importFrom(varPro,get.beta.entropy)
-importFrom(varPro,importance)
-importFrom(varPro,partialpro)
-importFrom(varPro,sdependent)
+importFrom(survival,
+  Surv,
+  strata,
+  survfit
+)
+importFrom(tidyr,
+  all_of,
+  pivot_longer
+)
+importFrom(utils,
+  head,
+  tail
+)
+importFrom(varPro,
+  get.beta.entropy,
+  importance,
+  partialpro,
+  sdependent
+)


### PR DESCRIPTION
CI installs roxygen2 8.1.0 while `DESCRIPTION` declared 8.0.0. On temporal_hazard that made the roxygen-currency check fail on a **version stamp rather than a doc change** — and its advice (`run roxygenise() and commit`) produced nothing locally, because on 8.0.0 there was nothing to write.

Regenerating portfolio-wide so committed output matches the version CI runs.

## What changes

Cosmetic only:

- `DESCRIPTION` consolidates to a single `Config/roxygen2/version` field — 8.1.0 drops the redundant `RoxygenNote`
- `NAMESPACE` regroups `importFrom()` calls into multi-line form, which is semantically identical

**No exports changed.** Verified across all eight packages before committing.

Where a workflow invokes roxygen, it is now pinned at `any::roxygen2@8.1.0` — roxygen2 writes its own version into `DESCRIPTION`, so an unpinned upgrade is self-inflicting. devtools pulls it in transitively, which is how it stayed unpinned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)