### PR TITLE
ci: stop the vdiffr snapshot pruning at the default, and block it at commit

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -59,3 +59,5 @@ framed.sty
 # Stray default-device plot artefact (created by plotting with no open device),
 # at the root or under tests/ — never ship it.
 Rplots\.pdf$
+^\.Renviron$
+^\.githooks$

--- a/.Renviron
+++ b/.Renviron
@@ -1,0 +1,17 @@
+# Project-level R environment.
+#
+# VDIFFR_RUN_TESTS guards the vdiffr visual-regression tests in
+# tests/testthat/test_snapshots.R. When it is not "true" those tests do not
+# run, and testthat then treats every baseline under
+# tests/testthat/_snaps/snapshots/ as unused and deletes it. The destructive
+# state is therefore the *absence* of a setting, which is the natural state of
+# any fresh shell, script, or CI-less local run. That is how all 49 baselines
+# have been pruned repeatedly.
+#
+# This line inverts that default: unset becomes "true" (tests register, nothing
+# is pruned), while an explicit value still wins. The three CI workflows that
+# deliberately set VDIFFR_RUN_TESTS: "false" are unaffected.
+#
+# Note that R --vanilla ignores this file, and an explicit "false" still
+# prunes; .githooks/pre-commit is the backstop for both.
+VDIFFR_RUN_TESTS=${VDIFFR_RUN_TESTS-true}

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,58 @@
+#!/bin/sh
+# Block commits that stage deletions of vdiffr snapshot baselines.
+#
+# Running the test suite without VDIFFR_RUN_TESTS=true makes testthat prune
+# every SVG under tests/testthat/_snaps/. A pruned working tree is recoverable;
+# a *committed* prune is what actually costs baselines, so this hook guards the
+# commit rather than the test run.
+#
+# Enable once per clone:
+#   git config core.hooksPath .githooks
+#
+# Deliberately removing a baseline (a test was retired, a plot was dropped):
+#   ALLOW_SNAPSHOT_DELETION=1 git commit ...
+
+SNAP_PATH='tests/testthat/_snaps'
+
+deleted=$(git diff --cached --name-only --diff-filter=D -- "$SNAP_PATH")
+
+if [ -z "$deleted" ]; then
+    exit 0
+fi
+
+count=$(printf '%s\n' "$deleted" | grep -c .)
+
+if [ "${ALLOW_SNAPSHOT_DELETION:-}" = "1" ]; then
+    printf 'pre-commit: allowing %s staged snapshot deletion(s) (ALLOW_SNAPSHOT_DELETION=1).\n' "$count"
+    exit 0
+fi
+
+cat >&2 <<EOF
+
+pre-commit: BLOCKED — this commit deletes $count vdiffr snapshot baseline(s).
+
+$(printf '%s\n' "$deleted" | sed 's/^/    /')
+
+The usual cause is a test run without the guard, which makes testthat treat
+the baselines as unused and delete them. It is almost never an intended change.
+
+To undo the deletions and keep your other work:
+
+    git restore --staged --worktree -- $SNAP_PATH
+
+Then re-run the suite with the guard set:
+
+    NOT_CRAN=true VDIFFR_RUN_TESTS=true Rscript -e 'devtools::test()'
+
+If a measurement run genuinely needs the guard off, run it against a throwaway
+export instead of this checkout:
+
+    git archive HEAD | tar -x -C "\$TMPDIR/tree" && cd "\$TMPDIR/tree"
+
+If you really are retiring these baselines, say so explicitly:
+
+    ALLOW_SNAPSHOT_DELETION=1 git commit ...
+
+EOF
+
+exit 1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,37 @@ So the guard is the fix, not the cleanup. Check `git status` before and after
 any local suite run, and treat a wave of staged snapshot deletions as a signal
 that the env var was missing — not as a change to commit.
 
+**Two protections now sit under that advice, because remembering an env var has
+failed repeatedly.**
+
+1. **`.Renviron` inverts the default.** It sets
+   `VDIFFR_RUN_TESTS=${VDIFFR_RUN_TESTS-true}`, so an unset variable — the
+   state of every fresh shell, script and agent session, and the cause of every
+   prune so far — now reads as `true`. An explicit value still wins, so the
+   three CI workflows that set `"false"` are unaffected. `R --vanilla` ignores
+   `.Renviron`, and an explicit `"false"` still prunes.
+
+2. **`.githooks/pre-commit` blocks the commit.** A pruned working tree is
+   recoverable; a committed prune is the real loss, so the hook guards the
+   commit. **It needs one command per clone:**
+
+   ```bash
+   git config core.hooksPath .githooks
+   ```
+
+   Without that, the hook does nothing. To retire a baseline deliberately, use
+   `ALLOW_SNAPSHOT_DELETION=1 git commit ...`.
+
+Note that the guard style in the test file is *not* a lever. `test_snapshots.R`
+wraps most tests in a file-level `if (Sys.getenv(...) == "true")` and the rest
+in `skip()` inside `test_that()`; on testthat 3.3.2 a prune takes the baselines
+of both. Rewriting the guards would not have prevented any of this.
+
+If a measurement genuinely needs the guard off (tracing under CRAN skip
+semantics, say), run it against a throwaway export rather than this checkout —
+`git archive HEAD | tar -x -C "$TMPDIR/tree"` — so pruning has nothing of
+yours to delete.
+
 Only the three CI workflows set `VDIFFR_RUN_TESTS: "false"` deliberately
 (`R-CMD-check`, `test-coverage`, `check-manual`), where snapshots are not
 regenerated and pruning has nothing to prune. That CI setting is why the hazard


### PR DESCRIPTION
Running the suite without `VDIFFR_RUN_TESTS=true` makes testthat treat all 49 baselines under `tests/testthat/_snaps/` as unused and delete them. This has happened repeatedly, including during the 3.5.1 release sweep that prompted this PR.

The reason "remember the env var" keeps failing: **the destructive state is the *absence* of a setting**, which is the natural state of every fresh shell, script, cron job and agent session. Nobody ever chooses `false` — they just don't set anything.

## What I ruled out first

The intuitive fix is to rewrite the guards in `test_snapshots.R`, on the theory that its file-level `if (Sys.getenv(...) == "true") { ... }` wrapper (lines 20–361) hides the tests from testthat while the `skip()`-inside-`test_that()` style (lines 364+) would not.

That theory is wrong. The prune took the baselines of **both** groups, including `gg-beta-varpro-*.svg` from the `skip()` group. On testthat 3.3.2 a skipped test does not protect its snapshot, so there is no fix available inside the test file.

## Two layers instead

**1. `.Renviron` inverts the default**

```bash
VDIFFR_RUN_TESTS=${VDIFFR_RUN_TESTS-true}
```

Verified both directions:

| Shell state | Resolves to |
|---|---|
| unset (the accidental case) | `true` — protected |
| `VDIFFR_RUN_TESTS=false` (what the 3 CI workflows set) | `false` — CI intent preserved |

Does not cover `R --vanilla`, or an explicit `false`.

**2. `.githooks/pre-commit` blocks the commit**

A pruned working tree is recoverable; a *committed* prune is the real loss, so the hook guards the commit rather than the test run. It catches every route, including the two the `.Renviron` layer misses.

Verified: blocks a staged deletion with a message explaining the likely cause and the recovery command; allows it under `ALLOW_SNAPSHOT_DELETION=1`; leaves ordinary commits alone.

⚠️ **Needs one command per clone, or it does nothing:**

```bash
git config core.hooksPath .githooks
```

## Checks

- Both new paths are `.Rbuildignore`d — confirmed by inspecting the built tarball, which still comes to 2.3 MB and carries neither.
- No hidden-file warning from `R CMD build`.
- `CLAUDE.md` documents both layers, the required `core.hooksPath` command, and the finding that guard style is not a lever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)