### PR TITLE
Make the Stop hook actually gate the workflow it is meant to gate

### DIFF
--- a/.claude/hooks/verify.sh
+++ b/.claude/hooks/verify.sh
@@ -53,7 +53,19 @@ cd "${CLAUDE_PROJECT_DIR:-$PWD}" || exit 0
 #
 # So: everything committed on this branch since it left the base, plus anything
 # still uncommitted, plus untracked files.
-base=$(git merge-base HEAD main 2>/dev/null || true)
+# Resolving the base has to survive a clone with no local `main`. `gh pr
+# checkout` and a single-branch clone both leave only `origin/main`, and a fork
+# may use another name. If this resolves to nothing, `changed` falls back to the
+# working tree alone and the committed-work blind spot comes straight back, so
+# try in order and take the first that answers.
+base=""
+for ref in main origin/main origin/HEAD master origin/master; do
+  if candidate=$(git merge-base HEAD "$ref" 2>/dev/null) && [ -n "$candidate" ]; then
+    base="$candidate"
+    break
+  fi
+done
+
 changed=$(
   {
     [ -n "$base" ] && git diff --name-only "$base" HEAD -- R/ tests/ 2>/dev/null
@@ -61,7 +73,19 @@ changed=$(
     git ls-files --others --exclude-standard -- R/ tests/ 2>/dev/null
   } | sort -u
 )
-[ -z "$changed" ] && exit 0
+
+# A clone where NO base resolves (git clone --single-branch fetches neither
+# `main` nor `origin/main`) cannot answer "what changed on this branch".
+# Exiting 0 there is the committed-work blind spot again by another route, so
+# say so and verify everything instead. Correct and slow beats silent. A normal
+# clone never takes this path, so "nothing changed, end immediately" is
+# unaffected.
+if [ -z "$base" ] && [ -z "$changed" ]; then
+  base_unknown=1
+else
+  base_unknown=0
+  [ -z "$changed" ] && exit 0
+fi
 
 # NOT_CRAN keeps the 34 skip_on_cran() tests live: without it they report SS
 # and a run that skipped everything looks like a run that passed.
@@ -183,6 +207,10 @@ fi
 #
 # All six together cost about 3.2 seconds, so this is close to free.
 always='extractor_contracts|autoplot_equivalence|determinism|plot_conventions|default_dispatch|namespace_hygiene'
+
+if [ "$base_unknown" = "1" ]; then
+  matched=""
+fi
 
 if [ -n "$matched" ]; then
   filter=$(printf '%s' "$tokens" | paste -sd'|' -)

--- a/.claude/hooks/verify.sh
+++ b/.claude/hooks/verify.sh
@@ -40,9 +40,24 @@ cd "${CLAUDE_PROJECT_DIR:-$PWD}" || exit 0
 
 # Only source and test changes are worth verifying. A session that read files,
 # edited a vignette or updated docs ends immediately.
+#
+# THREE SOURCES, AND THE FIRST ONE IS THE POINT.
+#
+# The original version asked `git diff HEAD` alone, which sees only uncommitted
+# work. AGENTS.md mandates branch, commit, push, open a PR, then stop, so the
+# hook fires precisely when the tree is clean, and it exited 0 having checked
+# nothing. Verified before the fix: syntactically invalid R committed to a
+# branch produced exit 0. Every case in the 5f suite had used an uncommitted
+# change, so the suite was green against a code path the real workflow never
+# takes.
+#
+# So: everything committed on this branch since it left the base, plus anything
+# still uncommitted, plus untracked files.
+base=$(git merge-base HEAD main 2>/dev/null || true)
 changed=$(
   {
-    git diff  --name-only HEAD -- R/ tests/ 2>/dev/null
+    [ -n "$base" ] && git diff --name-only "$base" HEAD -- R/ tests/ 2>/dev/null
+    git diff --name-only HEAD -- R/ tests/ 2>/dev/null
     git ls-files --others --exclude-standard -- R/ tests/ 2>/dev/null
   } | sort -u
 )
@@ -62,6 +77,36 @@ fail () {
   printf 'Do not stop yet. The verification harness is failing.\n\n%s\n' "$1" >&2
   exit 2
 }
+
+snapshot_deletions () {
+  git status --porcelain -- tests/testthat/_snaps 2>/dev/null | grep '^.D\|^D' || true
+}
+
+# ---- 0. snapshot check, BEFORE anything runs ---------------------------------
+# This has to come first, and the reason is not obvious.
+#
+# Checking only after the test step cannot see a prune that the test step
+# healed. If a suite ran earlier in the session with VDIFFR_RUN_TESTS unset,
+# the working tree holds 49 deletions. None of those paths map to a token, so
+# the hook takes the full-suite fallback, and that run regenerates every
+# missing baseline from the current rendering (vdiffr writes new snapshots
+# rather than failing when fail_on_new is FALSE, which it is off CI). The
+# deletions are replaced by files, the after-check finds nothing, and the hook
+# exits 0. The prune is now invisible AND .githooks/pre-commit has nothing left
+# to refuse.
+if [ -n "$(snapshot_deletions)" ]; then
+  fail "Deleted vdiffr baselines are already present in the working tree, before
+this hook ran anything:
+
+$(snapshot_deletions)
+
+That is the signature of a suite run without VDIFFR_RUN_TESTS=true. Restore
+them before doing anything else:
+  git checkout -- tests/testthat/_snaps/
+
+This check runs BEFORE the tests deliberately. A later full-suite run would
+regenerate the missing files from the current rendering and hide the loss."
+fi
 
 # ---- 1. lint -----------------------------------------------------------------
 if ! lint_out=$(Rscript -e 'l <- lintr::lint_package(); if (length(l)) { print(l); quit(status = 1) }' 2>&1); then
@@ -157,11 +202,25 @@ test_out=$(Rscript -e "
                               reporter = 'summary', stop_on_failure = FALSE)
   df  <- as.data.frame(res)
   bad <- sum(df\$failed) + sum(df\$error)
+  executed <- sum(!df\$skipped)
   cat('\nSCOPE: $scope\n')
-  cat('FILES:', length(unique(df\$file)), ' FAILED:', bad, '\n')
-  # Running nothing is not a pass. If the scope selected no files at all,
-  # something is wrong with the mapping and the run proved nothing.
-  if (length(unique(df\$file)) == 0L) quit(status = 1)
+  cat('FILES:', length(unique(df\$file)),
+      ' TESTS:', nrow(df), ' EXECUTED:', executed,
+      ' SKIPPED:', sum(df\$skipped), ' FAILED:', bad, '\n')
+  # Running nothing is not a pass, in either of the two ways it can happen.
+  #
+  # Selecting no file at all means the mapping is broken. Selecting files that
+  # then skip every block means the run proved nothing either: that is the
+  # SS-reads-as-a-pass failure AGENTS.md warns about, and counting only
+  # failed + error reproduced it inside the gate built to prevent it. A missing
+  # randomForestSRC, for instance, skips essentially the whole scope.
+  if (length(unique(df\$file)) == 0L) {
+    cat('ERROR: the scope selected no test file.\n'); quit(status = 1)
+  }
+  if (executed == 0L) {
+    cat('ERROR: every test in scope skipped. Nothing was verified.\n')
+    quit(status = 1)
+  }
   if (bad > 0) quit(status = 1)
 " 2>&1) || fail "Tests failed for the files you changed.
 

--- a/.gitignore
+++ b/.gitignore
@@ -56,11 +56,26 @@ vignettes/uvarpro.html
 # few files that are shared project configuration. settings.local.json in
 # particular is a per-machine permissions allowlist and must stay ignored;
 # settings.json is the shared hook registration and must not.
+# Everything under .claude is personal and stays out of the repo, EXCEPT the
+# few files that are shared project configuration. settings.local.json in
+# particular is a per-machine permissions allowlist and must stay ignored;
+# settings.json is the shared hook registration and must not.
+#
+# The hooks and agents entries are three lines each on purpose. Git will not
+# descend into an ignored directory, so the directory has to be un-ignored
+# first; but un-ignoring it alone exposes EVERYTHING inside, so a personal
+# subagent saved by /agents, or a local hook holding a machine path or token,
+# would be picked up by `git add -A`. Re-ignore the contents, then name the one
+# shared file.
 .claude/*
 !.claude/house-style.md
 !.claude/settings.json
 !.claude/hooks/
+.claude/hooks/*
+!.claude/hooks/verify.sh
 !.claude/agents/
+.claude/agents/*
+!.claude/agents/r-reviewer.md
 .positai
 
 # Brainstorm / visual-companion scratch

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,10 +36,10 @@ Three details in that list are load bearing:
   work" below. `devtools::test()` sets `NOT_CRAN=true` itself, but a bare
   `testthat::test_file()` under `load_all()` does not, so every `skip_on_cran()` test
   silently skips and the run reports `SS` instead of a result. Reading `SS` as "fine" is how
-  you conclude a test passed when it never ran. There are 34 `skip_on_cran()` calls in this
+  you conclude a test passed when it never ran. There are 37 `skip_on_cran()` calls in this
   suite, so this is not a hypothetical.
 
-`R CMD check` runs with `NOT_CRAN` false, so it does **not** exercise those 34 tests. A green
+`R CMD check` runs with `NOT_CRAN` false, so it does **not** exercise those 37 tests. A green
 check is not evidence that they pass; only the `devtools::test()` line above is.
 
 ## The one thing that destroys work
@@ -101,7 +101,7 @@ Three layers, at three different moments. They are complementary, not redundant.
 
 | Gate | When | What it runs |
 |---|---|---|
-| `.claude/hooks/verify.sh` (Claude Code `Stop` hook) | session end | lint, plus the test files matching what changed. About 27 seconds |
+| `.claude/hooks/verify.sh` (Claude Code `Stop` hook) | session end | lint, plus the test files matching what changed, plus the six cross-cutting files. About 25 seconds, or about 130 when a changed file maps to no test and it falls back to the whole suite |
 | `.githooks/pre-commit` | `git commit` | blocks a commit that deletes vdiffr baselines |
 | CI, and `R CMD check --as-cran` | PR | everything |
 
@@ -120,9 +120,9 @@ Neither hook is a substitute for running the definition of done yourself.
 ## Before you touch code
 
 Orient on the public API surface and where things live **before** editing. Do not infer the
-structure of this package from a partial file read: there are 60 exported symbols across
-19 extractor families, and the S3 dispatch layer means the function you found is often not the
-one that runs.
+structure of this package from a partial file read: `NAMESPACE` carries 29 `export()`
+directives and 115 `S3method()` registrations across 19 extractor families, and the S3
+dispatch layer means the function you found is often not the one that runs.
 
 ## Generated files: never hand-edit
 

--- a/tests/testthat/test_autoplot_equivalence.R
+++ b/tests/testthat/test_autoplot_equivalence.R
@@ -79,16 +79,26 @@ test_that("autoplot() equals plot() for every cheaply constructible gg_* class",
     "gg_roc (classification)"          = gg_roc(rc, which_outcome = 1),
     "gg_variable (regression)"         = gg_variable(rr),
     "gg_brier (survival)"              = gg_brier(rs),
-    "gg_shap (regression)"             = gg_shap(rr),
     "gg_survival"                      = gg_survival(
       interval = "time", censor = "status", by = "trt", data = survival::veteran
     )
   )
 
+  # gg_shap() stops() when kernelshap is absent, and kernelshap is Suggests.
+  # Built inside the list literal above it took the whole block down with it on
+  # any machine without the package, losing all the other comparisons, and
+  # since this is one of the files the Stop hook always runs, it blocked every
+  # session end there too. Add it only when it can be built, rather than
+  # guarding the whole test and skipping eleven working comparisons.
+  if (requireNamespace("kernelshap", quietly = TRUE)) {
+    objects[["gg_shap (regression)"]] <- gg_shap(rr)
+  }
+
   # Some plot methods are not deterministic: plot.gg_rfsrc and plot.gg_shap
   # jitter or beeswarm their points, so two renders of the SAME object differ
   # in built data. Reseed immediately before each render so both draw the same
   # random numbers and the comparison measures delegation, not jitter.
+  compared <- 0L
   for (label in names(objects)) {
     obj <- objects[[label]]
     set.seed(101L)
@@ -99,11 +109,16 @@ test_that("autoplot() equals plot() for every cheaply constructible gg_* class",
       same_plot(rendered_autoplot, rendered_plot),
       label = paste0("autoplot() matches plot() for ", label)
     )
+    compared <- compared + 1L
   }
 
-  # A guard on the guard: if a future refactor makes these objects fail to
-  # build, the loop above would silently assert nothing at all.
-  expect_length(objects, 12L)
+  # A guard on the guard. The previous version asserted length(objects) == 12,
+  # which could not fail as intended: a constructor that errors takes the list
+  # literal down before the assertion is reached, and if every constructor
+  # succeeds the length is 12 by construction. Counting the comparisons the
+  # loop actually performed is the property that was wanted.
+  expect_equal(compared, length(objects))
+  expect_gte(compared, 11L)
 })
 
 test_that("same_plot() can actually tell two plots apart", {


### PR DESCRIPTION
Findings from running the `r-reviewer` subagent against the merged harness, which
is to say the reviewer this work shipped reviewing the work that shipped it. Five
defects fixed here, each verified before and after. **Nothing under `R/` changes.**

## 1. The gate was silent in the workflow this repo mandates

`verify.sh` asked `git diff HEAD`, which sees only **uncommitted** work.
`AGENTS.md` mandates branch, commit, push, open a PR, then stop, so the hook
fired exactly when the tree was clean.

Verified against the merged hook with syntactically invalid R:

```
-- uncommitted (what 5f tested):   exit 2   blocked
-- same breakage, COMMITTED:       exit 0   waved through
   git diff HEAD:          []
   git diff main...HEAD:   [R/gg_vimp.R]
```

The three commits that built this hook would each have sailed past it.

**Why it survived Phase 5 is the part worth keeping.** All twelve 5f cases used
an uncommitted change, so the suite was green against a code path the real
workflow never takes. Same shape as the composition failure in #196: a path was
tested; the workflow was not. The fix unions the branch diff since its merge
base with the working tree and untracked files.

## 2. An all-skipped run counted as a pass

The gate compared only `failed + error` and never consulted `skipped`. Verified
with a probe file containing a single `skip()`:

```
files: 1  tests: 1  executed: 0  failed: 0
OLD rule (bad > 0):       PASS   <- would have waved it through
NEW rule (executed == 0): FAIL   <- correct
```

A library path without `randomForestSRC` skips essentially the whole selected
scope. This is the `SS`-reads-as-a-pass failure `AGENTS.md` warns about,
reproduced inside the gate built to prevent it.

## 3. The snapshot guard could not see a prune it had already healed

The check ran *after* the tests. If a suite had run earlier with
`VDIFFR_RUN_TESTS` unset, the tree held 49 deletions; none of those paths map to
a token, so the hook took the **full-suite fallback**, and that run regenerates
every missing baseline from the current rendering (vdiffr writes new snapshots
rather than failing when `fail_on_new` is FALSE, which it is off CI). The
deletions became files, the after-check found nothing, exit 0. The prune was
invisible **and** `pre-commit` had nothing left to refuse.

The check now also runs before anything else, and fails in ~0 s:

```
exit 2 (want 2), took 0s (should be ~0s: fails before running tests)
```

## 4. `.gitignore` un-ignored two whole directories

`!.claude/hooks/` and `!.claude/agents/` are directory-scoped, so everything
inside was trackable. A personal subagent saved by `/agents`, or a local hook
holding a machine path or token, would be caught by `git add -A`. Verified both
directions after the fix:

```
IGNORED      .claude/agents/personal-notes.md
IGNORED      .claude/hooks/local-secret.sh
IGNORED      .claude/settings.local.json
trackable    .claude/hooks/verify.sh
trackable    .claude/agents/r-reviewer.md
trackable    .claude/settings.json
```

## 5. `test_autoplot_equivalence.R` errored without `kernelshap`

`gg_shap()` stops when `kernelshap` is absent, and it was built inside the eager
list literal, so on a machine without that `Suggests` the whole block died and
**all twelve comparisons were lost**, not just the shap one. It is one of the six
files the hook always runs, so it also blocked every session end there. It is now
added only when it can be built.

The adjacent `expect_length(objects, 12L)` could never fail as intended (a
failing constructor errors before reaching it; if none fail the length is 12 by
construction), so it is replaced by a count of the comparisons the loop actually
performed.

## Also: counts in `AGENTS.md` that were wrong when they merged

- `34 skip_on_cran()` to **37**. This repo's own new tests made it stale in the
  same merge that introduced the claim.
- "60 exported symbols" to the actual **29 `export()` and 115 `S3method()`**.
- The gate table now gives both the 25 s targeted time and the ~130 s fallback.

## Phase 5f: twelve cases to fourteen

| Case | Want | Result |
|---|---|---|
| ...the twelve existing cases... | | all PASS |
| **committed breakage blocks** | **2** | **PASS** |
| **pre-existing prune blocks before tests** | **2** | **PASS** |

```
Rscript -e 'lintr::lint_package()'                                  LINTS: 0
NOT_CRAN=true VDIFFR_RUN_TESTS=true Rscript -e 'devtools::test()'   [ FAIL 0 | WARN 58 | SKIP 5 | PASS 1507 ]
```

49 baselines intact, tree clean.

## Deliberately not in this PR

Eight further findings from the same review, kept out to hold this to the gate's
correctness. All recorded in the vault handoff:

- `test_determinism.R`'s parser is blind to a namespaced `testthat::test_that()`,
  to a seed placed *after* the RNG call, and to `ggplot_build`/`sample.int` as
  consumers. **Verified**: it flags zero of six probe blocks. It also names six
  real blocks in `test_snapshots.R` relying on a file-level seed.
- `same_plot()` does not detect `coord_flip()` or `theme_bw()`. **Verified** on
  ggplot2 4.0.3. `coord_flip()` is what inverts the most-important-at-top
  convention, so this is the highest-value one remaining.
- The extractor cross-checks index the source by the extractor's own output, so a
  truncated variable set passes.
- The full-suite fallback is all-or-nothing: one matching token suppresses it.
- `matched` greps full paths while testthat filters stripped basenames.
- Deleting `test_lint.R` shifted lint coverage out of the suite for non-Claude
  contributors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)