### PR TITLE
Close the determinism parser and same_plot blind spots

### DIFF
--- a/tests/testthat/test_autoplot_equivalence.R
+++ b/tests/testthat/test_autoplot_equivalence.R
@@ -35,17 +35,46 @@
 # inside ggplot_build(), not when the plot object is constructed. Two builds of
 # the very same object therefore differ. Seeding before each build is what
 # makes this a comparison of delegation rather than of jitter.
+# ggplot_build()$data is post-stat but PRE-COORD, and $labels carries nothing
+# about coords, themes, scales or facets. Comparing only those two plus the
+# geoms therefore treated several whole classes of divergence as a match.
+# Measured on ggplot2 4.0.3 against plot(gg_error(rf)), each of these is
+# invisible to labels + built data + geoms alone:
+#
+#   + coord_flip()      transposes the plot
+#   + theme_bw()        restyles it
+#   + scale_fill_grey() recolours it
+#   + facet_wrap(...)   splits it into panels
+#
+# Note that a coord mutation on gg_vimp specifically is NOT detectable, and
+# should not be: plot.gg_vimp already applies coord_flip(), so adding another
+# replaces CoordFlip with CoordFlip and the plot really is unchanged. The
+# self-test below uses gg_error, whose plot is CoordCartesian, for exactly that
+# reason.
+# Everything about the plot that is an ordinary R object and so can be compared
+# with identical(). Kept separate from same_plot() because chaining these as one
+# && expression pushed cyclocomp past this repo's limit of 20, and the house
+# rule is to extract a helper rather than raise the cap.
+plot_shape <- function(p) {
+  list(
+    labels = p$labels,
+    geoms  = vapply(p$layers, function(l) class(l$geom)[1], character(1)),
+    coord  = class(p$coordinates)[1],
+    facet  = class(p$facet)[1],
+    scales = vapply(p$scales$scales, function(s) class(s)[1], character(1)),
+    theme  = p$theme
+  )
+}
+
+# Seeded because the draw happens here, not at construction.
+built_data <- function(p, seed) {
+  set.seed(seed)
+  ggplot2::ggplot_build(p)$data
+}
+
 same_plot <- function(a, b, seed = 101L) {
-  built <- function(p) {
-    set.seed(seed)
-    ggplot2::ggplot_build(p)$data
-  }
-  geoms <- function(p) {
-    vapply(p$layers, function(l) class(l$geom)[1], character(1))
-  }
-  identical(a$labels, b$labels) &&
-    isTRUE(all.equal(built(a), built(b))) &&
-    identical(geoms(a), geoms(b))
+  identical(plot_shape(a), plot_shape(b)) &&
+    isTRUE(all.equal(built_data(a, seed), built_data(b, seed)))
 }
 
 test_that("autoplot() equals plot() for every cheaply constructible gg_* class", {
@@ -112,10 +141,20 @@ test_that("same_plot() can actually tell two plots apart", {
   # pins the discriminating power itself rather than trusting it.
   skip_if_not_installed("randomForestSRC")
   set.seed(20260817L)
-  rf <- randomForestSRC::rfsrc(Species ~ ., iris, ntree = 20, importance = TRUE)
-  base <- plot(gg_vimp(rf))
+  rf <- randomForestSRC::rfsrc(
+    Species ~ ., iris,
+    ntree = 20, importance = TRUE, tree.err = TRUE
+  )
+
+  # gg_error, not gg_vimp: plot.gg_vimp already applies coord_flip(), so
+  # adding another is genuinely a no-op there and would make the coord case
+  # untestable. plot.gg_error is CoordCartesian.
+  base <- plot(gg_error(rf))
 
   expect_true(same_plot(base, base))
   expect_false(same_plot(base, base + ggplot2::labs(caption = "drifted")))
   expect_false(same_plot(base, base + ggplot2::ggtitle("different")))
+  expect_false(same_plot(base, base + ggplot2::coord_flip()))
+  expect_false(same_plot(base, base + ggplot2::theme_bw()))
+  expect_false(same_plot(base, base + ggplot2::scale_colour_grey()))
 })

--- a/tests/testthat/test_autoplot_equivalence.R
+++ b/tests/testthat/test_autoplot_equivalence.R
@@ -43,7 +43,7 @@
 #
 #   + coord_flip()      transposes the plot
 #   + theme_bw()        restyles it
-#   + scale_fill_grey() recolours it
+#   + scale_colour_grey() recolours it (gg_error maps colour, not fill)
 #   + facet_wrap(...)   splits it into panels
 #
 # Note that a coord mutation on gg_vimp specifically is NOT detectable, and

--- a/tests/testthat/test_determinism.R
+++ b/tests/testthat/test_determinism.R
@@ -17,8 +17,25 @@
 
 rng_consumers <- paste0(
   "^(rfsrc|randomForest|varpro|uvarpro|isopro|partialpro|beta\\.varpro|",
-  "sample|rnorm|runif|rbinom|rpois)$"
+  "sample|sample\\.int|rnorm|runif|rbinom|rpois|rexp|rgamma|rbeta)$"
 )
+
+# Deliberately NOT in that list: ggplot_build() and expect_doppelganger().
+#
+# They do consume the RNG, because plot.gg_rfsrc, plot.gg_shap,
+# plot.gg_variable, plot.gg_varpro and plot.gg_ivarpro all draw geom_jitter,
+# and the draw happens at build time rather than when the plot object is
+# constructed. But listing them flags 59 blocks, 46 of them in
+# test_snapshots.R, where a file-level local({ set.seed(42L); ... }) wraps the
+# fits and most of the rendered plots are bar charts that jitter nothing.
+#
+# Seeding all 46 would regenerate 46 of the 49 baselines to fix a latent
+# problem in about six of them, and a wave of regenerated baselines is exactly
+# the change that hides a real visual regression. This guard cannot tell a
+# jittered plot from a bar chart by parsing, so the blanket rule is worse than
+# the gap. The six genuinely jitter-dependent snapshot blocks are stable today
+# only because execution within a file is sequential; inserting a test earlier
+# in test_snapshots.R would shift them. That is a known, recorded gap.
 
 # TRUE when any call anywhere inside `expr` has a function name matching
 # `pattern`, ignoring any pkg:: prefix.
@@ -42,15 +59,61 @@ calls_any <- function(expr, pattern) {
   found
 }
 
+# The pkg:: prefix is stripped here for the same reason calls_any() strips it.
+# Without that, testthat::test_that(...) was invisible to this guard entirely:
+# the block was never examined, so any amount of unseeded randomness inside it
+# passed. Verified against a probe file before the fix: zero of six offending
+# blocks were flagged.
 is_test_that_call <- function(expr) {
   is.call(expr) &&
-    identical(paste(deparse(expr[[1]]), collapse = ""), "test_that") &&
+    identical(
+      sub("^.*::", "", paste(deparse(expr[[1]]), collapse = "")),
+      "test_that"
+    ) &&
     length(expr) >= 3L
 }
 
-# The offending combination: the block reaches the RNG but never seeds it.
+# Every set.seed() and RNG-consuming call inside `expr`, in source order.
+#
+# Order matters and was previously not checked at all. The failure message told
+# the reader to seed "before the first RNG-consuming call" while the check only
+# asked whether set.seed appeared anywhere in the block, so a seed placed AFTER
+# the forest fit it was meant to control satisfied the guard and controlled
+# nothing.
+#
+# A `{` block's elements are in source order, and the function of a call is
+# visited before its arguments, so a single depth-first walk in element order
+# yields the events in the order R will run them. Good enough for this: the
+# cases it cannot resolve are ones where both appear inside a single expression,
+# which is not a shape any test here uses.
+rng_events <- function(expr) {
+  events <- character(0)
+  recurse <- function(x) {
+    if (is.call(x)) {
+      nm <- sub("^.*::", "", paste(deparse(x[[1]]), collapse = ""))
+      if (grepl("^set\\.seed$", nm)) {
+        events <<- c(events, "seed")
+      } else if (grepl(rng_consumers, nm)) {
+        events <<- c(events, "rng")
+      }
+    }
+    if (is.recursive(x)) {
+      for (i in seq_along(x)) try(recurse(x[[i]]), silent = TRUE)
+    }
+    invisible(NULL)
+  }
+  recurse(expr)
+  events
+}
+
+# The offending combination: the block reaches the RNG, and either never seeds
+# it or seeds it too late to matter.
 block_is_unseeded <- function(expr) {
-  calls_any(expr[[3]], rng_consumers) && !calls_any(expr[[3]], "^set\\.seed$")
+  events <- rng_events(expr[[3]])
+  if (!("rng" %in% events)) {
+    return(FALSE)
+  }
+  !identical(events[1], "seed")
 }
 
 block_description <- function(expr) {

--- a/tests/testthat/test_gg_shap.R
+++ b/tests/testthat/test_gg_shap.R
@@ -1,7 +1,7 @@
 test_that("gg_shap.rfsrc returns a long tidy object for regression", {
-  set.seed(20260817L)
   skip_if_not_installed("kernelshap")
   skip_on_cran()
+  set.seed(20260817L)
 
   dta <- na.omit(airquality)
   rf <- randomForestSRC::rfsrc(Ozone ~ ., data = dta, ntree = 50)
@@ -25,8 +25,8 @@ test_that("gg_shap.default errors on a non-forest object", {
 })
 
 test_that("gg_shap.rfsrc errors on survival forests", {
-  set.seed(20260817L)
   skip_if_not_installed("kernelshap")
+  set.seed(20260817L)
   data(veteran, package = "randomForestSRC")
   rf <- randomForestSRC::rfsrc(Surv(time, status) ~ ., data = veteran,
                                ntree = 20)
@@ -34,9 +34,9 @@ test_that("gg_shap.rfsrc errors on survival forests", {
 })
 
 test_that("gg_shap.rfsrc handles classification via which.class", {
-  set.seed(20260817L)
   skip_if_not_installed("kernelshap")
   skip_on_cran()
+  set.seed(20260817L)
 
   rf <- randomForestSRC::rfsrc(Species ~ ., data = iris, ntree = 50)
   set.seed(42)
@@ -48,9 +48,9 @@ test_that("gg_shap.rfsrc handles classification via which.class", {
 })
 
 test_that("gg_shap.randomForest works for regression", {
-  set.seed(20260817L)
   skip_if_not_installed("kernelshap")
   skip_on_cran()
+  set.seed(20260817L)
 
   dta <- na.omit(airquality)
   rf <- randomForest::randomForest(Ozone ~ ., data = dta, ntree = 50)
@@ -62,9 +62,9 @@ test_that("gg_shap.randomForest works for regression", {
 })
 
 test_that("gg_shap.randomForest handles classification via which.class", {
-  set.seed(20260817L)
   skip_if_not_installed("kernelshap")
   skip_on_cran()
+  set.seed(20260817L)
 
   rf <- randomForest::randomForest(Species ~ ., data = iris, ntree = 50)
   set.seed(42)
@@ -76,9 +76,9 @@ test_that("gg_shap.randomForest handles classification via which.class", {
 })
 
 test_that("shap_importance and plot(type='importance') return ggplots", {
-  set.seed(20260817L)
   skip_if_not_installed("kernelshap")
   skip_on_cran()
+  set.seed(20260817L)
 
   rf <- randomForestSRC::rfsrc(Ozone ~ ., data = na.omit(airquality),
                                ntree = 50)
@@ -90,9 +90,9 @@ test_that("shap_importance and plot(type='importance') return ggplots", {
 })
 
 test_that("shap_beeswarm and default plot() return ggplots", {
-  set.seed(20260817L)
   skip_if_not_installed("kernelshap")
   skip_on_cran()
+  set.seed(20260817L)
 
   rf <- randomForestSRC::rfsrc(Ozone ~ ., data = na.omit(airquality),
                                ntree = 50)
@@ -104,9 +104,9 @@ test_that("shap_beeswarm and default plot() return ggplots", {
 })
 
 test_that("shap_beeswarm scales feature values per-variable into [0,1]", {
-  set.seed(20260817L)
   skip_if_not_installed("kernelshap")
   skip_on_cran()
+  set.seed(20260817L)
 
   rf <- randomForestSRC::rfsrc(Ozone ~ ., data = na.omit(airquality),
                                ntree = 50)
@@ -123,9 +123,9 @@ test_that("shap_beeswarm scales feature values per-variable into [0,1]", {
 })
 
 test_that("shap_dependence honors xvar and defaults to top variable", {
-  set.seed(20260817L)
   skip_if_not_installed("kernelshap")
   skip_on_cran()
+  set.seed(20260817L)
 
   rf <- randomForestSRC::rfsrc(Ozone ~ ., data = na.omit(airquality),
                                ntree = 50)
@@ -138,9 +138,9 @@ test_that("shap_dependence honors xvar and defaults to top variable", {
 })
 
 test_that("shap_dependence uses geom_boxplot for a categorical feature", {
-  set.seed(20260817L)
   skip_if_not_installed("kernelshap")
   skip_on_cran()
+  set.seed(20260817L)
 
   dta <- na.omit(airquality)
   dta$hot <- factor(ifelse(dta$Temp > 80, "hot", "cool"))
@@ -156,9 +156,9 @@ test_that("shap_dependence uses geom_boxplot for a categorical feature", {
 })
 
 test_that("autoplot.gg_shap delegates to plot", {
-  set.seed(20260817L)
   skip_if_not_installed("kernelshap")
   skip_on_cran()
+  set.seed(20260817L)
 
   rf <- randomForestSRC::rfsrc(Ozone ~ ., data = na.omit(airquality),
                                ntree = 50)
@@ -169,24 +169,24 @@ test_that("autoplot.gg_shap delegates to plot", {
 })
 
 test_that("gg_shap.rfsrc errors on out-of-range which.class", {
-  set.seed(20260817L)
   skip_if_not_installed("kernelshap")
+  set.seed(20260817L)
 
   rf <- randomForestSRC::rfsrc(Species ~ ., data = iris, ntree = 20)
   expect_error(gg_shap(rf, which.class = 99), "which.class")
 })
 
 test_that("gg_shap.randomForest errors on out-of-range which.class", {
-  set.seed(20260817L)
   skip_if_not_installed("kernelshap")
+  set.seed(20260817L)
 
   rf <- randomForest::randomForest(Species ~ ., data = iris, ntree = 20)
   expect_error(gg_shap(rf, which.class = 99), "which.class")
 })
 
 test_that("gg_shap.rfsrc validates bg_n", {
-  set.seed(20260817L)
   skip_if_not_installed("kernelshap")
+  set.seed(20260817L)
   rf <- randomForestSRC::rfsrc(Ozone ~ ., data = na.omit(airquality), ntree = 20)
   expect_error(gg_shap(rf, bg_n = 0), "bg_n")
   expect_error(gg_shap(rf, bg_n = NA), "bg_n")
@@ -194,17 +194,17 @@ test_that("gg_shap.rfsrc validates bg_n", {
 })
 
 test_that("gg_shap.randomForest validates bg_n", {
-  set.seed(20260817L)
   skip_if_not_installed("kernelshap")
+  set.seed(20260817L)
   rf <- randomForest::randomForest(Ozone ~ ., data = na.omit(airquality), ntree = 20)
   expect_error(gg_shap(rf, bg_n = 0), "bg_n")
   expect_error(gg_shap(rf, bg_n = NA), "bg_n")
 })
 
 test_that("shap_beeswarm scales finite values even when a variable has Inf entries", {
-  set.seed(20260817L)
   skip_if_not_installed("kernelshap")
   skip_on_cran()
+  set.seed(20260817L)
 
   rf <- randomForestSRC::rfsrc(Ozone ~ ., data = na.omit(airquality), ntree = 50)
   set.seed(42)
@@ -228,8 +228,8 @@ test_that("shap_beeswarm scales finite values even when a variable has Inf entri
 ## convention.
 
 test_that("gg_shap rejects bg_n that is not a whole, finite, in-range number", {
-  set.seed(20260817L)
   skip_if_not_installed("kernelshap")
+  set.seed(20260817L)
   # No skip_on_cran(): every expectation below errors during argument
   # validation, before kernelshap::kernelshap() is ever reached, so the test
   # costs one small forest fit. Skipping it would leave the integer contract
@@ -248,8 +248,8 @@ test_that("gg_shap rejects bg_n that is not a whole, finite, in-range number", {
 })
 
 test_that("gg_shap rejects which.class that is not a whole, finite number", {
-  set.seed(20260817L)
   skip_if_not_installed("kernelshap")
+  set.seed(20260817L)
 
   # As above: validation-only, so no skip_on_cran() and a minimal ntree.
   rf <- randomForestSRC::rfsrc(Species ~ ., data = iris, ntree = 10)

--- a/tests/testthat/test_gg_shap.R
+++ b/tests/testthat/test_gg_shap.R
@@ -1,4 +1,5 @@
 test_that("gg_shap.rfsrc returns a long tidy object for regression", {
+  set.seed(20260817L)
   skip_if_not_installed("kernelshap")
   skip_on_cran()
 
@@ -33,6 +34,7 @@ test_that("gg_shap.rfsrc errors on survival forests", {
 })
 
 test_that("gg_shap.rfsrc handles classification via which.class", {
+  set.seed(20260817L)
   skip_if_not_installed("kernelshap")
   skip_on_cran()
 
@@ -46,6 +48,7 @@ test_that("gg_shap.rfsrc handles classification via which.class", {
 })
 
 test_that("gg_shap.randomForest works for regression", {
+  set.seed(20260817L)
   skip_if_not_installed("kernelshap")
   skip_on_cran()
 
@@ -59,6 +62,7 @@ test_that("gg_shap.randomForest works for regression", {
 })
 
 test_that("gg_shap.randomForest handles classification via which.class", {
+  set.seed(20260817L)
   skip_if_not_installed("kernelshap")
   skip_on_cran()
 
@@ -72,6 +76,7 @@ test_that("gg_shap.randomForest handles classification via which.class", {
 })
 
 test_that("shap_importance and plot(type='importance') return ggplots", {
+  set.seed(20260817L)
   skip_if_not_installed("kernelshap")
   skip_on_cran()
 
@@ -85,6 +90,7 @@ test_that("shap_importance and plot(type='importance') return ggplots", {
 })
 
 test_that("shap_beeswarm and default plot() return ggplots", {
+  set.seed(20260817L)
   skip_if_not_installed("kernelshap")
   skip_on_cran()
 
@@ -98,6 +104,7 @@ test_that("shap_beeswarm and default plot() return ggplots", {
 })
 
 test_that("shap_beeswarm scales feature values per-variable into [0,1]", {
+  set.seed(20260817L)
   skip_if_not_installed("kernelshap")
   skip_on_cran()
 
@@ -116,6 +123,7 @@ test_that("shap_beeswarm scales feature values per-variable into [0,1]", {
 })
 
 test_that("shap_dependence honors xvar and defaults to top variable", {
+  set.seed(20260817L)
   skip_if_not_installed("kernelshap")
   skip_on_cran()
 
@@ -130,6 +138,7 @@ test_that("shap_dependence honors xvar and defaults to top variable", {
 })
 
 test_that("shap_dependence uses geom_boxplot for a categorical feature", {
+  set.seed(20260817L)
   skip_if_not_installed("kernelshap")
   skip_on_cran()
 
@@ -147,6 +156,7 @@ test_that("shap_dependence uses geom_boxplot for a categorical feature", {
 })
 
 test_that("autoplot.gg_shap delegates to plot", {
+  set.seed(20260817L)
   skip_if_not_installed("kernelshap")
   skip_on_cran()
 
@@ -192,6 +202,7 @@ test_that("gg_shap.randomForest validates bg_n", {
 })
 
 test_that("shap_beeswarm scales finite values even when a variable has Inf entries", {
+  set.seed(20260817L)
   skip_if_not_installed("kernelshap")
   skip_on_cran()
 


### PR DESCRIPTION
Two findings from the `r-reviewer` pass, both verified against probe cases before
and after. **Nothing under `R/` changes.**

> Branched from `main` before #197 merged. If #197 lands first this needs a sync;
> the two touch different files (`verify.sh` vs the test files), so no conflict.

## The determinism parser missed three things

| Blind spot | Why |
|---|---|
| `testthat::test_that(...)` | `is_test_that_call` wanted an exact `"test_that"` deparse while `calls_any` already stripped `pkg::`, so the block was **never examined** |
| Seed placed *after* the RNG call | Order was never checked, though the failure message told the reader to seed "before the first RNG-consuming call" |
| `sample.int`, `rexp`, `rgamma`, `rbeta` | not in the consumer list |

Verified against a five-block probe: the namespaced block, the seed-after-fit
block and the `sample.int` block are all flagged; a correctly seeded block, and
one seeding after its `skip_*()` guards, are not.

### It immediately found eleven real violations

All in `test_gg_shap.R`, where `set.seed(42)` sat **after** the `rfsrc()` call:

```r
rf <- randomForestSRC::rfsrc(Ozone ~ ., data = dta, ntree = 50)

set.seed(42)
gg_dta <- gg_shap(rf, bg_n = 20)
```

The forest fit was never reproducible; only the SHAP sampling after it was.
Those blocks now seed first. Their assertions are shape-based, so the values
they check are unaffected.

### Deliberately not added: `ggplot_build()` and `expect_doppelganger()`

They *do* consume the RNG (five plot methods draw `geom_jitter`, and the draw
happens at build time). But listing them flags **59 blocks, 46 of them in
`test_snapshots.R`**, where a file-level `local({ set.seed(42L); ... })` wraps
the fits and most rendered plots are bar charts that jitter nothing.

Seeding all 46 would regenerate 46 of the 49 baselines to fix a latent problem
in about six, and a wave of regenerated baselines is exactly the change that
hides a real visual regression. The guard cannot tell a jittered plot from a bar
chart by parsing, so the blanket rule is worse than the gap. Recorded as known.

## `same_plot()` treated four kinds of divergence as a match

`ggplot_build()$data` is post-stat but **pre-coord**, and `$labels` carries
nothing about coords, themes, scales or facets. Measured on ggplot2 4.0.3
against `plot(gg_error(rf))`, all four were invisible: `coord_flip()`,
`theme_bw()`, `scale_*_grey()`, `facet_wrap()`.

Now compared via a `plot_shape()` helper, kept separate because chaining the
conditions pushed cyclocomp to 22 against this repo's limit of 20, and the house
rule is to extract rather than raise the cap.

### One correction to the review that prompted this

The mutation it offered, `autoplot.gg_vimp` gaining `coord_flip()`, is genuinely
undetectable **and should be**: `plot.gg_vimp` already applies `coord_flip()`, so
adding another replaces `CoordFlip` with `CoordFlip` and the plot really is
unchanged, built data included. Verified.

The gap is real on plots that are *not* already flipped. The discrimination
self-test therefore moved from `gg_vimp` to `gg_error` (`CoordCartesian`) and now
covers coord, theme and scale alongside labs and ggtitle.

Confirmed by mutation:

```
autoplot.gg_error + coord_flip()   before: PASS (missed)   after: FAIL 2 (caught)
```

## Verification

```
Rscript -e 'devtools::document()'                                   man/ and NAMESPACE untouched
Rscript -e 'lintr::lint_package()'                                  LINTS: 0
NOT_CRAN=true VDIFFR_RUN_TESTS=true Rscript -e 'devtools::test()'   [ FAIL 0 | WARN 58 | SKIP 5 | PASS 1509 ]
```

49 baselines intact, tree clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)