### PR TITLE
Recompose house-style from the vault sources

### DIFF
--- a/.claude/house-style.md
+++ b/.claude/house-style.md
@@ -10,7 +10,7 @@
   profile:         package-cran
   default persona: (d)
   sources:
-    writing-voice.md               sha256:6ca5d2b7682a
+    writing-voice.md               sha256:19e1e5dcbb41
     writing-reader-profile.md      sha256:179212de138c
     writing-context.md             sha256:87d5555936e1
     r-package-structure.md         sha256:e64cb6f25dbd
@@ -59,8 +59,12 @@ personality or a slightly imperfect sentence.
 
 ## Rules
 
-- Em-dashes: use sparingly. Native to the voice and honestly overused. Keep one
-  where it earns the pause; otherwise a comma, parentheses, or a full stop.
+- Em-dashes: Claude does not write them. Native to the voice and honestly
+  overused, so the drafting rule is a comma, parentheses, or a full stop. John
+  adds them back where he wants the pause. (Changed 2026-08-17 from "use
+  sparingly, keep one where it earns the pause", which conflicted with the
+  absolute rule in [[preferences]] and [[identity]]. Placing them is a judgement
+  about his own voice, so he makes it rather than delegating it.)
 - Ellipses: an informal-register habit (text, email). Keep them out of package docs.
 - Don't overstate. No overselling. Cut "enhanced", "powerful", "seamlessly",
   "robust" (as a brag), "comprehensive". State what the thing does, at its size.

--- a/.claude/house-style.md
+++ b/.claude/house-style.md
@@ -10,7 +10,7 @@
   profile:         package-cran
   default persona: (d)
   sources:
-    writing-voice.md               sha256:19e1e5dcbb41
+    writing-voice.md               sha256:3018e1e0bf8e
     writing-reader-profile.md      sha256:179212de138c
     writing-context.md             sha256:87d5555936e1
     r-package-structure.md         sha256:e64cb6f25dbd
@@ -63,7 +63,7 @@ personality or a slightly imperfect sentence.
   overused, so the drafting rule is a comma, parentheses, or a full stop. John
   adds them back where he wants the pause. (Changed 2026-08-17 from "use
   sparingly, keep one where it earns the pause", which conflicted with the
-  absolute rule in [[preferences]] and [[identity]]. Placing them is a judgement
+  absolute rule in [[preferences]] and [[identity]]. Placing them is a judgment
   about his own voice, so he makes it rather than delegating it.)
 - Ellipses: an informal-register habit (text, email). Keep them out of package docs.
 - Don't overstate. No overselling. Cut "enhanced", "powerful", "seamlessly",


### PR DESCRIPTION
Recomposes `.claude/house-style.md` from the vault sources.

Depends on **ehrlinger/house-style#13**, which brings the CI mirror up to the
vault's `writing-voice.md`. Merge that first, or this repo's `house-style` check
will compare against the older mirror and report drift.

## Why now

The vault edited `writing-voice.md` on 2026-08-17, changing the em-dash rule to
"Claude does not write them; John adds them back where he wants the pause",
because the old "use sparingly" wording conflicted with the absolute rule in
`preferences` and `identity`.

`sources/` in the composer repo is the **CI mirror**: the composer falls back to
it when the vault is not mounted, which is how `--check` runs on a runner, and it
refuses to compose from it. The mirror still held the 2026-08-07 copy, so CI here
was comparing against a voice document the vault had already moved past.

Measured across the registry:

| Composed against | Result |
|---|---|
| the mirror (what CI does) | 8 of 9 repos OK |
| the vault (canonical) | **all 9 stale** |

CI green everywhere, every artifact stale. This PR is one of nine bringing the
fleet back in line.

## Note

`.claude/house-style.md` is a generated file and carries a DO NOT EDIT banner.
This change is the output of `compose-house-style.R --repo <name>`, not a hand
edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)