### PR TITLE
Always run the cross-cutting tests in the Stop hook

### DIFF
--- a/.claude/hooks/verify.sh
+++ b/.claude/hooks/verify.sh
@@ -123,8 +123,25 @@ if [ -n "$tokens" ]; then
   )
 fi
 
+# Cross-cutting test files, always run when anything changed.
+#
+# These pin invariants across the whole package rather than testing one
+# extractor, so they are named after the property they check and NO per-file
+# token will ever select them. Leaving them out made the gate miss the thing it
+# exists for: editing R/gg_rfsrc.R selected only test_gg_rfsrc.R, while the
+# cross-check that catches a wrong value (predicted.oob swapped for the in-bag
+# predicted) lives in test_extractor_contracts.R. The hook passed a forest
+# extractor that had been made to report in-bag predictions.
+#
+# Both halves of the harness worked in isolation and did not compose. Only an
+# end-to-end run against merged main showed it.
+#
+# All six together cost about 3.2 seconds, so this is close to free.
+always='extractor_contracts|autoplot_equivalence|determinism|plot_conventions|default_dispatch|namespace_hygiene'
+
 if [ -n "$matched" ]; then
   filter=$(printf '%s' "$tokens" | paste -sd'|' -)
+  filter="$filter|$always"
   # No quote characters in scope: it is interpolated into an R string literal
   # inside a double-quoted bash string, and a stray ' ends that literal early.
   scope="filter $filter"


### PR DESCRIPTION
**The harness did not meet its own success criterion.** Both halves worked in
isolation and did not compose, and only an end-to-end run against merged `main`
showed it.

## What I checked, and what happened

The whole-job criterion from the handoff:

> an agent session that edits `R/` cannot end without `lintr::lint_package()`
> returning zero lints and `devtools::test()` passing, **and a wrong extractor
> value fails a test rather than passing review**

Verified on merged `main` by making `gg_rfsrc` report in-bag predictions instead
of out-of-bag, the exact mutant Phase 4 was written to catch, then running the
Stop hook:

```
--- mutant: gg_rfsrc reads in-bag predictions instead of OOB ---
 1 file changed, 1 insertion(+), 1 deletion(-)
  hook exit: 0
```

The session would have ended cleanly with a forest extractor reporting
optimistically biased predictions.

## Why

The two phases named their test files by different schemes, and nobody checked
that the schemes met.

The hook maps `R/gg_rfsrc.R` to the token `gg_rfsrc`, which selects
`test_gg_rfsrc.R`. But the Phase 4 cross-checks are named after the **property
they pin**, not the extractor they cover, so the one that catches a wrong value
lives in `test_extractor_contracts.R` and **no per-file token can ever select
it**. The same is true of `test_autoplot_equivalence.R`,
`test_determinism.R`, `test_plot_conventions.R`, `test_default_dispatch.R` and
`test_namespace_hygiene.R`.

So the gate was running the shape-based tests and skipping the value-based ones.
That is an unusually bad way to be wrong: it is the precise inversion of what
Phase 4 exists for.

## The fix

Those six always run when anything under `R/` or `tests/` changed. They pin
invariants across the whole package rather than testing one extractor, so
"always" is the only correct scope for them.

| File | Cost |
|---|---|
| `test_extractor_contracts.R` | 0.3 s |
| `test_autoplot_equivalence.R` | 1.6 s |
| `test_determinism.R` | 0.3 s |
| `test_plot_conventions.R` | 0.9 s |
| `test_default_dispatch.R` | 0.0 s |
| `test_namespace_hygiene.R` | 0.1 s |
| **total** | **3.2 s** |

Measured hook time for a typical change did not move: **25 s against 27 s
before**, inside run-to-run noise, because these overlap work `devtools` is
already doing.

## Phase 5f: ten cases to twelve

The two new ones are the regression tests for exactly this gap.

| Case | Want | Result |
|---|---|---|
| no source changes | 0 | PASS |
| `stop_hook_active` honoured | 0 | PASS |
| deliberate lint error | 2 | PASS |
| deliberate test failure | 2 | PASS |
| harmless passing change | 0 | PASS |
| deleted vdiffr baseline | 2 | PASS |
| `jq` absent from PATH | 0 | PASS |
| `jq` present but failing | 0 | PASS |
| `surv_partial.rfsrc.R` maps to its test | match | PASS |
| unmapped R file falls back to full suite | 0 | PASS |
| **in-bag-for-OOB mutant in `gg_rfsrc`** | **2** | **PASS** |
| **`autoplot.gg_vimp` delegation drift** | **2** | **PASS** |

## Verification

```
Rscript -e 'lintr::lint_package()'                                  LINTS: 0
NOT_CRAN=true VDIFFR_RUN_TESTS=true Rscript -e 'devtools::test()'   [ FAIL 0 | WARN 58 | SKIP 5 | PASS 1506 ]
```

49 baselines intact, tree clean.

## The general point

Every individual piece of this harness was tested and passing before this
commit. What was not tested was whether they added up, and they did not. An
end-to-end check against the merged result is not the same as the sum of the
phase checks, and it is the only one that would have caught this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)