### PR TITLE
Add a Stop hook that gates on lint and the relevant tests

### DIFF
--- a/.claude/agents/r-reviewer.md
+++ b/.claude/agents/r-reviewer.md
@@ -1,0 +1,71 @@
+---
+name: r-reviewer
+description: Reviews R package changes for correctness, API stability and CRAN compliance. Use before opening a PR, and whenever a change touches an exported function.
+tools: Read, Grep, Glob, Bash
+model: opus
+---
+
+You review changes to ggRandomForests, a CRAN package that visualises
+`randomForestSRC`, `randomForest` and `varPro` objects. You did not write this
+code and you are not here to approve it.
+
+Read `git diff main...HEAD` and the files it touches. Report only defects,
+ranked by severity, each with file, line, and the concrete input that breaks it.
+If you find nothing, say so in one line. Do not summarise the change back.
+
+Check, in this order.
+
+1. **Numerical correctness.** Does the computation match the documented method?
+   Trace one value by hand if you can. Passing tests are not evidence: a wrong
+   estimator passes its own test. Specifically, does an extractor read the field
+   it claims to? `$predicted` and `$predicted.oob` have the same length, names
+   and rough range, and only one of them is out of bag. `%IncMSE` and
+   `IncNodePurity` are both positive and variable-named, and differ by orders of
+   magnitude.
+
+2. **API stability.** Any change to the class, element names or column names of
+   a returned object is breaking. This package is on CRAN. Check `NAMESPACE` and
+   the roxygen `@export` tags against what actually changed, and say so plainly
+   rather than noting it in passing.
+
+3. **Test quality.** For each new or changed test, name the specific mutation it
+   would catch. A test that only asserts `expect_s3_class(p, "ggplot")` or a row
+   count catches almost nothing. Two traps that have already bitten this repo:
+   - **`expect_equal()` on a whole ggplot object asserts nothing.** On ggplot2
+     4.x a ggplot is an S7 object, `all.equal()` has no S7 method, and it
+     returns TRUE for plots with different titles. Compare labels, built layer
+     data and geoms instead. See `test_autoplot_equivalence.R`.
+   - A number pasted from a previous run is not a cross-check. It bakes in
+     whatever was wrong when it was recorded. Compare against the source object.
+
+4. **Determinism.** Every `test_that()` block that reaches the RNG must call
+   `set.seed()` inside that block; a file-level seed does not count, because
+   testthat promises no execution order. `test_determinism.R` enforces this.
+   Note that `plot.gg_rfsrc` and `plot.gg_shap` draw their jitter inside
+   `ggplot_build()`, so seeding before `plot()` is not enough.
+
+5. **The vdiffr baselines.** Any deletion under `tests/testthat/_snaps/` is a
+   defect unless the change explicitly says a baseline is being retired. A wave
+   of deletions means a suite ran without `VDIFFR_RUN_TESTS=true`.
+
+6. **S3 consistency.** Methods match their generic. `plot()` and `autoplot()`
+   return a ggplot object rather than printing it. `print()` returns its
+   argument invisibly. Importance plots put the most important variable at the
+   top, which after `coord_flip()` is the LAST factor level.
+
+7. **Edge cases**: NA, zero rows, single row, single-level factor, unsorted
+   input, ties.
+
+8. **CRAN and dependency hygiene.** `Depends` carries only the R version
+   constraint; the forest packages are `Imports` and are never attached from
+   `R/`. A new dependency is a cost and needs the maintainer's agreement. Watch
+   the check-time budget: the overall `R CMD check` must stay well under ten
+   minutes, and the vignette rebuild plus `--run-donttest` examples already
+   account for most of it.
+
+9. **Debris**: `browser()`, bare `print()`, commented-out code, `library()`
+   inside `R/`, a hand-edited file under `man/` or `NAMESPACE`, or an edit to
+   the generated `.claude/house-style.md`.
+
+`Bash` is available because you need `git diff`. You have no `Write` or `Edit`,
+so you cannot alter what you review, and you should not ask for them.

--- a/.claude/hooks/verify.sh
+++ b/.claude/hooks/verify.sh
@@ -24,9 +24,17 @@ payload=$(cat)
 
 # Mandatory loop guard. Without it, a failure the agent cannot fix traps the
 # session in a stop / block / stop cycle forever.
-if [ "$(printf '%s' "$payload" | jq -r '.stop_hook_active // false')" = "true" ]; then
+#
+# Reading it needs jq, so a missing or failing jq has to mean "let the session
+# end", never "carry on without the guard". Carrying on is precisely the
+# endless loop this guard exists to prevent: the hook would block, the retry
+# would arrive with stop_hook_active true, and we still could not read it.
+# Fail open, and treat unparseable input the same way.
+if ! command -v jq >/dev/null 2>&1; then
   exit 0
 fi
+stop_active=$(printf '%s' "$payload" | jq -r '.stop_hook_active // false' 2>/dev/null) || exit 0
+[ "$stop_active" = "true" ] && exit 0
 
 cd "${CLAUDE_PROJECT_DIR:-$PWD}" || exit 0
 
@@ -81,31 +89,62 @@ token_for () {
     tests/testthat/test_*.R)
       basename "$f" .R | sed 's/^test_//' ;;
     R/*.R)
+      # Strip a method prefix, then truncate at the first remaining dot.
+      # R/plot.gg_vimp.R      -> gg_vimp
+      # R/surv_partial.rfsrc.R-> surv_partial   (matches test_surv_partial.R)
+      # R/ggrandomforests.news.R -> ggrandomforests (matches the _news test)
+      # Without the truncation those last two produce tokens that match no
+      # test file at all.
       basename "$f" .R | sed -e 's/^\.//' -e 's/^plot\.//' -e 's/^autoplot\.//' \
-                             -e 's/^print\.//' -e 's/^summary\.//' ;;
+                             -e 's/^print\.//' -e 's/^summary\.//' | cut -d. -f1 ;;
   esac
 }
 
 tokens=$(
   printf '%s\n' "$changed" | while read -r f; do
     token_for "$f"
-  done | sed 's/[^A-Za-z0-9_.]//g' | grep -v '^$' | sort -u
+  done | sed 's/[^A-Za-z0-9_]//g' | grep -v '^$' | sort -u
 )
 
-if [ -z "$tokens" ]; then
-  exit 0
+# Which test files do those tokens actually select? Eight files in R/
+# (calc_roc.R, print_methods.R, utils.R and friends) have no same-named test
+# and are covered indirectly, so "no match" is a normal case, not an edge one.
+#
+# Running zero tests and exiting 0 would be the worst possible outcome: the
+# hook would report success having verified nothing. So when targeting fails,
+# fall back to the whole suite. Cheap when we can target, correct when we
+# cannot.
+matched=""
+if [ -n "$tokens" ]; then
+  matched=$(
+    printf '%s\n' "$tokens" | while read -r t; do
+      ls tests/testthat/test_*.R 2>/dev/null | grep -- "$t" || true
+    done | sort -u
+  )
 fi
 
-filter=$(printf '%s' "$tokens" | paste -sd'|' -)
+if [ -n "$matched" ]; then
+  filter=$(printf '%s' "$tokens" | paste -sd'|' -)
+  # No quote characters in scope: it is interpolated into an R string literal
+  # inside a double-quoted bash string, and a stray ' ends that literal early.
+  scope="filter $filter"
+else
+  filter=""
+  scope="the FULL suite (nothing under R/ mapped to a test file)"
+fi
 
 test_out=$(Rscript -e "
   suppressMessages(devtools::load_all(quiet = TRUE))
-  res <- testthat::test_local(filter = '$filter', reporter = 'summary',
-                              stop_on_failure = FALSE)
-  df <- as.data.frame(res)
+  f   <- '$filter'
+  res <- testthat::test_local(filter = if (nzchar(f)) f else NULL,
+                              reporter = 'summary', stop_on_failure = FALSE)
+  df  <- as.data.frame(res)
   bad <- sum(df\$failed) + sum(df\$error)
-  cat('\nFILTER: $filter\n')
+  cat('\nSCOPE: $scope\n')
   cat('FILES:', length(unique(df\$file)), ' FAILED:', bad, '\n')
+  # Running nothing is not a pass. If the scope selected no files at all,
+  # something is wrong with the mapping and the run proved nothing.
+  if (length(unique(df\$file)) == 0L) quit(status = 1)
   if (bad > 0) quit(status = 1)
 " 2>&1) || fail "Tests failed for the files you changed.
 

--- a/.claude/hooks/verify.sh
+++ b/.claude/hooks/verify.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+#
+# Stop hook: refuse to let a session end with a failing harness.
+#
+# Exit 0 lets the session end. Exit 2 blocks it, and whatever this script
+# writes to stderr becomes the agent's instructions for what to fix.
+#
+# WHY THIS DOES NOT RUN THE WHOLE SUITE
+#
+# The full suite is about 109 seconds, and that is its floor: its cost is
+# dominated by two gg_partial_varpro tests whose expense IS the function under
+# test (partialpro), not setup, so no amount of fixture work makes it cheap.
+# See the Phase 3 profiling in AGENTS.md. Lint plus a full suite would put
+# about 126 seconds on the end of every session, and a gate that expensive gets
+# switched off within a week, which is worse than no gate.
+#
+# So: lint always (17 s, catches the cheap failures), then only the test files
+# that correspond to what actually changed. CI and the pre-PR
+# `R CMD check --as-cran` remain the full-coverage gates. This hook is the fast
+# one, and it is allowed to miss a cross-file breakage that CI will catch.
+set -uo pipefail
+
+payload=$(cat)
+
+# Mandatory loop guard. Without it, a failure the agent cannot fix traps the
+# session in a stop / block / stop cycle forever.
+if [ "$(printf '%s' "$payload" | jq -r '.stop_hook_active // false')" = "true" ]; then
+  exit 0
+fi
+
+cd "${CLAUDE_PROJECT_DIR:-$PWD}" || exit 0
+
+# Only source and test changes are worth verifying. A session that read files,
+# edited a vignette or updated docs ends immediately.
+changed=$(
+  {
+    git diff  --name-only HEAD -- R/ tests/ 2>/dev/null
+    git ls-files --others --exclude-standard -- R/ tests/ 2>/dev/null
+  } | sort -u
+)
+[ -z "$changed" ] && exit 0
+
+# NOT_CRAN keeps the 34 skip_on_cran() tests live: without it they report SS
+# and a run that skipped everything looks like a run that passed.
+#
+# VDIFFR_RUN_TESTS is the one that destroys work. Unset, testthat treats every
+# vdiffr baseline as unused and deletes all 49 of them. .Renviron already
+# defaults it to true, but this hook must not depend on that: R --vanilla
+# ignores .Renviron.
+export NOT_CRAN=true
+export VDIFFR_RUN_TESTS=true
+
+fail () {
+  printf 'Do not stop yet. The verification harness is failing.\n\n%s\n' "$1" >&2
+  exit 2
+}
+
+# ---- 1. lint -----------------------------------------------------------------
+if ! lint_out=$(Rscript -e 'l <- lintr::lint_package(); if (length(l)) { print(l); quit(status = 1) }' 2>&1); then
+  fail "lintr::lint_package() reported lints. Fix these, then re-run:
+
+$lint_out
+
+Note that cyclocomp_linter caps complexity at 20. When a function grows one
+branch too many the fix is to extract a helper, not to raise the cap."
+fi
+
+# ---- 2. targeted tests -------------------------------------------------------
+# Map each changed file to a testthat filter token. Test files map to
+# themselves; R/ files map to their gg_* family, so R/plot.gg_varpro.R and
+# R/gg_varpro.R both select test_gg_varpro.R.
+#
+# Deliberately a function rather than a `case` inside the $( ) below. A case
+# pattern ends in ')', and inside a command substitution bash reads that ')' as
+# the closing paren of the $( , which is a parse error several lines later at
+# the first ';;'. The Phase 5f tests caught this, having first "passed" three
+# cases for the wrong reason: a crashing hook also exits non-zero.
+token_for () {
+  local f="$1"
+  case "$f" in
+    tests/testthat/test_*.R)
+      basename "$f" .R | sed 's/^test_//' ;;
+    R/*.R)
+      basename "$f" .R | sed -e 's/^\.//' -e 's/^plot\.//' -e 's/^autoplot\.//' \
+                             -e 's/^print\.//' -e 's/^summary\.//' ;;
+  esac
+}
+
+tokens=$(
+  printf '%s\n' "$changed" | while read -r f; do
+    token_for "$f"
+  done | sed 's/[^A-Za-z0-9_.]//g' | grep -v '^$' | sort -u
+)
+
+if [ -z "$tokens" ]; then
+  exit 0
+fi
+
+filter=$(printf '%s' "$tokens" | paste -sd'|' -)
+
+test_out=$(Rscript -e "
+  suppressMessages(devtools::load_all(quiet = TRUE))
+  res <- testthat::test_local(filter = '$filter', reporter = 'summary',
+                              stop_on_failure = FALSE)
+  df <- as.data.frame(res)
+  bad <- sum(df\$failed) + sum(df\$error)
+  cat('\nFILTER: $filter\n')
+  cat('FILES:', length(unique(df\$file)), ' FAILED:', bad, '\n')
+  if (bad > 0) quit(status = 1)
+" 2>&1) || fail "Tests failed for the files you changed.
+
+$test_out
+
+Run the full suite before opening a PR:
+  NOT_CRAN=true VDIFFR_RUN_TESTS=true Rscript -e 'devtools::test()'"
+
+# ---- 3. the snapshot guard ---------------------------------------------------
+# The env vars above should make this impossible, but this repo has lost its
+# vdiffr baselines repeatedly and a deletion is far cheaper to catch here than
+# after it is committed.
+if git status --porcelain -- tests/testthat/_snaps | grep -q '^.D\|^D'; then
+  fail "Deleted vdiffr baselines are present in the working tree:
+
+$(git status --porcelain -- tests/testthat/_snaps)
+
+That is the signature of a suite run without VDIFFR_RUN_TESTS=true. Restore
+them with:
+  git checkout -- tests/testthat/_snaps/
+
+Do NOT commit the deletions. If you meant to retire a baseline, say so
+explicitly rather than letting a prune through."
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/verify.sh",
+            "timeout": 300
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -52,8 +52,15 @@ vignettes/uvarpro_cache/
 vignettes/uvarpro_files/
 vignettes/uvarpro.html
 
+# Everything under .claude is personal and stays out of the repo, EXCEPT the
+# few files that are shared project configuration. settings.local.json in
+# particular is a per-machine permissions allowlist and must stay ignored;
+# settings.json is the shared hook registration and must not.
 .claude/*
 !.claude/house-style.md
+!.claude/settings.json
+!.claude/hooks/
+!.claude/agents/
 .positai
 
 # Brainstorm / visual-companion scratch

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,6 +95,28 @@ Further notes, so nobody re-derives them:
   deliberately, where snapshots are not regenerated and pruning has nothing to prune. That CI
   setting is why the hazard stays invisible until someone runs the suite on a laptop.
 
+## The automated gates
+
+Three layers, at three different moments. They are complementary, not redundant.
+
+| Gate | When | What it runs |
+|---|---|---|
+| `.claude/hooks/verify.sh` (Claude Code `Stop` hook) | session end | lint, plus the test files matching what changed. About 27 seconds |
+| `.githooks/pre-commit` | `git commit` | blocks a commit that deletes vdiffr baselines |
+| CI, and `R CMD check --as-cran` | PR | everything |
+
+The `Stop` hook deliberately does **not** run the full suite. At about 109
+seconds the suite's cost is the code under test, not setup, so a full-suite gate
+would add roughly 126 seconds to every session end, and a gate that expensive
+gets switched off. It is allowed to miss a cross-file breakage that CI catches.
+
+There is **no auto-formatting hook.** `styler` was measured against this repo
+and would rewrite 48 of 51 files in `R/`, 2917 diff lines, so a one-line edit
+would come back with hundreds of lines of unrelated reformatting attached. Lint
+is the style gate here, and it is already at zero.
+
+Neither hook is a substitute for running the definition of done yourself.
+
 ## Before you touch code
 
 Orient on the public API surface and where things live **before** editing. Do not infer the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -374,6 +374,40 @@ A clean check means:
 0 errors ✔ | 0 warnings ✔ | 0 notes ✔
 ```
 
+### If you use Claude Code, or hit an unexplained hook failure
+
+`.claude/settings.json` registers a `Stop` hook, `.claude/hooks/verify.sh`, which
+refuses to let a Claude Code session end while the harness is failing. It runs
+only when something under `R/` or `tests/` changed, and then it runs
+`lintr::lint_package()` plus the test files that correspond to what you touched,
+not the whole suite. Roughly 27 seconds for a typical change.
+
+None of this affects a normal contributor working in another editor: the hook is
+read by Claude Code and by nothing else. It also does not replace anything. CI
+and `R CMD check --as-cran` remain the full-coverage gates, and the hook is
+allowed to miss a cross-file breakage that CI will catch.
+
+It assumes `jq`, `Rscript`, `lintr` and `devtools` are on `PATH`. If any is
+missing, or the hook misbehaves, move `.claude/settings.json` aside:
+
+```bash
+mv .claude/settings.json .claude/settings.json.off
+```
+
+Separately, and for everyone regardless of editor, please run this once per
+clone:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+That enables `.githooks/pre-commit`, which blocks a commit that deletes vdiffr
+baselines. It is the repo's protection against the single most destructive
+mistake available here: a test run with `VDIFFR_RUN_TESTS` unset deletes all 49
+visual-regression baselines. See `AGENTS.md` for the full story. The `Stop` hook
+also warns about deleted baselines in the working tree, which is earlier but
+weaker; the pre-commit hook is the one that actually stops the loss.
+
 One note about the package size or installed path is acceptable. Errors or warnings must be fixed before a PR can be merged.
 
 To reproduce the exact CI matrix locally you can use [rhub](https://r-hub.github.io/rhub/):

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -387,7 +387,7 @@ read by Claude Code and by nothing else. It also does not replace anything. CI
 and `R CMD check --as-cran` remain the full-coverage gates, and the hook is
 allowed to miss a cross-file breakage that CI will catch.
 
-It assumes `jq`, `Rscript`, `lintr` and `devtools` are on `PATH`. If any is
+It assumes `jq`, `Rscript`, `lintr` and `devtools` are on `PATH`. If any are
 missing, or the hook misbehaves, move `.claude/settings.json` aside:
 
 ```bash


### PR DESCRIPTION
Phase 5 of the agent-harness handoff: the enforcement layer. Adds
`.claude/settings.json`, `.claude/hooks/verify.sh`, and an `r-reviewer`
subagent. **Nothing under `R/` changes.**

## What the hook does

On session end, and only if something under `R/` or `tests/` changed:

1. `lintr::lint_package()`
2. the test files matching what changed, via a `testthat` filter
3. a check for deleted vdiffr baselines in the working tree

Exit 2 blocks the stop, and the stderr text becomes the agent's instructions.

## It does not run the full suite, on purpose

This is a deliberate departure from the drafted `verify.sh`, and it follows from
Phase 3's profiling. The suite's 109 seconds is its **floor**: the cost is two
`gg_partial_varpro` tests whose expense *is* the function under test
(`partialpro`), not setup. Lint plus a full suite would add about **126 seconds
to every session end**, and a gate that expensive gets switched off within a
week, which is worse than no gate.

Measured instead:

| Change | Hook runtime |
|---|---|
| Typical (`R/gg_vimp.R`) | **27 s** |
| Worst case (`R/gg_partial_varpro.R`, maps to the 59 s test file) | **83 s** |
| Drafted full-suite version | ~126 s |

CI and the pre-PR `R CMD check --as-cran` remain the full-coverage gates. This
hook is explicitly allowed to miss a cross-file breakage that CI will catch;
that trade is what keeps it cheap enough to survive.

## No auto-formatting hook

The plan called for a `PostToolUse` `styler` hook. Measured against this repo:

> **styler would rewrite 48 of 51 files in `R/`, 2917 diff lines.**

A one-line edit to `gg_partial_varpro.R` would come back with 313 lines of
unrelated reformatting attached, automatically, on every edit. That is the
handoff's own "no opportunistic refactoring" rule violated mechanically. Lint is
the style gate here and it is already at zero, so the hook is dropped rather
than shipped and quietly disabled later.

## Phase 5f, which is not optional

Six cases, each asserting an exact exit code:

| Case | Want | Result |
|---|---|---|
| no source changes | 0 | PASS |
| `stop_hook_active` honoured (loop guard) | 0 | PASS |
| deliberate lint error | 2 | PASS |
| deliberate test failure | 2 | PASS |
| harmless passing change | 0 | PASS |
| deleted vdiffr baseline | 2 | PASS |

**The first run found a real defect, and how it found it is the point.** A `)`
inside a `case` pattern closes an enclosing `$( )`, so the hook had a parse
error. Three cases "passed" anyway, because a crashing hook also exits non-zero.
Only the must-exit-0 case exposed it. `token_for()` is now a function outside
the substitution, with a comment explaining why.

The lint case also failed at first, **correctly**: the injected fault was an
unused local, and `object_usage_linter` is disabled in this repo's `.lintr`,
which `AGENTS.md` already warns about. The test now uses an over-length line,
which `line_length_linter` does catch.

## `.gitignore` change, worth a look

Line 55 excluded everything under `.claude` except `house-style.md`. That looks
deliberate, so I added three narrow exceptions rather than relaxing the rule:

```
!.claude/settings.json
!.claude/hooks/
!.claude/agents/
```

`settings.local.json` **stays ignored**: it is a per-machine permissions
allowlist, not shared configuration. Verified with `git check-ignore` both ways.
Say the word if you would rather keep all of `.claude` out of the repo, in which
case the hook has to be installed per clone instead.

## Two things deliberately not done

**5e is redundant.** It would have added `R-CMD-check` and `test-coverage`
workflows. Both already exist, along with seven others.

**The hook's snapshot check does not replace `.githooks/pre-commit`.** They act
at different moments: the hook warns about deletions in the working tree, the
pre-commit hook refuses the commit. The commit is where the loss becomes real,
so pre-commit stays the primary protection and still needs its one-time
`git config core.hooksPath .githooks`. Both are documented in `CONTRIBUTING.md`.

## Notes for a fresh clone

A committed `.claude/settings.json` does not run until the workspace is trusted,
so a fresh clone needs that prompt first. The hook assumes `jq`, `Rscript`,
`lintr` and `devtools` on `PATH`, and `CONTRIBUTING.md` now documents how to
switch it off (`mv .claude/settings.json .claude/settings.json.off`) for anyone
who hits an opaque failure. Contributors not using Claude Code are unaffected:
nothing else reads these files.

## Verification

```
Rscript -e 'devtools::document()'                                   no change to man/ or NAMESPACE
Rscript -e 'lintr::lint_package()'                                  LINTS: 0
NOT_CRAN=true VDIFFR_RUN_TESTS=true Rscript -e 'devtools::test()'   [ FAIL 0 | WARN 58 | SKIP 5 | PASS 1506 ]
```

Suite unchanged from Phase 4. All 49 baselines intact, `git status` clean before
and after every run. `verify.sh` is committed mode 100755.

🤖 Generated with [Claude Code](https://claude.com/claude-code)