### PR TITLE
Name varPro in the README, and report the 3.5.1 win-builder results

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@
 [randomForestSRC](https://cran.r-project.org/package=randomForestSRC) (>= 3.4.0) or
 [randomForest](https://cran.r-project.org/package=randomForest).
 It keeps the data step apart from the figure step, so you can inspect, save, or reuse the tidy object on its own.
+
+It also covers [varPro](https://cran.r-project.org/package=varPro) (>= 3.1.0), which reaches the same
+questions by a different route: variable selection built from rules rather than permutation, importance
+for one observation rather than the whole fit, and dependency and signal detection on unsupervised fits.
+Eight of the nineteen `gg_*` families read a varPro object.
+
 Listed in the [ggplot2 extensions gallery](https://exts.ggplot2.tidyverse.org/).
 
 ## Installation

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -66,20 +66,39 @@ regenerated `.Rd` files, and the version metadata.
   with the manual, built from a clean `git archive` export: **0 ERRORs,
   0 WARNINGs, 1 NOTE**. Check time 3m53s across timed steps; the source tarball
   is 2.27 MB. The full test suite, run with `NOT_CRAN=true` so the
-  `skip_on_cran()` tests execute too, is 1510 passing and 0 failing.
+  `skip_on_cran()` tests execute too, is 1512 passing and 0 failing.
 * **Reverse-dependency check:** 0 reverse dependencies on CRAN.
 * **URL check:** `urlchecker::url_check()` reports all URLs correct.
 
-**win-builder:** R-devel, R-release and R-oldrelease, run against this exact
-tarball.
+**win-builder:** x86_64-w64-mingw32, Windows Server 2022. All three branches
+return **Status: 1 NOTE**, the same `Number of updates in past 6 months: 7`
+reported locally, with no second NOTE and no ERRORs or WARNINGs:
 
-On check time: the 3.5.0 win-builder totals ran to roughly 8 minutes
-(R-release), 10 minutes (R-devel) and 12 minutes (R-oldrelease), with the
-vignette rebuild the dominant term in each. R-oldrelease has come down sharply
-on 3.5.1, because every `rfsrc` fit in an example now carries an explicit
-`ntree`; R-release and R-devel are essentially unchanged, with R-devel the
-closest to the line. If that is too long, the vignette rebuild is the lever and
-I am glad to precompute further, as I did for 3.1.0.
+| Branch | R | Status | Check time |
+|---|---|---|---|
+| R-devel | 2026-08-17 r90424 | 1 NOTE | 10m19s |
+| R-release | 4.6.1 | 1 NOTE | 8m21s |
+| R-oldrelease | 4.5.3 | 1 NOTE | 6m33s |
+
+One caveat, so the record is exact: those three runs were made against this tree
+with a single later change, a paragraph added to `README.md` naming `varPro` in
+the opening description. `R CMD check` does not parse `README.md`, so no check
+outcome depends on it, but the tarball was rebuilt after the runs and I would
+rather say so than let "run against this exact tarball" stand unqualified.
+
+On check time, which I would rather flag than leave you to find. The 3.5.0
+totals were roughly 8 minutes (R-release), 10 minutes (R-devel) and 12m15s
+(R-oldrelease). Measured on 3.5.1:
+
+* **R-oldrelease 12m15s to 6m33s.** Every `rfsrc` fit in an example now carries
+  an explicit `ntree`, which nearly halved the branch that was furthest over.
+* **R-release 8m21s and R-devel 10m19s**, both essentially unchanged from the
+  3.5.0 you accepted on 2026-08-04.
+
+R-devel is therefore the one sitting just above ten minutes, and the vignette
+rebuild is 299s of its 619s. That is the lever: I am glad to precompute the
+expensive vignette calls, as I did for 3.1.0, and can turn that around quickly
+if you would like it before acceptance rather than after.
 
 ### NOTE disposition
 


### PR DESCRIPTION
Two release-prep changes, both documentation. **Nothing under `R/` changes.**

## 1. `README.md` names varPro

The opening described the package as plots for forests fit with `randomForestSRC`
or `randomForest`. That understates it: **varPro is an `Imports`, not a Suggests,
and 8 of the 19 exported `gg_*` families read a varPro object** (`gg_varpro`,
`gg_ivarpro`, `gg_beta_varpro`, `gg_beta_uvarpro`, `gg_udependent`,
`gg_sdependent`, `gg_partial_varpro`, `gg_isopro`). A reader deciding whether
this package covers their work could not tell that from the first paragraph.

It gets its own paragraph rather than a fourth name in a list, because what
varPro brings is a different route to the same questions: selection built from
rules rather than permutation, importance for one observation rather than the
whole fit, and dependency and signal detection on unsupervised fits.

Every claim checked against the repo, not written from memory: the bound is
`DESCRIPTION`'s `varPro (>= 3.1.0)`, the CRAN link resolves (varPro 3.1.0 is
published), the 8-of-19 count is from `NAMESPACE`, and the characterisation comes
from the family titles in `man/`.

The GitHub **About** block was updated to match, separately; it is repo metadata
and not part of the package.

## 2. `cran-comments.md` reports the win-builder results

All three branches, against this tree, return **Status: 1 NOTE** (the same
frequency note reported locally). No second NOTE, no ERRORs, no WARNINGs.

| Branch | R | Status | Check time | 3.5.0 was |
|---|---|---|---|---|
| R-devel | 2026-08-17 r90424 | 1 NOTE | **10m19s** | ~10 min |
| R-release | 4.6.1 | 1 NOTE | **8m21s** | ~8 min |
| R-oldrelease | 4.5.3 | 1 NOTE | **6m33s** | **12m15s** |

The hidden-files NOTE from the first round is gone. That was `.remember` reaching
the tarball from a working-tree build, fixed in #202.

**R-oldrelease came down from 12m15s to 6m33s**, which is the branch that
mattered: CRAN archived 3.1.0 over check time. R-devel is the one still just
above ten minutes, so the text names the vignette rebuild as 299s of its 619s and
offers to precompute before acceptance rather than after.

### One thing stated plainly rather than glossed

`README.md` ships, so the tarball is rebuilt after those win-builder runs.
`R CMD check` does not parse `README.md` and no check outcome depends on it, but
"run against this exact tarball" would have been untrue, and this file is pasted
verbatim into the CRAN submission form. The caveat is in the file.

## Verification

```
Rscript -e 'lintr::lint_package()'                                  LINTS: 0
NOT_CRAN=true VDIFFR_RUN_TESTS=true Rscript -e 'devtools::test()'   [ FAIL 0 | WARN 58 | SKIP 5 | PASS 1512 ]
test_cran_comments.R                                               FAIL 0 | PASS 2
```

49 vdiffr baselines intact, tree clean. The `cran-comments.md` guard confirms the
version heading matches `DESCRIPTION` (`v3.5.1` / `3.5.1`) and that no
unfinished-work markers remain.

## After merge

Rebuild the tarball from `main` before submitting; the one built at 12:33 predates
the README change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)