### PR TITLE
perf(examples): bound every roxygen rfsrc fit with an explicit ntree

### DIFF
--- a/R/calc_roc.R
+++ b/R/calc_roc.R
@@ -77,7 +77,7 @@
 #'
 #' @examples
 #' ## Taken from the gg_roc example
-#' rfsrc_iris <- randomForestSRC::rfsrc(Species ~ ., data = iris)
+#' rfsrc_iris <- randomForestSRC::rfsrc(Species ~ ., data = iris, ntree = 100)
 #'
 #' gg_dta <- calc_roc(rfsrc_iris, rfsrc_iris$yvar,
 #'   which_outcome = 1, oob = TRUE
@@ -309,7 +309,7 @@ calc_roc.randomForest <-
 #' @examples
 #' ##
 #' ## Taken from the gg_roc example
-#' rfsrc_iris <- randomForestSRC::rfsrc(Species ~ ., data = iris)
+#' rfsrc_iris <- randomForestSRC::rfsrc(Species ~ ., data = iris, ntree = 100)
 #'
 #' gg_dta <- gg_roc(rfsrc_iris, which_outcome = 1)
 #'

--- a/R/gg_brier.R
+++ b/R/gg_brier.R
@@ -91,7 +91,7 @@
 #' library(survival)   # Surv() must be on the search path for rfsrc()
 #' data(pbc, package = "randomForestSRC")
 #' rfsrc_pbc <- randomForestSRC::rfsrc(
-#'   Surv(days, status) ~ ., data = pbc, nsplit = 10
+#'   Surv(days, status) ~ ., data = pbc, nsplit = 10, ntree = 100
 #' )
 #' gg_dta <- gg_brier(rfsrc_pbc)
 #' plot(gg_dta)
@@ -100,7 +100,7 @@
 #'
 #' # Multi-model comparison: stack gg_brier outputs and plot with ggplot2.
 #' rf2 <- randomForestSRC::rfsrc(
-#'   Surv(days, status) ~ ., data = pbc, nsplit = 10, mtry = 4
+#'   Surv(days, status) ~ ., data = pbc, nsplit = 10, mtry = 4, ntree = 100
 #' )
 #' compare_dta <- dplyr::bind_rows(
 #'   dplyr::mutate(gg_brier(rfsrc_pbc), model = "default"),

--- a/R/gg_error.R
+++ b/R/gg_error.R
@@ -90,7 +90,7 @@
 #' ## RandomForest example
 #' rf_iris <- randomForest::randomForest(Species ~ .,
 #'   data = iris,
-#'   tree.err = TRUE,
+#'   tree.err = TRUE
 #' )
 #' gg_dta <- gg_error(rf_iris)
 #' plot(gg_dta)
@@ -104,7 +104,7 @@
 #' ## ------------- airq data
 #' rfsrc_airq <- randomForestSRC::rfsrc(Ozone ~ .,
 #'   data = airquality, ntree = 250,
-#'   na.action = "na.impute", tree.err = TRUE, block.size = 1,
+#'   na.action = "na.impute", tree.err = TRUE, block.size = 1
 #' )
 #'
 #' # Get a data.frame containing error rates

--- a/R/gg_error.R
+++ b/R/gg_error.R
@@ -79,7 +79,7 @@
 #' ## ------------- iris data
 #' ## You can build a randomForest
 #' rfsrc_iris <- randomForestSRC::rfsrc(Species ~ ., data = iris,
-#'   tree.err = TRUE, block.size = 1)
+#'   ntree = 250, tree.err = TRUE, block.size = 1)
 #'
 #' # Get a data.frame containing error rates
 #' gg_dta <- gg_error(rfsrc_iris)
@@ -103,7 +103,7 @@
 #'
 #' ## ------------- airq data
 #' rfsrc_airq <- randomForestSRC::rfsrc(Ozone ~ .,
-#'   data = airquality,
+#'   data = airquality, ntree = 250,
 #'   na.action = "na.impute", tree.err = TRUE, block.size = 1,
 #' )
 #'
@@ -120,6 +120,7 @@
 #'   Boston$chas <- as.logical(Boston$chas)
 #'   rfsrc_boston <- randomForestSRC::rfsrc(medv ~ .,
 #'     data = Boston,
+#'     ntree = 250,
 #'     forest = TRUE,
 #'     importance = TRUE,
 #'     tree.err = TRUE,
@@ -136,7 +137,7 @@
 #'
 #' ## ------------- mtcars data
 #' rfsrc_mtcars <- randomForestSRC::rfsrc(mpg ~ ., data = mtcars,
-#'   tree.err = TRUE, block.size = 1)
+#'   ntree = 250, tree.err = TRUE, block.size = 1)
 #'
 
 #' # Get a data.frame containing error rates
@@ -153,7 +154,7 @@
 #' ## randomized trial of two treatment regimens for lung cancer
 #' data(veteran, package = "randomForestSRC")
 #' rfsrc_veteran <- randomForestSRC::rfsrc(Surv(time, status) ~ ., data = veteran,
-#'                        tree.err = TRUE, block.size = 1)
+#'                        ntree = 250, tree.err = TRUE, block.size = 1)
 #'
 #' gg_dta <- gg_error(rfsrc_veteran)
 #' plot(gg_dta)
@@ -167,6 +168,7 @@
 #' rfsrc_pbc <- randomForestSRC::rfsrc(
 #'   Surv(years, status) ~ .,
 #'  dta_train,
+#'  ntree = 250,
 #'  nsplit = 10,
 #'  na.action = "na.impute",
 #'  tree.err = TRUE,

--- a/R/gg_partial_rfsrc.R
+++ b/R/gg_partial_rfsrc.R
@@ -99,7 +99,7 @@
 #' ##
 #' ## ------------------------------------------------------------
 #'
-#' airq.obj <- randomForestSRC::rfsrc(Ozone ~ ., data = airquality)
+#' airq.obj <- randomForestSRC::rfsrc(Ozone ~ ., data = airquality, ntree = 100)
 #'
 #' ## partial effect for wind
 #' prt_dta <- gg_partial_rfsrc(airq.obj,

--- a/R/gg_roc.R
+++ b/R/gg_roc.R
@@ -80,7 +80,7 @@
 #' ## classification example
 #' ## ------------------------------------------------------------
 #' ## -------- iris data
-#' rfsrc_iris <- randomForestSRC::rfsrc(Species ~ ., data = iris)
+#' rfsrc_iris <- randomForestSRC::rfsrc(Species ~ ., data = iris, ntree = 100)
 #'
 #' # ROC for setosa
 #' gg_dta <- gg_roc(rfsrc_iris, which_outcome = 1)

--- a/R/gg_vimp.R
+++ b/R/gg_vimp.R
@@ -96,6 +96,7 @@
 #' ## -------- iris data
 #' rfsrc_iris <- randomForestSRC::rfsrc(Species ~ .,
 #'   data = iris,
+#'   ntree = 100,
 #'   importance = TRUE
 #' )
 #' gg_dta <- gg_vimp(rfsrc_iris)
@@ -107,6 +108,7 @@
 #'
 #' ## -------- air quality data
 #' rfsrc_airq <- randomForestSRC::rfsrc(Ozone ~ ., airquality,
+#'   ntree = 100,
 #'   importance = TRUE
 #' )
 #' gg_dta <- gg_vimp(rfsrc_airq)
@@ -117,6 +119,7 @@
 #' if (requireNamespace("MASS", quietly = TRUE)) {
 #'   data(Boston, package = "MASS")
 #'   rfsrc_boston <- randomForestSRC::rfsrc(medv ~ ., Boston,
+#'     ntree = 100,
 #'     importance = TRUE
 #'   )
 #'   gg_dta <- gg_vimp(rfsrc_boston)
@@ -135,6 +138,7 @@
 #' ## -------- mtcars data
 #' rfsrc_mtcars <- randomForestSRC::rfsrc(mpg ~ .,
 #'   data = mtcars,
+#'   ntree = 100,
 #'   importance = TRUE
 #' )
 #' gg_dta <- gg_vimp(rfsrc_mtcars)
@@ -164,6 +168,7 @@
 #' rfsrc_pbc <- randomForestSRC::rfsrc(
 #'   Surv(years, status) ~ .,
 #'   dta_train,
+#'   ntree = 100,
 #'   nsplit = 10,
 #'   na.action = "na.impute",
 #'   forest = TRUE,

--- a/R/plot.gg_brier.R
+++ b/R/plot.gg_brier.R
@@ -47,7 +47,7 @@
 #' library(survival)   # Surv() must be on the search path for rfsrc()
 #' data(pbc, package = "randomForestSRC")
 #' rf <- randomForestSRC::rfsrc(Surv(days, status) ~ ., data = pbc,
-#'                              nsplit = 10)
+#'                              nsplit = 10, ntree = 100)
 #' gg_dta <- gg_brier(rf)
 #' plot(gg_dta)
 #' plot(gg_dta, type = "crps")

--- a/R/plot.gg_error.R
+++ b/R/plot.gg_error.R
@@ -55,6 +55,7 @@
 #' ## ------------- iris data
 #' ## You can build a randomForest
 #' rfsrc_iris <- randomForestSRC::rfsrc(Species ~ ., data = iris,
+#'   ntree = 250,
 #'   forest = TRUE,
 #'   importance = TRUE,
 #'   tree.err = TRUE,
@@ -85,6 +86,7 @@
 #' ## ------------- airq data
 #' rfsrc_airq <- randomForestSRC::rfsrc(Ozone ~ .,
 #'   data = airquality,
+#'   ntree = 250,
 #'   na.action = "na.impute",
 #'   forest = TRUE,
 #'   importance = TRUE,
@@ -105,6 +107,7 @@
 #'   Boston$chas <- as.logical(Boston$chas)
 #'   rfsrc_boston <- randomForestSRC::rfsrc(medv ~ .,
 #'     data = Boston,
+#'     ntree = 250,
 #'     forest = TRUE,
 #'     importance = TRUE,
 #'     tree.err = TRUE,
@@ -120,6 +123,7 @@
 #'
 #' ## ------------- mtcars data
 #' rfsrc_mtcars <- randomForestSRC::rfsrc(mpg ~ ., data = mtcars,
+#'   ntree = 250,
 #'   importance = TRUE,
 #'   save.memory = TRUE,
 #'   forest = TRUE,
@@ -139,7 +143,7 @@
 #' ## randomized trial of two treatment regimens for lung cancer
 #' data(veteran, package = "randomForestSRC")
 #' rfsrc_veteran <- randomForestSRC::rfsrc(Surv(time, status) ~ ., data = veteran,
-#'                        tree.err = TRUE)
+#'                        ntree = 250, tree.err = TRUE)
 #'
 #' gg_dta <- gg_error(rfsrc_veteran)
 #' plot(gg_dta)
@@ -153,6 +157,7 @@
 #' rfsrc_pbc <- randomForestSRC::rfsrc(
 #'   Surv(years, status) ~ .,
 #'  dta_train,
+#'  ntree = 250,
 #'  nsplit = 10,
 #'  na.action = "na.impute",
 #'  tree.err = TRUE,

--- a/R/plot.gg_rfsrc.R
+++ b/R/plot.gg_rfsrc.R
@@ -138,6 +138,7 @@
 #' rfsrc_pbc <- randomForestSRC::rfsrc(
 #'   Surv(years, status) ~ .,
 #'   dta_train,
+#'   ntree = 100,
 #'   nsplit = 10,
 #'   na.action = "na.impute",
 #'   forest = TRUE,

--- a/R/plot.gg_vimp.R
+++ b/R/plot.gg_vimp.R
@@ -54,7 +54,7 @@
 #' ## classification example
 #' ## ------------------------------------------------------------
 #' ## -------- iris data
-#' rfsrc_iris <- randomForestSRC::rfsrc(Species ~ ., data = iris)
+#' rfsrc_iris <- randomForestSRC::rfsrc(Species ~ ., data = iris, ntree = 100)
 #' gg_dta <- gg_vimp(rfsrc_iris)
 #' plot(gg_dta)
 #'
@@ -62,7 +62,7 @@
 #' ## regression example
 #' ## ------------------------------------------------------------
 #' ## -------- air quality data
-#' rfsrc_airq <- randomForestSRC::rfsrc(Ozone ~ ., airquality)
+#' rfsrc_airq <- randomForestSRC::rfsrc(Ozone ~ ., airquality, ntree = 100)
 #' gg_dta <- gg_vimp(rfsrc_airq)
 #' plot(gg_dta)
 #'

--- a/R/quantile_pts.R
+++ b/R/quantile_pts.R
@@ -39,7 +39,7 @@
 #' @examples
 #' if (requireNamespace("MASS", quietly = TRUE)) {
 #'   data(Boston, package = "MASS")
-#'   rfsrc_boston <- randomForestSRC::rfsrc(medv ~ ., Boston)
+#'   rfsrc_boston <- randomForestSRC::rfsrc(medv ~ ., Boston, ntree = 100)
 #'
 #'   # To create 6 intervals, we want 7 points.
 #'   # quantile_pts will find balanced intervals

--- a/man/calc_auc.Rd
+++ b/man/calc_auc.Rd
@@ -25,7 +25,7 @@ This is a helper function for the \code{\link{gg_roc}} functions.
 \examples{
 ##
 ## Taken from the gg_roc example
-rfsrc_iris <- randomForestSRC::rfsrc(Species ~ ., data = iris)
+rfsrc_iris <- randomForestSRC::rfsrc(Species ~ ., data = iris, ntree = 100)
 
 gg_dta <- gg_roc(rfsrc_iris, which_outcome = 1)
 

--- a/man/calc_roc.rfsrc.Rd
+++ b/man/calc_roc.rfsrc.Rd
@@ -49,7 +49,7 @@ not intended for use by the end user.
 }
 \examples{
 ## Taken from the gg_roc example
-rfsrc_iris <- randomForestSRC::rfsrc(Species ~ ., data = iris)
+rfsrc_iris <- randomForestSRC::rfsrc(Species ~ ., data = iris, ntree = 100)
 
 gg_dta <- calc_roc(rfsrc_iris, rfsrc_iris$yvar,
   which_outcome = 1, oob = TRUE

--- a/man/gg_brier.Rd
+++ b/man/gg_brier.Rd
@@ -78,7 +78,7 @@ is no \code{randomForest} method.
 library(survival)   # Surv() must be on the search path for rfsrc()
 data(pbc, package = "randomForestSRC")
 rfsrc_pbc <- randomForestSRC::rfsrc(
-  Surv(days, status) ~ ., data = pbc, nsplit = 10
+  Surv(days, status) ~ ., data = pbc, nsplit = 10, ntree = 100
 )
 gg_dta <- gg_brier(rfsrc_pbc)
 plot(gg_dta)
@@ -87,7 +87,7 @@ plot(gg_dta, envelope = TRUE)   # overall line + 15-85\% envelope
 
 # Multi-model comparison: stack gg_brier outputs and plot with ggplot2.
 rf2 <- randomForestSRC::rfsrc(
-  Surv(days, status) ~ ., data = pbc, nsplit = 10, mtry = 4
+  Surv(days, status) ~ ., data = pbc, nsplit = 10, mtry = 4, ntree = 100
 )
 compare_dta <- dplyr::bind_rows(
   dplyr::mutate(gg_brier(rfsrc_pbc), model = "default"),

--- a/man/gg_error.Rd
+++ b/man/gg_error.Rd
@@ -70,7 +70,7 @@ plot(gg_dta)
 ## RandomForest example
 rf_iris <- randomForest::randomForest(Species ~ .,
   data = iris,
-  tree.err = TRUE,
+  tree.err = TRUE
 )
 gg_dta <- gg_error(rf_iris)
 plot(gg_dta)
@@ -84,7 +84,7 @@ plot(gg_dta)
 ## ------------- airq data
 rfsrc_airq <- randomForestSRC::rfsrc(Ozone ~ .,
   data = airquality, ntree = 250,
-  na.action = "na.impute", tree.err = TRUE, block.size = 1,
+  na.action = "na.impute", tree.err = TRUE, block.size = 1
 )
 
 # Get a data.frame containing error rates

--- a/man/gg_error.Rd
+++ b/man/gg_error.Rd
@@ -59,7 +59,7 @@ predictions. Training curves are only available when the forest was stored
 ## ------------- iris data
 ## You can build a randomForest
 rfsrc_iris <- randomForestSRC::rfsrc(Species ~ ., data = iris,
-  tree.err = TRUE, block.size = 1)
+  ntree = 250, tree.err = TRUE, block.size = 1)
 
 # Get a data.frame containing error rates
 gg_dta <- gg_error(rfsrc_iris)
@@ -83,7 +83,7 @@ plot(gg_dta)
 
 ## ------------- airq data
 rfsrc_airq <- randomForestSRC::rfsrc(Ozone ~ .,
-  data = airquality,
+  data = airquality, ntree = 250,
   na.action = "na.impute", tree.err = TRUE, block.size = 1,
 )
 
@@ -100,6 +100,7 @@ if (requireNamespace("MASS", quietly = TRUE)) {
   Boston$chas <- as.logical(Boston$chas)
   rfsrc_boston <- randomForestSRC::rfsrc(medv ~ .,
     data = Boston,
+    ntree = 250,
     forest = TRUE,
     importance = TRUE,
     tree.err = TRUE,
@@ -116,7 +117,7 @@ if (requireNamespace("MASS", quietly = TRUE)) {
 
 ## ------------- mtcars data
 rfsrc_mtcars <- randomForestSRC::rfsrc(mpg ~ ., data = mtcars,
-  tree.err = TRUE, block.size = 1)
+  ntree = 250, tree.err = TRUE, block.size = 1)
 
 # Get a data.frame containing error rates
 gg_dta<- gg_error(rfsrc_mtcars)
@@ -132,7 +133,7 @@ plot(gg_dta)
 ## randomized trial of two treatment regimens for lung cancer
 data(veteran, package = "randomForestSRC")
 rfsrc_veteran <- randomForestSRC::rfsrc(Surv(time, status) ~ ., data = veteran,
-                       tree.err = TRUE, block.size = 1)
+                       ntree = 250, tree.err = TRUE, block.size = 1)
 
 gg_dta <- gg_error(rfsrc_veteran)
 plot(gg_dta)
@@ -179,6 +180,7 @@ pbc_test <- pbc[which(is.na(pbc$treatment)), ]
 rfsrc_pbc <- randomForestSRC::rfsrc(
   Surv(years, status) ~ .,
  dta_train,
+ ntree = 250,
  nsplit = 10,
  na.action = "na.impute",
  tree.err = TRUE,

--- a/man/gg_partial_rfsrc.Rd
+++ b/man/gg_partial_rfsrc.Rd
@@ -135,7 +135,7 @@ before fitting the model.
 ##
 ## ------------------------------------------------------------
 
-airq.obj <- randomForestSRC::rfsrc(Ozone ~ ., data = airquality)
+airq.obj <- randomForestSRC::rfsrc(Ozone ~ ., data = airquality, ntree = 100)
 
 ## partial effect for wind
 prt_dta <- gg_partial_rfsrc(airq.obj,

--- a/man/gg_roc.rfsrc.Rd
+++ b/man/gg_roc.rfsrc.Rd
@@ -78,7 +78,7 @@ distinction matters; issue #72 tracks reconciling the two.
 ## classification example
 ## ------------------------------------------------------------
 ## -------- iris data
-rfsrc_iris <- randomForestSRC::rfsrc(Species ~ ., data = iris)
+rfsrc_iris <- randomForestSRC::rfsrc(Species ~ ., data = iris, ntree = 100)
 
 # ROC for setosa
 gg_dta <- gg_roc(rfsrc_iris, which_outcome = 1)

--- a/man/gg_vimp.Rd
+++ b/man/gg_vimp.Rd
@@ -88,6 +88,7 @@ hazard function (CHF); the error metric is one minus the concordance index
 ## -------- iris data
 rfsrc_iris <- randomForestSRC::rfsrc(Species ~ .,
   data = iris,
+  ntree = 100,
   importance = TRUE
 )
 gg_dta <- gg_vimp(rfsrc_iris)
@@ -99,6 +100,7 @@ plot(gg_dta)
 
 ## -------- air quality data
 rfsrc_airq <- randomForestSRC::rfsrc(Ozone ~ ., airquality,
+  ntree = 100,
   importance = TRUE
 )
 gg_dta <- gg_vimp(rfsrc_airq)
@@ -109,6 +111,7 @@ plot(gg_dta)
 if (requireNamespace("MASS", quietly = TRUE)) {
   data(Boston, package = "MASS")
   rfsrc_boston <- randomForestSRC::rfsrc(medv ~ ., Boston,
+    ntree = 100,
     importance = TRUE
   )
   gg_dta <- gg_vimp(rfsrc_boston)
@@ -127,6 +130,7 @@ if (requireNamespace("MASS", quietly = TRUE)) {
 ## -------- mtcars data
 rfsrc_mtcars <- randomForestSRC::rfsrc(mpg ~ .,
   data = mtcars,
+  ntree = 100,
   importance = TRUE
 )
 gg_dta <- gg_vimp(rfsrc_mtcars)
@@ -189,6 +193,7 @@ pbc_test <- pbc[which(is.na(pbc$treatment)), ]
 rfsrc_pbc <- randomForestSRC::rfsrc(
   Surv(years, status) ~ .,
   dta_train,
+  ntree = 100,
   nsplit = 10,
   na.action = "na.impute",
   forest = TRUE,

--- a/man/plot.gg_brier.Rd
+++ b/man/plot.gg_brier.Rd
@@ -44,7 +44,7 @@ minority of subjects are driving the average.
 library(survival)   # Surv() must be on the search path for rfsrc()
 data(pbc, package = "randomForestSRC")
 rf <- randomForestSRC::rfsrc(Surv(days, status) ~ ., data = pbc,
-                             nsplit = 10)
+                             nsplit = 10, ntree = 100)
 gg_dta <- gg_brier(rf)
 plot(gg_dta)
 plot(gg_dta, type = "crps")

--- a/man/plot.gg_error.Rd
+++ b/man/plot.gg_error.Rd
@@ -39,6 +39,7 @@ from the \code{\link[randomForestSRC]{plot.rfsrc}} function.
 ## ------------- iris data
 ## You can build a randomForest
 rfsrc_iris <- randomForestSRC::rfsrc(Species ~ ., data = iris,
+  ntree = 250,
   forest = TRUE,
   importance = TRUE,
   tree.err = TRUE,
@@ -69,6 +70,7 @@ plot(gg_dta)
 ## ------------- airq data
 rfsrc_airq <- randomForestSRC::rfsrc(Ozone ~ .,
   data = airquality,
+  ntree = 250,
   na.action = "na.impute",
   forest = TRUE,
   importance = TRUE,
@@ -89,6 +91,7 @@ if (requireNamespace("MASS", quietly = TRUE)) {
   Boston$chas <- as.logical(Boston$chas)
   rfsrc_boston <- randomForestSRC::rfsrc(medv ~ .,
     data = Boston,
+    ntree = 250,
     forest = TRUE,
     importance = TRUE,
     tree.err = TRUE,
@@ -104,6 +107,7 @@ if (requireNamespace("MASS", quietly = TRUE)) {
 
 ## ------------- mtcars data
 rfsrc_mtcars <- randomForestSRC::rfsrc(mpg ~ ., data = mtcars,
+  ntree = 250,
   importance = TRUE,
   save.memory = TRUE,
   forest = TRUE,
@@ -123,7 +127,7 @@ plot(gg_dta)
 ## randomized trial of two treatment regimens for lung cancer
 data(veteran, package = "randomForestSRC")
 rfsrc_veteran <- randomForestSRC::rfsrc(Surv(time, status) ~ ., data = veteran,
-                       tree.err = TRUE)
+                       ntree = 250, tree.err = TRUE)
 
 gg_dta <- gg_error(rfsrc_veteran)
 plot(gg_dta)
@@ -170,6 +174,7 @@ pbc_test <- pbc[which(is.na(pbc$treatment)), ]
 rfsrc_pbc <- randomForestSRC::rfsrc(
   Surv(years, status) ~ .,
  dta_train,
+ ntree = 250,
  nsplit = 10,
  na.action = "na.impute",
  tree.err = TRUE,

--- a/man/plot.gg_rfsrc.Rd
+++ b/man/plot.gg_rfsrc.Rd
@@ -156,6 +156,7 @@ set.seed(42)
 rfsrc_pbc <- randomForestSRC::rfsrc(
   Surv(years, status) ~ .,
   dta_train,
+  ntree = 100,
   nsplit = 10,
   na.action = "na.impute",
   forest = TRUE,

--- a/man/plot.gg_vimp.Rd
+++ b/man/plot.gg_vimp.Rd
@@ -41,7 +41,7 @@ are positive; the color distinction matters when a handful are not.
 ## classification example
 ## ------------------------------------------------------------
 ## -------- iris data
-rfsrc_iris <- randomForestSRC::rfsrc(Species ~ ., data = iris)
+rfsrc_iris <- randomForestSRC::rfsrc(Species ~ ., data = iris, ntree = 100)
 gg_dta <- gg_vimp(rfsrc_iris)
 plot(gg_dta)
 
@@ -49,7 +49,7 @@ plot(gg_dta)
 ## regression example
 ## ------------------------------------------------------------
 ## -------- air quality data
-rfsrc_airq <- randomForestSRC::rfsrc(Ozone ~ ., airquality)
+rfsrc_airq <- randomForestSRC::rfsrc(Ozone ~ ., airquality, ntree = 100)
 gg_dta <- gg_vimp(rfsrc_airq)
 plot(gg_dta)
 

--- a/man/quantile_pts.Rd
+++ b/man/quantile_pts.Rd
@@ -32,7 +32,7 @@ The output can be passed directly into the breaks argument of the
 \examples{
 if (requireNamespace("MASS", quietly = TRUE)) {
   data(Boston, package = "MASS")
-  rfsrc_boston <- randomForestSRC::rfsrc(medv ~ ., Boston)
+  rfsrc_boston <- randomForestSRC::rfsrc(medv ~ ., Boston, ntree = 100)
 
   # To create 6 intervals, we want 7 points.
   # quantile_pts will find balanced intervals


### PR DESCRIPTION
Scoped out of #187 as orthogonal. The premise there was that 86 `rfsrc()` calls across the roxygen examples are a structural check-time risk. They are — but not in the shape the raw grep suggests, so this measures before it cuts.

## What the measurement showed

Timing the scripts `R CMD check` actually sources — `tools::Rd2ex()` run twice, once with `commentDonttest = TRUE` for the default pass and once with `FALSE` for `--run-donttest`:

| Count | What it is |
|---|---|
| 86 | raw `grep "^#'.*rfsrc("` over `R/*.R` — counts prose and `\donttest` bodies |
| 81 | executable in the `--run-donttest` pass |
| **51** | executable in the **default check pass** |

Total cost 6.7 s (default) / 24.6 s (donttest) locally, matching the 16 s / 36 s the last full check reported. There are zero `\dontrun{}` blocks.

**The concentration is not where the fit count points.** `plot.gg_rfsrc` runs the most fits of any topic — 10 in the default pass — for 0.265 s, because all ten already pass `ntree`. Per-statement timing put 52% of the default pass in six fits that pass no `ntree` at all, so they run at the rfsrc default of 500 trees with `importance = TRUE`:

| Cost | Fits | Where |
|---|---|---|
| 2.06 s | 3 | uncapped pbc survival — `gg_error`, `plot.gg_error`, `gg_vimp` |
| 1.39 s | 3 | uncapped Boston regression — same three topics |

A sweep for the same hole found **28 uncapped fits** in total. The other 22 are cheap only because they happen to sit on iris/mtcars/airquality. All 28 now carry an explicit `ntree`, so the example surface is bounded by construction rather than by which dataset was used.

## Why two values

**`gg_error` / `plot.gg_error` → `ntree = 250`.** The OOB error curve is what these topics teach, so the forest has to be big enough that the curve visibly flattens.

| `ntree` | fit time | final OOB error | vs. 500 |
|---|---|---|---|
| 500 | 0.88 s | 0.2131 | — |
| 250 | 0.36 s | 0.2117 | −0.7% |
| 100 | 0.13 s | 0.2076 | −2.6% |
| 50 | 0.07 s | 0.2099 | −1.5% |

On pbc the curve is within 2% of its final value by roughly tree 20–40, so 250 still reads as converging. 50 would be too thin for these two topics specifically.

**Everything else → `ntree = 100`**, matching the convention `gg_vimp` already used for its veteran fit. Checked this does not misrepresent the VIMP plot — against a 500-tree reference on pbc, the top-six *set* is the same at 250, 100 and 50 trees (order identical at 250 and 50; at 100 only the adjacent near-tied `edema`/`ascites` pair swaps):

```
500: bili > edema > ascites > albumin > copper > prothrombin > age > chol > platelet > sgot
250: bili > edema > ascites > albumin > copper > prothrombin > age > sgot > chol > stage
100: bili > ascites > edema > albumin > copper > prothrombin > chol > age > stage > sgot
```

Ranks 7–10 reorder, but they reorder at 250 as much as at 100 — near-tied importances, not a low-`ntree` artifact.

## Result

- default example pass **6.69 s → 4.62 s (−31%)**
- donttest pass 24.60 s → 22.75 s

The donttest pass barely moves because its bulk is the varPro `gg_udependent` / `plot.gg_sdependent` topics (~3.6 s each), not rfsrc.

## Scope and verification

Examples-only. No behaviour change, no API change, no `\donttest{}` restructuring — so the `@example`/brace-balance constraint from #187 never came up. No version bump: the NEWS-vs-DESCRIPTION grep test passes at 3.5.1, and #187 set the precedent that doc-only changes don't bump.

- zero uncapped fits remain in **either** pass (re-ran the sweep after `document()`)
- every example block still sources without error in both passes
- `lintr::lint_package()` → **0 lints**
- `NOT_CRAN=true VDIFFR_RUN_TESTS=true devtools::test()` → **FAIL 0 | PASS 1468 | SKIP 5**, all 49 vdiffr snapshots intact, no pruning

The 5 skips are pre-existing and unrelated: one opt-in slow test (`GG_IVARPRO_SLOW_TESTS`), three superseded `plot.gg_partialpro` tests, one clean-session test that only runs under `R CMD check`.

**Not run here:** the full `R CMD check --as-cran` with manual from a clean `git archive` export — that's the release gate, not a per-PR gate, and CI runs `R-CMD-check` on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
