### PR TITLE
chore(cran): record v3.5.1 submission

### DIFF
--- a/CRAN-SUBMISSION
+++ b/CRAN-SUBMISSION
@@ -1,3 +1,3 @@
-Version: 3.5.0
-Date: 2026-08-04 14:29:14 UTC
-SHA: 676555ecfc6f10946ef38fa4e2c88add95c91416
+Version: 3.5.1
+Date: 2026-08-19 18:54:10 UTC
+SHA: 22aff871bdab46addbbd696ef0074e846e600f20


### PR DESCRIPTION
`devtools::submit_cran()` rewrote `CRAN-SUBMISSION` when v3.5.1 was
uploaded on 2026-08-19. This commits that record, following the repo
convention set by the five previous submissions.

```
Version: 3.5.1
Date: 2026-08-19 18:54:10 UTC
SHA: 22aff871bdab46addbbd696ef0074e846e600f20
```

The recorded SHA is the merge of #203, which is the commit the submitted
tarball was built from. `usethis::use_github_release()` reads this file
to tag the right commit, so it is worth having on `main` before the
`v3.5.1` tag goes on.

`CRAN-SUBMISSION` is already covered by `.Rbuildignore`, so it does not
reach the tarball.

Metadata only. No change to `R/`, `man/`, `tests/` or `NAMESPACE`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)