### PR TITLE
Cross-check extractors against their source forests

### DIFF
--- a/tests/testthat/test_autoplot_equivalence.R
+++ b/tests/testthat/test_autoplot_equivalence.R
@@ -1,0 +1,121 @@
+# autoplot() and plot() must produce the same plot for every gg_* class.
+#
+# All 19 autoplot methods are thin delegators: autoplot.gg_x() calls plot() or
+# plot.gg_x() and returns the result. That makes the failure mode a drift one.
+# Someone adds an argument, a default or a layer to plot.gg_x and does not
+# carry it through the delegator, or replaces a delegator with a second
+# implementation that starts out identical and then diverges. Nothing in the
+# suite noticed, because the existing autoplot tests only assert
+# expect_s3_class(p, "ggplot"), which stays true no matter how far the two
+# drift apart.
+#
+# A vdiffr baseline per autoplot method would also catch this, but it would
+# mean 19 more SVGs rendering the same plots the plot() baselines already
+# cover, and a visual diff answers "these images differ" rather than "the
+# delegation broke". Comparing the ggplot objects is cheaper and names the
+# actual defect. Audited 2026-08-17: all 49 existing baselines exercise
+# plot(); none exercise autoplot().
+#
+# DO NOT rewrite same_plot() as expect_equal(autoplot(x), plot(x)).
+#
+# On ggplot2 4.x a ggplot is an S7 object, all.equal() has no S7 method, and
+# the fallback compares nothing useful: all.equal() returns TRUE for two plots
+# with different titles. That version of this test passed while an
+# autoplot.gg_vimp() carrying an extra labs(caption = ...) was installed, which
+# is how the problem was found. Verified on ggplot2 4.0.3.
+#
+# identical() is no use either: it is FALSE even for plot(g) against plot(g),
+# because each carries its own plot environment.
+#
+# So compare the three things that actually characterise the plot, all of which
+# are ordinary R objects: the labels, the built layer data, and the geoms.
+
+# Some plot methods are not deterministic at BUILD time: plot.gg_rfsrc and
+# plot.gg_shap jitter or beeswarm their points, and the random draw happens
+# inside ggplot_build(), not when the plot object is constructed. Two builds of
+# the very same object therefore differ. Seeding before each build is what
+# makes this a comparison of delegation rather than of jitter.
+same_plot <- function(a, b, seed = 101L) {
+  built <- function(p) {
+    set.seed(seed)
+    ggplot2::ggplot_build(p)$data
+  }
+  geoms <- function(p) {
+    vapply(p$layers, function(l) class(l$geom)[1], character(1))
+  }
+  identical(a$labels, b$labels) &&
+    isTRUE(all.equal(built(a), built(b))) &&
+    identical(geoms(a), geoms(b))
+}
+
+test_that("autoplot() equals plot() for every cheaply constructible gg_* class", {
+  skip_on_cran()
+  skip_if_not_installed("randomForestSRC")
+  skip_if_not_installed("randomForest")
+  set.seed(20260817L)
+
+  rc <- randomForestSRC::rfsrc(
+    Species ~ ., iris,
+    ntree = 30, importance = TRUE, tree.err = TRUE
+  )
+  rr <- randomForestSRC::rfsrc(
+    mpg ~ ., mtcars,
+    ntree = 30, importance = TRUE, tree.err = TRUE
+  )
+  rs <- randomForestSRC::rfsrc(
+    Surv(time, status) ~ ., survival::veteran,
+    ntree = 30, importance = TRUE, tree.err = TRUE
+  )
+  rf <- randomForest::randomForest(Species ~ ., iris, ntree = 30, importance = TRUE)
+
+  objects <- list(
+    "gg_vimp (rfsrc classification)"   = gg_vimp(rc),
+    "gg_vimp (randomForest)"           = gg_vimp(rf),
+    "gg_error (classification)"        = gg_error(rc),
+    "gg_error (survival)"              = gg_error(rs),
+    "gg_rfsrc (classification)"        = gg_rfsrc(rc),
+    "gg_rfsrc (regression)"            = gg_rfsrc(rr),
+    "gg_rfsrc (survival)"              = gg_rfsrc(rs),
+    "gg_roc (classification)"          = gg_roc(rc, which_outcome = 1),
+    "gg_variable (regression)"         = gg_variable(rr),
+    "gg_brier (survival)"              = gg_brier(rs),
+    "gg_shap (regression)"             = gg_shap(rr),
+    "gg_survival"                      = gg_survival(
+      interval = "time", censor = "status", by = "trt", data = survival::veteran
+    )
+  )
+
+  # Some plot methods are not deterministic: plot.gg_rfsrc and plot.gg_shap
+  # jitter or beeswarm their points, so two renders of the SAME object differ
+  # in built data. Reseed immediately before each render so both draw the same
+  # random numbers and the comparison measures delegation, not jitter.
+  for (label in names(objects)) {
+    obj <- objects[[label]]
+    set.seed(101L)
+    rendered_autoplot <- ggplot2::autoplot(obj)
+    set.seed(101L)
+    rendered_plot <- plot(obj)
+    expect_true(
+      same_plot(rendered_autoplot, rendered_plot),
+      label = paste0("autoplot() matches plot() for ", label)
+    )
+  }
+
+  # A guard on the guard: if a future refactor makes these objects fail to
+  # build, the loop above would silently assert nothing at all.
+  expect_length(objects, 12L)
+})
+
+test_that("same_plot() can actually tell two plots apart", {
+  # Without this, the test above is one ggplot2 release away from passing
+  # vacuously again, exactly as the expect_equal() version already did. This
+  # pins the discriminating power itself rather than trusting it.
+  skip_if_not_installed("randomForestSRC")
+  set.seed(20260817L)
+  rf <- randomForestSRC::rfsrc(Species ~ ., iris, ntree = 20, importance = TRUE)
+  base <- plot(gg_vimp(rf))
+
+  expect_true(same_plot(base, base))
+  expect_false(same_plot(base, base + ggplot2::labs(caption = "drifted")))
+  expect_false(same_plot(base, base + ggplot2::ggtitle("different")))
+})

--- a/tests/testthat/test_extractor_contracts.R
+++ b/tests/testthat/test_extractor_contracts.R
@@ -1,0 +1,214 @@
+# Cross-checks: every gg_* value is compared against the field of the source
+# forest it is supposed to carry.
+#
+# The rest of the suite asserts shape: right class, right column names, right
+# number of rows. Shape assertions pass just as happily when an extractor reads
+# the wrong field, transposes a matrix, or silently reorders rows, which is the
+# failure mode that actually matters in a visualisation layer: the plot still
+# renders, and it shows the wrong number.
+#
+# Every assertion here compares against the source object, never against a
+# number pasted from a previous run. A stored constant bakes in whatever was
+# wrong when it was recorded, and breaks on every upstream version bump for a
+# reason that has nothing to do with this package.
+#
+# Each test names the specific wrong behaviour it would catch.
+
+## ---- gg_vimp ---------------------------------------------------------------
+
+test_that("gg_vimp carries rfsrc regression importance, sorted", {
+  # Catches: reading the wrong importance column, dropping the name-to-value
+  # pairing when sorting, or returning importance in fitted rather than
+  # descending order (the plot layer depends on that order).
+  skip_if_not_installed("randomForestSRC")
+  set.seed(20260817L)
+  rf <- randomForestSRC::rfsrc(mpg ~ ., mtcars, ntree = 50, importance = TRUE)
+
+  gg <- gg_vimp(rf)
+
+  expect_equal(gg$vimp, unname(rf$importance[as.character(gg$vars)]))
+  expect_false(is.unsorted(rev(gg$vimp)))
+})
+
+test_that("gg_vimp 'all' set matches the rfsrc classification importance column", {
+  # Catches: a multi-class pivot that pairs a variable with another class's
+  # importance. The long frame has one row per (variable, class), so an
+  # off-by-one in the pivot still yields a plausible plot.
+  skip_if_not_installed("randomForestSRC")
+  set.seed(20260817L)
+  rf <- randomForestSRC::rfsrc(Species ~ ., iris, ntree = 50, importance = TRUE)
+
+  gg  <- gg_vimp(rf)
+  all <- gg[gg$set == "all", ]
+
+  expect_equal(all$vimp, unname(rf$importance[as.character(all$vars), "all"]))
+})
+
+test_that("gg_vimp uses %IncMSE for randomForest, not IncNodePurity", {
+  # Catches: taking the wrong column of randomForest's two-column importance
+  # matrix. Both columns are numeric, positive and variable-named, so the
+  # substitution is invisible to every shape-based test, and IncNodePurity is
+  # a different quantity on a different scale.
+  skip_if_not_installed("randomForest")
+  set.seed(20260817L)
+  rf <- randomForest::randomForest(mpg ~ ., mtcars, ntree = 50, importance = TRUE)
+
+  gg <- gg_vimp(rf)
+
+  expect_equal(gg$vimp, unname(rf$importance[as.character(gg$vars), "%IncMSE"]))
+})
+
+## ---- gg_error --------------------------------------------------------------
+
+test_that("gg_error drops rfsrc's NA error rows and keeps the tree index", {
+  # rfsrc only evaluates err.rate every block.size trees, so with ntree = 50
+  # the vector is 50 long but mostly NA. gg_error keeps the evaluated points.
+  # Catches: retaining the NAs (a broken curve), renumbering the x axis 1..k
+  # instead of carrying the true tree index (a curve compressed to the left),
+  # or an upstream block.size default change going unnoticed.
+  skip_if_not_installed("randomForestSRC")
+  set.seed(20260817L)
+  rf <- randomForestSRC::rfsrc(mpg ~ ., mtcars, ntree = 50, tree.err = TRUE)
+
+  gg <- gg_error(rf)
+
+  expect_equal(gg$error, as.numeric(stats::na.omit(rf$err.rate)))
+  expect_equal(as.numeric(gg$ntree), as.numeric(which(!is.na(rf$err.rate))))
+  expect_false(anyNA(gg$error))
+})
+
+test_that("gg_error carries the full randomForest MSE trajectory", {
+  # randomForest's $mse is dense, one value per tree, unlike rfsrc's. Catches
+  # an extractor that applies rfsrc's NA-dropping logic to both packages and
+  # silently truncates the randomForest curve.
+  skip_if_not_installed("randomForest")
+  set.seed(20260817L)
+  rf <- randomForest::randomForest(mpg ~ ., mtcars, ntree = 50)
+
+  gg <- gg_error(rf)
+
+  expect_equal(gg$error, as.numeric(rf$mse))
+  expect_equal(nrow(gg), rf$ntree)
+})
+
+## ---- gg_rfsrc --------------------------------------------------------------
+
+test_that("gg_rfsrc regression carries OOB predictions, not in-bag", {
+  # Catches the substitution of $predicted for $predicted.oob. Both are
+  # numeric vectors of length n with the same names and a similar range, so
+  # nothing shape-based can tell them apart, but in-bag predictions are
+  # optimistically biased and would make every error plot look better than
+  # the model is. as.numeric() on both sides because predicted.oob is a 1-d
+  # array; the contract is about values, not the dim attribute.
+  skip_if_not_installed("randomForestSRC")
+  set.seed(20260817L)
+  rf <- randomForestSRC::rfsrc(mpg ~ ., mtcars, ntree = 50)
+
+  gg <- gg_rfsrc(rf)
+
+  expect_equal(as.numeric(gg$yhat), as.numeric(rf$predicted.oob))
+  expect_false(isTRUE(all.equal(as.numeric(gg$yhat), as.numeric(rf$predicted))))
+  expect_equal(as.numeric(gg$mpg), as.numeric(rf$yvar))
+})
+
+test_that("gg_rfsrc classification carries the OOB probability matrix intact", {
+  # Catches a transposed or column-rotated probability matrix. Every row still
+  # sums to 1 under a column rotation, so a sum-to-one check would pass while
+  # every class label was wrong.
+  skip_if_not_installed("randomForestSRC")
+  set.seed(20260817L)
+  rf <- randomForestSRC::rfsrc(Species ~ ., iris, ntree = 50)
+  lev <- levels(iris$Species)
+
+  gg <- gg_rfsrc(rf)
+
+  expect_equal(
+    unname(as.matrix(gg[, lev])),
+    unname(matrix(rf$predicted.oob, ncol = length(lev)))
+  )
+  expect_equal(gg$y, rf$yvar)
+})
+
+## ---- gg_brier --------------------------------------------------------------
+
+test_that("gg_brier agrees with randomForestSRC's own Brier calculation", {
+  # The integrated CRPS is the one scalar gg_brier and randomForestSRC both
+  # compute, so it is the available cross-check on the whole Brier pipeline.
+  # Catches a wrong time grid, a mis-weighted censoring correction, or an
+  # integration over the wrong axis. Note that the per-time crps column is a
+  # time-NORMALISED running score and is legitimately non-monotone; do not
+  # "fix" it into a monotone curve.
+  skip_if_not_installed("randomForestSRC")
+  set.seed(20260817L)
+  rf <- randomForestSRC::rfsrc(
+    Surv(time, status) ~ ., survival::veteran, ntree = 50
+  )
+
+  gg  <- gg_brier(rf)
+  src <- randomForestSRC::get.brier.survival(rf)
+
+  expect_equal(gg$time, as.numeric(rf$time.interest))
+  expect_equal(
+    as.numeric(attr(gg, "crps_integrated")), as.numeric(src$crps)
+  )
+  expect_true(all(gg$brier >= 0 & gg$brier <= 1, na.rm = TRUE))
+})
+
+## ---- gg_roc / calc_auc -----------------------------------------------------
+
+test_that("calc_auc matches the Mann-Whitney rank identity", {
+  # AUC equals the probability that a random positive outscores a random
+  # negative, which is computable from predicted.oob by ranks alone and shares
+  # no code with the ROC path. Catches a trapezoid integrated in the wrong
+  # direction, an off-by-one in the threshold grid, or sens/spec swapped:
+  # all of those still produce a monotone curve inside [0, 1].
+  skip_if_not_installed("randomForestSRC")
+  set.seed(20260817L)
+  rf  <- randomForestSRC::rfsrc(Species ~ ., iris, ntree = 50)
+  lev <- levels(iris$Species)
+
+  auc_rank <- function(score, positive) {
+    r  <- rank(score)
+    n1 <- sum(positive)
+    n0 <- sum(!positive)
+    (sum(r[positive]) - n1 * (n1 + 1) / 2) / (n1 * n0)
+  }
+
+  for (k in seq_along(lev)) {
+    expect_equal(
+      calc_auc(gg_roc(rf, which_outcome = k)),
+      auc_rank(as.numeric(rf$predicted.oob[, k]), iris$Species == lev[k]),
+      label = paste("AUC for class", lev[k])
+    )
+  }
+})
+
+## ---- known-truth simulation ------------------------------------------------
+
+test_that("gg_vimp separates known signal from known noise", {
+  # The only test here that can catch a plausible-but-wrong ranking. Every
+  # other importance test compares gg_vimp against rfsrc's importance field,
+  # so both would move together if the field were misread in a
+  # order-preserving way. Here the truth is fixed by construction: x1 and x2
+  # drive y, x3..x6 are independent noise, so every signal variable must
+  # outrank every noise variable.
+  skip_on_cran()
+  skip_if_not_installed("randomForestSRC")
+  set.seed(20260817L)
+  n   <- 300L
+  dta <- data.frame(
+    x1 = stats::rnorm(n), x2 = stats::rnorm(n), x3 = stats::rnorm(n),
+    x4 = stats::rnorm(n), x5 = stats::rnorm(n), x6 = stats::rnorm(n)
+  )
+  dta$y <- 5 * dta$x1 + 3 * dta$x2 + stats::rnorm(n, sd = 0.5)
+
+  rf <- randomForestSRC::rfsrc(y ~ ., dta, ntree = 200, importance = TRUE)
+  gg <- gg_vimp(rf)
+
+  imp    <- stats::setNames(gg$vimp, as.character(gg$vars))
+  signal <- imp[c("x1", "x2")]
+  noise  <- imp[c("x3", "x4", "x5", "x6")]
+
+  expect_true(min(signal) > max(noise))
+  expect_equal(names(which.max(imp)), "x1")
+})


### PR DESCRIPTION
Phase 4 of the agent-harness handoff: the tests that can catch a wrong answer.
Two new test files, **no change to `R/`**.

## Why

The suite asserts shape: right class, right column names, right row count. Shape
assertions pass just as happily when an extractor reads the wrong field,
transposes a matrix, or silently reorders rows. In a visualisation layer that is
the failure mode that matters, because the plot still renders and simply shows
the wrong number.

## `test_extractor_contracts.R`

Each value is compared against the field of the source forest it is supposed to
carry, never against a number pasted from a previous run. A stored constant
bakes in whatever was wrong when it was recorded and breaks on every upstream
bump for an unrelated reason.

| Test | Wrong behaviour it catches |
|---|---|
| `gg_vimp` rfsrc regression | wrong importance column; name-to-value pairing lost when sorting; not descending |
| `gg_vimp` rfsrc classification | multi-class pivot pairing a variable with another class's importance |
| `gg_vimp` randomForest | taking `IncNodePurity` instead of `%IncMSE`. Both are numeric, positive and variable-named; here they differ by 20x (10.1 vs 242.7) |
| `gg_error` rfsrc | keeping the NAs, or renumbering the x axis 1..k instead of the true tree index. rfsrc evaluates `err.rate` every `block.size` trees, so at `ntree = 50` only 5 of 50 entries are non-NA |
| `gg_error` randomForest | applying rfsrc's NA-dropping to randomForest's dense `$mse` and truncating the curve |
| `gg_rfsrc` regression | `$predicted` substituted for `$predicted.oob`. Same length, same names, similar range, but in-bag predictions are optimistically biased |
| `gg_rfsrc` classification | a transposed or column-rotated probability matrix. Rows still sum to 1 under rotation, so a sum-to-one check would pass with every class label wrong |
| `gg_brier` | wrong time grid, mis-weighted censoring correction, integration over the wrong axis. Checked against `randomForestSRC::get.brier.survival()` |
| `calc_auc` | trapezoid integrated backwards, off-by-one in the threshold grid, sens/spec swapped. Checked against the Mann-Whitney rank identity, which shares no code with the ROC path |
| known-truth simulation | a plausible-but-wrong ranking. `y` is driven by `x1`, `x2`; `x3..x6` are noise; every signal variable must outrank every noise variable |

The simulation is the only one of these that can catch a wrong ranking: the
others compare against rfsrc's importance field, so both sides would move
together if that field were misread in an order-preserving way.

## `test_autoplot_equivalence.R`

Auditing the baselines turned up a specific gap: all 19 `autoplot` methods are
thin delegators to `plot()`, **all 49 vdiffr baselines exercise `plot()`, and
none exercise `autoplot()`**. The existing autoplot tests assert only
`expect_s3_class(p, "ggplot")`, which stays true however far a delegator drifts.

A vdiffr baseline per autoplot method would also catch drift, but it means 19
more SVGs re-rendering plots the `plot()` baselines already cover, and a visual
diff says "these images differ" rather than "the delegation broke".

### The first version of this file was vacuous

Worth reading, because it is the actual finding of this phase:

> On ggplot2 4.x a ggplot is an **S7 object**. `all.equal()` has no S7 method
> and its fallback compares nothing useful, so **`expect_equal(autoplot(x),
> plot(x))` returns `TRUE` for two plots with completely different titles.**

That version passed cleanly with a deliberately drifted `autoplot.gg_vimp()`
installed. Mutation testing found it; the green test did not. The comparison is
now labels, built layer data and geoms, all ordinary R objects, and there is a
second test pinning the comparison's own discriminating power so this cannot
silently regress on the next ggplot2 release. The file carries a `DO NOT rewrite
this as expect_equal()` note with the reason.

Two related findings, recorded in comments rather than acted on:

- **`plot.gg_rfsrc` and `plot.gg_shap` are non-deterministic at build time**,
  not at construction time: the jitter draw happens inside `ggplot_build()`, so
  two builds of the same object differ. Both sides are seeded before building.
- **The existing suite is not affected by the S7 problem.** It compares scalar
  plot fields such as `p$labels$fill`, never whole ggplot objects.

## Verified by mutation, not by the tests passing

| Mutant | Result |
|---|---|
| `gg_rfsrc`: `predicted.oob` to `predicted` | **CAUGHT** (2 failures) |
| `autoplot.gg_vimp` gains a caption | **CAUGHT** (2 failures) |
| `autoplot.gg_roc` gains a layer | **CAUGHT** (1 failure) |

## Numbers

```
Rscript -e 'devtools::document()'                                   no change to man/ or NAMESPACE
Rscript -e 'lintr::lint_package()'                                  LINTS: 0
NOT_CRAN=true VDIFFR_RUN_TESTS=true Rscript -e 'devtools::test()'   [ FAIL 0 | WARN 58 | SKIP 5 | PASS 1506 ]
```

| Metric | Before | After |
|---|---|---|
| Assertions | 1468 | **1506** |
| Coverage | 89.06% | **89.06%** |
| Lints | 0 | 0 |
| New test wall time | | 1.3 s |

**Coverage is unchanged on purpose, and that is the point of the phase.** These
tests assert the correctness of lines the suite already executed. Coverage was
never the thing that catches a wrong estimator, which is why the handoff says
not to set a threshold.

All 49 vdiffr baselines intact; `git status` clean before and after every run.

## Remaining Phase 4 work, not done here

- **Five classes have no vdiffr baseline**: `gg_beta_uvarpro`,
  `gg_partial_rfsrc`, `gg_partialpro`, `gg_sdependent`, `gg_survival`. Baseline
  generation has to be done last in a session per `AGENTS.md`, so it is better
  as its own change.
- **Edge cases per extractor** (item 4: NA, zero rows, single row, single-level
  factor, unsorted input, ties) are not covered here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)