### PR TITLE
docs: correct the rfsrc ntree default from 1000 to 500

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -248,7 +248,7 @@ test_that("gg_depth throws on wrong input", {
 
 ### Practical tips
 
-- Keep forests small in tests — `ntree = 50` is plenty, faster than the default 1000.
+- Keep forests small in tests — `ntree = 50` is plenty, faster than the default 500.
 - Test the error path as well as the happy path (`expect_error`, `expect_warning`).
 - Use `expect_s3_class()` rather than the older `expect_is()`.
 - Avoid `set.seed()` unless you are explicitly testing something random — randomForestSRC results are stochastic and exact-value tests break across versions.

--- a/vignettes/ggRandomForests-survival.qmd
+++ b/vignettes/ggRandomForests-survival.qmd
@@ -301,8 +301,8 @@ stopping at a minimum terminal node size of `r rfsrc_pbc$nodesize`.
 plot(gg_error(rfsrc_pbc))
 ```
 
-The error stabilizes well before the 150 trees grown here, indicating the forest
-is large enough for reliable predictions.
+The error stabilizes well before the `r rfsrc_pbc$ntree` trees grown here,
+indicating the forest is large enough for reliable predictions.
 
 ## OOB predicted survival
 

--- a/vignettes/ggRandomForests-survival.qmd
+++ b/vignettes/ggRandomForests-survival.qmd
@@ -301,8 +301,8 @@ stopping at a minimum terminal node size of `r rfsrc_pbc$nodesize`.
 plot(gg_error(rfsrc_pbc))
 ```
 
-The error stabilizes well before 1000 trees, indicating the forest is large
-enough for reliable predictions.
+The error stabilizes well before the 150 trees grown here, indicating the forest
+is large enough for reliable predictions.
 
 ## OOB predicted survival
 


### PR DESCRIPTION
## What

`formals(randomForestSRC::rfsrc)$ntree` returns **500**, not 1000, on randomForestSRC 3.6.2:

```
$ Rscript -e 'print(formals(randomForestSRC::rfsrc)$ntree)'
[1] 500
```

`CONTRIBUTING.md:251` claimed 1000, directly contradicting `code-review.md:116`, which already said 500. The wrong figure was copied into a `NEWS.md` bullet during the 3.5.1 release sweep and only caught in Copilot review on #189 — it is actively misleading, so the source is now fixed too.

## Second instance, different cause

Grepping for the figure (`grep -rn "default 1000\|1000-tree\|1000 trees\|default of 1000"`) turned up one more hit, and it is a different kind of error worth flagging separately.

`vignettes/ggRandomForests-survival.qmd:304` told the reader the OOB error "stabilizes well before 1000 trees" — but the forest immediately above it is grown with `ntree = 150`, so the error plot's x-axis stops at 150. The prose described a figure the reader is not looking at.

That sentence is a fossil of the tree-count reduction done for the CRAN <10-min check-time budget: the forests were shrunk, the surrounding narrative was not. This is the failure mode to watch for — prose that hardcodes a number read off a figure goes stale silently when the figure's code changes, because nothing fails.

So rather than correct the literal to 150, the line now interpolates the count off the fitted object:

```
The error stabilizes well before the `r rfsrc_pbc$ntree` trees grown here,
indicating the forest is large enough for reliable predictions.
```

That is the same form line 294 already uses in the same scope (`` The forest grew `r rfsrc_pbc$ntree` trees ``), so the sentence cannot drift out of sync with the fit again.

Note that `code-review.md:116` was correct all along, because it was written from reading the failing tests rather than copied from prose — which is why it never inherited the error.

## Verification

- `grep` for the figure across the repo now returns nothing.
- Both remaining `ntree`-default statements (`CONTRIBUTING.md:251`, `code-review.md:116`) agree on 500.
- `$ntree` confirmed to return the grown count on a fitted `rfsrc` object.
- `lintr::lint_package()` → 0 lints.
- Prose only; no R code or code chunks touched. The full suite was not run — nothing it covers changed, and an unguarded run risks the vdiffr snapshot pruning documented in `CLAUDE.md`. The vignette renders under `R CMD check`, which will exercise the new inline R.

No version bump or NEWS entry: `main` is the frozen 3.5.1 CRAN mirror, the NEWS-vs-DESCRIPTION version grep already matches, and a prose-number correction is not a release-note-worthy behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)