### PR TITLE
chore: recompose house-style after the hvtiRpropensity rename

### DIFF
--- a/.claude/house-style.md
+++ b/.claude/house-style.md
@@ -13,7 +13,7 @@
     writing-voice.md               sha256:3018e1e0bf8e
     writing-reader-profile.md      sha256:179212de138c
     writing-context.md             sha256:87d5555936e1
-    r-package-structure.md         sha256:e64cb6f25dbd
+    r-package-structure.md         sha256:0b90e3e645fd
 -->
 
 # House Style — ggRandomForests
@@ -286,7 +286,7 @@ the reader already stands, and forcing everyone through the same opening
 would flatten a real difference between them:
 
 - *What it is and who it is for* — the reader has already been told to use
-  the package. Current examples: hvtiPlotR, hvtiPropensityScores.
+  the package. Current examples: hvtiPlotR, hvtiRpropensity.
 - *The pain you already have* — the reader still needs convincing to adopt.
   Current example: hvtiRtables.
 - *What works today* — the reader is judging whether the package is ready.
@@ -299,7 +299,7 @@ That part isn't optional across the three.
 nearly everywhere — most of these packages started life as something else.
 Three kinds:
 
-- *SAS-macro port* — hvtiPlotR (`plot.sas`), hvtiPropensityScores,
+- *SAS-macro port* — hvtiPlotR (`plot.sas`), hvtiRpropensity,
   hvtiRutilities (`PROC CONTENTS`, `PROC MEANS`), hvtiRtables (SAS table
   macro).
 - *Upstream fork* — hvtiBoostmtree, forked from `kogalur/boostmtree` at
@@ -554,7 +554,7 @@ report the code clean while the runner disagrees.
 
 `object_usage_linter` needs the package's own namespace to resolve internal
 calls. Without `local::.` it cannot see them and reports every call to one as an
-undefined global. On hvtiPropensityScores that was 58 phantom lints against 12
+undefined global. On hvtiRpropensity that was 58 phantom lints against 12
 real ones — the noise outnumbered the signal five to one.
 
 Worse than the count: the phantoms were *hiding a real finding of the same


### PR DESCRIPTION
Regenerated `.claude/house-style.md` from the vault sources at `house-style-v1`.

`hvtiPropensityScores` renamed itself to `hvtiRpropensity`. That name appears in three prose mentions inside `r-package-structure.md`, so every repo whose profile includes that source drifted — nine of the ten governed repos. The registry and the vault source both moved ([house-style#18](https://github.com/ehrlinger/house-style/pull/18), vault `dcf7fc5`) and the tag was advanced to match.

Diff is 4 insertions / 4 deletions: the recorded `r-package-structure.md` hash in the provenance header, plus the three renamed mentions. No other source changed for this repo.

Generated file — produced by `compose-house-style.R --repo ggRandomForests`, not hand-edited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)