### PR TITLE
ci: skip the heavy workflows for house-style-only commits

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -2,9 +2,10 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   # A commit that only touches the generated house-style artifact cannot change
-  # the package: .claude is in .Rbuildignore, so it never reaches the build.
-  # Running this on such a commit burns runner minutes and queues ahead of
-  # checks that can actually fail.
+  # the package: .claude is in .Rbuildignore, so it is excluded from the built
+  # package, and no step in this workflow reads it from the checkout. Running
+  # this on such a commit burns runner minutes and queues ahead of checks that
+  # can actually fail.
   push:
     paths-ignore:
       - '.claude/**'

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,9 +1,17 @@
 # Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
+  # A commit that only touches the generated house-style artifact cannot change
+  # the package: .claude is in .Rbuildignore, so it never reaches the build.
+  # Running this on such a commit burns runner minutes and queues ahead of
+  # checks that can actually fail.
   push:
+    paths-ignore:
+      - '.claude/**'
     branches: [main]
   pull_request:
+    paths-ignore:
+      - '.claude/**'
 
 name: R-CMD-check.yaml
 

--- a/.github/workflows/check-manual.yaml
+++ b/.github/workflows/check-manual.yaml
@@ -5,7 +5,13 @@
 # because building the manual is slow and a check that makes every PR wait
 # is one people learn to route around.
 on:
+  # A commit that only touches the generated house-style artifact cannot change
+  # the package: .claude is in .Rbuildignore, so it never reaches the build.
+  # Running this on such a commit burns runner minutes and queues ahead of
+  # checks that can actually fail.
   push:
+    paths-ignore:
+      - '.claude/**'
     branches: [main]
   release:
     types: [published]

--- a/.github/workflows/check-manual.yaml
+++ b/.github/workflows/check-manual.yaml
@@ -6,9 +6,10 @@
 # is one people learn to route around.
 on:
   # A commit that only touches the generated house-style artifact cannot change
-  # the package: .claude is in .Rbuildignore, so it never reaches the build.
-  # Running this on such a commit burns runner minutes and queues ahead of
-  # checks that can actually fail.
+  # the package: .claude is in .Rbuildignore, so it is excluded from the built
+  # package, and no step in this workflow reads it from the checkout. Running
+  # this on such a commit burns runner minutes and queues ahead of checks that
+  # can actually fail.
   push:
     paths-ignore:
       - '.claude/**'

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -2,9 +2,10 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   # A commit that only touches the generated house-style artifact cannot change
-  # the package: .claude is in .Rbuildignore, so it never reaches the build.
-  # Running this on such a commit burns runner minutes and queues ahead of
-  # checks that can actually fail.
+  # the package: .claude is in .Rbuildignore, so it is excluded from the built
+  # package, and no step in this workflow reads it from the checkout. Running
+  # this on such a commit burns runner minutes and queues ahead of checks that
+  # can actually fail.
   push:
     paths-ignore:
       - '.claude/**'

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -1,9 +1,17 @@
 # Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
+  # A commit that only touches the generated house-style artifact cannot change
+  # the package: .claude is in .Rbuildignore, so it never reaches the build.
+  # Running this on such a commit burns runner minutes and queues ahead of
+  # checks that can actually fail.
   push:
+    paths-ignore:
+      - '.claude/**'
     branches: [main]
   pull_request:
+    paths-ignore:
+      - '.claude/**'
   release:
     types: [published]
   workflow_dispatch:

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -2,9 +2,10 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   # A commit that only touches the generated house-style artifact cannot change
-  # the package: .claude is in .Rbuildignore, so it never reaches the build.
-  # Running this on such a commit burns runner minutes and queues ahead of
-  # checks that can actually fail.
+  # the package: .claude is in .Rbuildignore, so it is excluded from the built
+  # package, and no step in this workflow reads it from the checkout. Running
+  # this on such a commit burns runner minutes and queues ahead of checks that
+  # can actually fail.
   push:
     paths-ignore:
       - '.claude/**'

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -1,9 +1,17 @@
 # Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
+  # A commit that only touches the generated house-style artifact cannot change
+  # the package: .claude is in .Rbuildignore, so it never reaches the build.
+  # Running this on such a commit burns runner minutes and queues ahead of
+  # checks that can actually fail.
   push:
+    paths-ignore:
+      - '.claude/**'
     branches: [main]
   pull_request:
+    paths-ignore:
+      - '.claude/**'
 
 name: test-coverage.yaml
 


### PR DESCRIPTION
Adds `paths-ignore: ['.claude/**']` to the heavy workflows — `R-CMD-check`, `test-coverage`, `pkgdown`, `check-manual`.

The first three carry the key on both `push` and `pull_request`. `check-manual` has no `pull_request` trigger — it runs on `push` to the default branch plus `release`, because building the PDF manual is slow and a check that makes every PR wait is one people learn to route around — so it gets the key on `push` only.

## Why

Recomposing `.claude/house-style.md` currently triggers all of them, including `R-CMD-check`'s five-way OS/R matrix. None can be affected by that file: `.claude` is listed in `.Rbuildignore`, so it never reaches the build.

On 2026-08-18 one vault source edit drifted nine repos at once. The eight recompose merges queued **over a hundred jobs against a ten-job concurrency ceiling**, and the only check that could actually verify a recompose — the `house-style` drift check, which installs two packages and never builds the package — sat queued behind all of it for 39 minutes. Thirty-six runs had to be cancelled by hand to clear it.

## What still runs

`house-style` and `lint` are untouched, so a recompose is still verified by the job that can verify it. Only the workflows that provably cannot be affected are skipped.

## Safety

`main` has no branch protection and no required status checks in this repo, so a skipped workflow cannot leave a PR waiting on a check that will never report. Every modified file was validated to parse, and every `push`/`pull_request` trigger present in those workflows confirmed to carry the new key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)