### PR TITLE
Add AGENTS.md and repo rules

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -61,3 +61,4 @@ framed.sty
 Rplots\.pdf$
 ^\.Renviron$
 ^\.githooks$
+^AGENTS\.md$

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,194 @@
+# ggRandomForests
+
+CRAN R package. A visualisation and exploration layer over `randomForestSRC`, `randomForest`
+and `varPro` objects, built on ggplot2. The public API is the `gg_*` extractor family plus
+their `plot()` and `autoplot()` methods (19 of each, as declared in `NAMESPACE`).
+
+This file is the operational contract for any agent working in this repo. It is deliberately
+short. Structure, the `gg_*` design pattern, roxygen standards and code style are documented
+once in `CONTRIBUTING.md`; read that rather than expecting them restated here.
+
+## Definition of done
+
+A change is not done until these pass, in this order:
+
+```bash
+Rscript -e 'devtools::document()'
+Rscript -e 'lintr::lint_package()'                                  # must be 0 lints
+NOT_CRAN=true VDIFFR_RUN_TESTS=true Rscript -e 'devtools::test()'    # 0 failures, 0 errors
+```
+
+Then, once per PR rather than once per edit:
+
+```bash
+R CMD check --as-cran   # with the manual; do not pass --no-manual
+```
+
+Run the commands. Reading the code is not evidence, and neither is a subagent's report.
+
+Three details in that list are load bearing:
+
+- **`document()` runs first, every time.** `man/` and `NAMESPACE` are generated. A stale
+  `NAMESPACE` makes the test run answer a question about the previous commit.
+- **Lint runs before tests** because it costs about 17 seconds against about 130 for the
+  suite. Cheap failures first.
+- **The test command needs both environment variables.** See "The one thing that destroys
+  work" below. `devtools::test()` sets `NOT_CRAN=true` itself, but a bare
+  `testthat::test_file()` under `load_all()` does not, so every `skip_on_cran()` test
+  silently skips and the run reports `SS` instead of a result. Reading `SS` as "fine" is how
+  you conclude a test passed when it never ran. There are 34 `skip_on_cran()` calls in this
+  suite, so this is not a hypothetical.
+
+`R CMD check` runs with `NOT_CRAN` false, so it does **not** exercise those 34 tests. A green
+check is not evidence that they pass; only the `devtools::test()` line above is.
+
+## The one thing that destroys work
+
+**A suite run with `VDIFFR_RUN_TESTS` unset deletes every vdiffr baseline as "unused."**
+There are 49 of them under `tests/testthat/_snaps/snapshots/`, and they are the package's
+only visual regression coverage.
+
+Always run the suite as:
+
+```bash
+NOT_CRAN=true VDIFFR_RUN_TESTS=true Rscript -e 'devtools::test()'
+```
+
+Check `git status` before and after any local suite run. A wave of staged snapshot deletions
+is a signal that the variable was missing, not a change to commit.
+
+This has happened repeatedly, so two protections now sit under that advice:
+
+1. **`.Renviron` inverts the default.** It sets `VDIFFR_RUN_TESTS=${VDIFFR_RUN_TESTS-true}`,
+   so an unset variable (the natural state of every fresh shell, script and agent session,
+   and the cause of every prune so far) now reads as `true`. An explicit value still wins, so
+   the three CI workflows that set `"false"` are unaffected. Note that `R --vanilla` ignores
+   `.Renviron`, and an explicit `"false"` still prunes.
+
+2. **`.githooks/pre-commit` blocks the commit.** A pruned working tree is recoverable; a
+   committed prune is the real loss. **This needs one command per clone:**
+
+   ```bash
+   git config core.hooksPath .githooks
+   ```
+
+   Without it the hook does nothing. To retire a baseline deliberately, use
+   `ALLOW_SNAPSHOT_DELETION=1 git commit ...`.
+
+Further notes, so nobody re-derives them:
+
+- If you regenerate a baseline, do it **last**. A later full-suite run deletes it, and a
+  blanket `git checkout -- tests/testthat/_snaps/` to undo that silently reverts your
+  regeneration along with the pruning.
+- All 49 baselines are tracked today. That was not true on 2026-08-06, when one unguarded run
+  pruned 49 files and the 9 untracked ones survived only because a stale copy happened to
+  remain in `ggRandomForests.Rcheck/00_pkg_src/`. That is not a backup and will not reliably
+  be there.
+- The guard style in the test file is **not** a lever. `test_snapshots.R` wraps most tests in
+  a file-level `if (Sys.getenv(...) == "true")` and the rest in `skip()` inside `test_that()`;
+  on testthat 3.3.2 a prune takes the baselines of both. Rewriting the guards would not have
+  prevented any of this.
+- If a measurement genuinely needs the guard off (tracing under CRAN skip semantics, say), run
+  it against a throwaway export rather than this checkout:
+  `git archive HEAD | tar -x -C "$TMPDIR/tree"`, so pruning has nothing of yours to delete.
+- Only `R-CMD-check`, `test-coverage` and `check-manual` set `VDIFFR_RUN_TESTS: "false"`
+  deliberately, where snapshots are not regenerated and pruning has nothing to prune. That CI
+  setting is why the hazard stays invisible until someone runs the suite on a laptop.
+
+## Before you touch code
+
+Orient on the public API surface and where things live **before** editing. Do not infer the
+structure of this package from a partial file read: there are 60 exported symbols across
+19 extractor families, and the S3 dispatch layer means the function you found is often not the
+one that runs.
+
+## Generated files: never hand-edit
+
+| Path | Generated by |
+|---|---|
+| `man/`, `NAMESPACE` | roxygen2, via `devtools::document()` |
+| `.claude/house-style.md` | the `ehrlinger/house-style` composer |
+
+`.claude/house-style.md` carries a `DO NOT EDIT` banner and the `house-style` CI job **fails
+the build** when it drifts from its vault sources. Editing it reddens CI and the next
+recompose reverts you.
+
+## Rules for this repo
+
+- `gg_*` functions return an object. `plot()` and `autoplot()` methods **return** a ggplot
+  object; they never `print()` it.
+- **Changing the class, element names or column names of a returned object is a breaking
+  change.** This package is on CRAN. Check reverse dependencies before proposing one.
+- **Importance plots put the most-important variable at the top.** After `coord_flip()` that
+  means it is the *last* factor level of the variable axis. `test_plot_conventions.R` pins
+  this across `gg_vimp`, `gg_varpro`, `gg_beta_varpro` and `gg_ivarpro`, because a
+  bottom-heavy ordering was a real bug once.
+- **`Depends` carries only the R version constraint.** `randomForestSRC`, `randomForest` and
+  `varPro` are `Imports` and are never attached from `R/`. `test_namespace_hygiene.R` pins
+  this. (`tests/testthat/setup.R` attaches them for the tests only; that is not licence to do
+  it in `R/`.)
+- Every `plot()` / `autoplot()` method should have a `vdiffr::expect_doppelganger()` test in
+  `test_snapshots.R`. There are 49 today against 38 methods; coverage is broad but has not
+  been audited per method.
+- Tests are deterministic. Any randomness gets an explicit `set.seed()`.
+- Anything slow gets `skip_on_cran()`.
+- No `browser()`, no bare `print()`, no `library()` inside `R/`.
+
+### Known gap, being addressed
+
+Tests currently fit forests inline at roughly 200 call sites across 23 files, which is why the
+suite takes about 130 seconds. There is no `tests/testthat/fixtures/` directory yet; the only
+precomputed fixtures are the in-memory session cache in `helper-varpro-fixtures.R`. Prefer
+reusing an existing fixture or a memoised helper over adding another inline fit, and keep any
+new fit small (few trees, few rows). It exists to exercise a code path, not to be
+statistically realistic.
+
+## Change discipline
+
+1. **Think before coding.** Do not assume, ask. If the request is ambiguous or a name, path or
+   signature is uncertain, surface the confusion instead of running with a guess. One good
+   clarifying question beats a confident wrong edit.
+2. **Simplicity first.** Write the minimum code that solves the stated problem. No speculative
+   abstractions, no "while I'm here" generalising. For this scientific code, prefer the plain
+   readable form a future reader can follow over the clever one.
+3. **Surgical changes.** Touch only what the task requires. Do not refactor, reformat or
+   re-style adjacent code, and do not reorganise imports or rename things that were not asked
+   for. If you spot something worth changing nearby, note it separately rather than folding it
+   in.
+4. **Define "done" as a passing test.** State what done looks like before you start. If no
+   test covers the change, add or propose one rather than declaring success from inspection.
+
+A new dependency is a CRAN cost. Ask first.
+
+## Git and versioning
+
+- **Never push to `main`.** Branch, commit, push the branch, open a PR, then stop. The
+  maintainer merges.
+- **Never roll the MINOR or MAJOR digit.** That is the maintainer's call, made when a feature
+  set is consolidated into a release. Patch bumps (`3.5.1` to `3.5.2`) are fine for
+  incremental work; say so when you make one.
+- **Always a plain three-digit version.** No `.9000` suffix, no fourth digit.
+- Every version bump updates **both** `DESCRIPTION` and the `Version:` line in `NEWS.md`. A
+  test greps `NEWS.md` for the exact `DESCRIPTION` version.
+
+## Prose
+
+Documentation prose (vignettes, README, roxygen `@description` and `@details`, release copy)
+follows the house style in `.claude/house-style.md`: a specific voice, reader persona and
+project context. Read it before writing user-facing text.
+
+## Gotchas
+
+- `object_usage_linter` is currently **disabled** in `.lintr`, so lint will not catch an
+  undefined symbol or an unused local. Do not rely on a green lint for that class of error.
+- `testthat` runs on **edition 2** here: `DESCRIPTION` has no `Config/testthat/edition` field.
+  Do not assume 3rd-edition semantics.
+- `randomForestSRC` output structure varies by version (3.6.2 is installed; `DESCRIPTION`
+  requires `>= 3.4.0`). Never index its fields by position.
+- CRAN rejects a package whose overall `R CMD check` exceeds about 10 minutes even at 0/0/0.
+  The current baseline is about 3.8 minutes of timed steps, dominated by the vignette rebuild
+  (53s) and `--run-donttest` examples (35s). Watch that budget when adding either.
+- Build `R CMD check` from a clean `git archive` export, not the working tree. An empty
+  `inst/doc` fabricates two vignette WARNINGs, and in a git worktree `.git` is a *file*, so
+  the VCS exclusion misses it and it lands in the tarball as a spurious hidden-files NOTE.
+  Both look like package defects and are not.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,124 +1,20 @@
-# CLAUDE.md
+@AGENTS.md
+
+# Claude Code specifics
+
+`AGENTS.md`, imported above, is the operational contract and applies in full. It is written to
+be tool neutral so that Codex and other agents read the same rules. Only the Claude Code
+affordances live here.
 
 ## Before you touch code
-Load this repo's codemap first. It lives in the Obsidian vault under `Claude/repomaps/`
-and is read via the `read-codemap` skill (`/codemap <repo>`). Orient on the public API
-surface and where-things-live *before* editing — do not infer structure from a partial
-file read. If the codemap looks stale, say so and offer to refresh it (`/regenerate-codemap`)
-rather than working from a guess.
 
-## Four rules
-1. **Think before coding.** Don't assume — ask. If the request is ambiguous or a name/path/
-   signature is uncertain, surface the confusion instead of running with a guess. One good
-   clarifying question beats a confident wrong edit.
+`AGENTS.md` says to orient on the public API surface before editing. In Claude Code the way to
+do that is the codemap: it lives in the Obsidian vault under `Claude/repomaps/` and is read via
+the `read-codemap` skill (`/codemap ggRandomForests`). If the codemap looks stale, say so and
+offer to refresh it (`/regenerate-codemap`) rather than working from a guess.
 
-2. **Simplicity first.** Write the minimum code that solves the stated problem. No speculative
-   abstractions, no "while I'm here" generalizing. For this scientific code, prefer the plain,
-   readable form a future reader can follow over the clever one.
+## Prose
 
-3. **Surgical changes.** Touch only what the task requires. Do not refactor, reformat, or
-   re-style adjacent code, and do not reorganize imports or rename things that weren't asked
-   for. If you spot something worth changing nearby, note it separately — don't fold it in.
-
-4. **Goal-driven execution — define "done" as a passing test.** State what "done" looks like
-   before you start, and use tests as the success criterion, not vibes. By language:
-   - **R** — `devtools::test()` and `R CMD check` pass, examples run clean.
-   - **Python** — the relevant `pytest` / doctests pass.
-   - **C** — it compiles clean with warnings on (`-Wall -Wextra`) and its checks pass:
-     `make check` / `ctest` for standalone code, or, for C compiled inside an R package,
-     `R CMD check` builds the native routines and the R tests that exercise them pass.
-     Run under a sanitizer (`-fsanitize=address,undefined`) when touching memory or pointers.
-   - **SAS** — the log is clean (no ERROR, no unexpected WARNING or uninitialized-variable
-     notes), and output validates against a known reference — `PROC COMPARE` against a
-     baseline dataset, or check figures against previously verified results. A run that
-     "finished" is not the same as a run that's correct; read the log.
-
-   If there's no test covering the change, add or propose one rather than declaring success
-   from inspection.
-
-## Before you push
-
-CI enforces `lint` and `R-CMD-check` on every PR. Run both locally first — a
-30-second local `lintr` run beats a full CI cycle to learn the same thing.
-
-1. **`Rscript -e 'lintr::lint_package()'` — must report 0 lints.** The `lint` job
-   fails the PR otherwise. `cyclocomp_linter` caps cyclomatic complexity at 20;
-   when a function grows one branch too many the fix is to extract a helper, not
-   to raise the cap.
-
-2. **`NOT_CRAN=true VDIFFR_RUN_TESTS=true Rscript -e 'devtools::test()'`** — not
-   `test_file()` under `load_all()`. `devtools::test()` sets `NOT_CRAN=true`; a
-   bare `test_file()` does not, so every `skip_on_cran()` test silently skips and
-   the run reports `SS` rather than a result. Reading `SS` as "fine" is how you
-   conclude a test passed when it never ran.
-
-   `VDIFFR_RUN_TESTS=true` is not optional here — without it this exact command
-   prunes the snapshots. See below.
-
-3. **`R CMD check --as-cran` with the manual** — see the release gate in the
-   global CLAUDE.md. It runs with `NOT_CRAN` false, so it does *not* exercise
-   `skip_on_cran()` tests. Step 2 is the only thing that does; a green check is
-   not evidence that those tests pass.
-
-### vdiffr snapshots
-
-A suite run with `VDIFFR_RUN_TESTS` unset deletes the guarded snapshots as
-"unused". Run with `VDIFFR_RUN_TESTS=true` so they register and nothing is
-pruned, or restore afterwards. If you regenerate a baseline, do it **last**: a
-later full-suite run deletes it, and a blanket
-`git checkout -- tests/testthat/_snaps/` to undo that will silently revert your
-regeneration along with the pruning.
-
-**Restoring afterwards only recovers the tracked snapshots.** There are 40
-tracked SVGs under `tests/testthat/_snaps/snapshots/` and, on a working
-checkout, several more that are untracked. `git restore` brings back the 40 and
-cannot bring back the rest — git never had them. This happened on 2026-08-06:
-one unguarded suite run pruned 49 files, and the 9 untracked ones were only
-recovered because a stale copy happened to survive in
-`ggRandomForests.Rcheck/00_pkg_src/`. That copy is not a backup and will not
-reliably be there.
-
-So the guard is the fix, not the cleanup. Check `git status` before and after
-any local suite run, and treat a wave of staged snapshot deletions as a signal
-that the env var was missing — not as a change to commit.
-
-**Two protections now sit under that advice, because remembering an env var has
-failed repeatedly.**
-
-1. **`.Renviron` inverts the default.** It sets
-   `VDIFFR_RUN_TESTS=${VDIFFR_RUN_TESTS-true}`, so an unset variable — the
-   state of every fresh shell, script and agent session, and the cause of every
-   prune so far — now reads as `true`. An explicit value still wins, so the
-   three CI workflows that set `"false"` are unaffected. `R --vanilla` ignores
-   `.Renviron`, and an explicit `"false"` still prunes.
-
-2. **`.githooks/pre-commit` blocks the commit.** A pruned working tree is
-   recoverable; a committed prune is the real loss, so the hook guards the
-   commit. **It needs one command per clone:**
-
-   ```bash
-   git config core.hooksPath .githooks
-   ```
-
-   Without that, the hook does nothing. To retire a baseline deliberately, use
-   `ALLOW_SNAPSHOT_DELETION=1 git commit ...`.
-
-Note that the guard style in the test file is *not* a lever. `test_snapshots.R`
-wraps most tests in a file-level `if (Sys.getenv(...) == "true")` and the rest
-in `skip()` inside `test_that()`; on testthat 3.3.2 a prune takes the baselines
-of both. Rewriting the guards would not have prevented any of this.
-
-If a measurement genuinely needs the guard off (tracing under CRAN skip
-semantics, say), run it against a throwaway export rather than this checkout —
-`git archive HEAD | tar -x -C "$TMPDIR/tree"` — so pruning has nothing of
-yours to delete.
-
-Only the three CI workflows set `VDIFFR_RUN_TESTS: "false"` deliberately
-(`R-CMD-check`, `test-coverage`, `check-manual`), where snapshots are not
-regenerated and pruning has nothing to prune. That CI setting is why the hazard
-is invisible until someone runs the suite on a laptop.
-
-## Voice
-Prose in vignettes, README, roxygen `@description`/`@details`, and release/post copy follows
-the `ehrlinger-writing` harness — my voice, reader persona, project context. Apply it for any
-documentation text in this repo.
+`AGENTS.md` points at `.claude/house-style.md` for the house voice. In Claude Code, apply the
+`ehrlinger-writing` skill instead: it carries the same voice, reader persona and project
+context, kept in sync from the vault sources that `house-style.md` is composed from.


### PR DESCRIPTION
Phase 1 of the agent-harness handoff. Rules files only; no logic changes, no
change to any file under `R/`, `tests/` or `man/`.

## What changed

* **`AGENTS.md` (new)** carries the tool-neutral operational contract.
* **`CLAUDE.md`** becomes the `@AGENTS.md` import plus the two Claude Code
  affordances the contract cannot express (the `/codemap` skill and the
  `ehrlinger-writing` skill).
* **`.Rbuildignore`** gains `^AGENTS\.md$`. `CLAUDE.md` and `.claude` were
  already listed.

## Why a split rather than an append

The handoff proposed reducing `CLAUDE.md` to a single import line. Taken
literally that would have deleted the vdiffr-pruning protocol and the pre-push
gate, so the content was sorted instead, by one question per paragraph: would a
non-Claude agent destroy something or ship something wrong without this?

That question matters here specifically. The whole point of `AGENTS.md` is that
Codex and other agents read it natively, so leaving the snapshot hazard behind
in `CLAUDE.md` would keep the single most destructive fact about this repo
visible to exactly one agent. A Codex session reading the repo today would run
the suite and prune all 49 baselines. The hazard had to move, not stay.

Structure, the `gg_*` design pattern, roxygen standards and code style are
already documented in `CONTRIBUTING.md`, so `AGENTS.md` links there rather than
restating them. The handoff's template would have made a fourth source of truth
for the same facts, alongside `CONTRIBUTING.md` and the generated
`.claude/house-style.md`.

## Corrected while migrating, not copied forward

The Phase 0 audit contradicted several statements in the old `CLAUDE.md` and in
the handoff's template. These were fixed rather than carried over:

* The snapshot count read "40 tracked SVGs and, on a working checkout, several
  more that are untracked". All 49 are tracked now (`git ls-files` and `find`
  agree), so the 9 recovered files were committed after that sentence was
  written. Carrying the old number forward would have understated what a prune
  now costs.
* The handoff's definition of done specified a bare `devtools::test()`. That is
  the exact command the same document warns about. `AGENTS.md` specifies
  `NOT_CRAN=true VDIFFR_RUN_TESTS=true Rscript -e 'devtools::test()'`.
* The handoff described `tests/testthat/fixtures/` as existing. It does not;
  that directory is Phase 3's output. `AGENTS.md` describes the actual state
  (about 200 inline fits across 23 files, in-memory memoisation only in
  `helper-varpro-fixtures.R`) under a "known gap" heading, so the file does not
  assert something false for the duration of Phases 2 to 4.
* The handoff asserted "every plot method needs a doppelganger". There are 19
  `plot` and 19 `autoplot` methods against 49 baselines. The file states that
  coverage is broad but unaudited per method rather than claiming completeness.
* Dropped the Python, C and SAS "done" criteria from the old `CLAUDE.md`. There
  is no `src/` and no package source in those languages; they were inherited
  boilerplate.

## Newly written down

Facts the Phase 0 audit measured that no file recorded: 34 `skip_on_cran()`
tests (so a green `R CMD check` is not evidence they pass), `object_usage_linter`
disabled in `.lintr`, testthat running on edition 2 because
`Config/testthat/edition` is absent, the `git config core.hooksPath .githooks`
one-time setup, the generated-and-CI-checked status of `.claude/house-style.md`,
and the check-time budget with its two dominant steps.

## Definition of done, as agreed

`document()` first, then lint, then tests, with `R CMD check --as-cran` once per
PR rather than per edit.

## Verification

`R CMD check --as-cran` with the manual, built from a clean `git archive HEAD`
export of this branch:

```
* checking top-level files ... OK
Status: 1 NOTE
```

Unchanged from the Phase 0 baseline. The single NOTE is `checking CRAN incoming
feasibility`, carrying "Number of updates in past 6 months: 7" and a
"possibly invalid URL" for the DESCRIPTION `BugReports` link. That 404 is a
false positive: `gh api` reports `has_issues: true` and a direct `curl` of the
URL returns 200. GitHub blocks the checker's user agent.

`AGENTS.md` is correctly absent from the built tarball. Tarball size is
2,368,790 bytes against the baseline 2,377,060, so it did not grow.

No file under `R/` changed, so lint and the test suite are unaffected by this
PR; the Phase 0 baselines (0 lints, FAIL 0 / WARN 46 / SKIP 5 / PASS 1468) stand.

## Note

`AGENTS.md` is expected to be edited before merge. It is deliberately not
polished into something that looks finished.

Two pre-existing em-dashes remain in `.Rbuildignore` comments (lines 55 and 60).
They were not introduced here and were left alone rather than folded into an
unrelated diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)