### PR TITLE
docs: document varPro's missing-data contract on gg_partial_varpro

### DIFF
--- a/CRAN-SUBMISSION
+++ b/CRAN-SUBMISSION
@@ -1,3 +1,3 @@
-Version: 3.5.0
-Date: 2026-08-04 14:29:14 UTC
-SHA: 676555ecfc6f10946ef38fa4e2c88add95c91416
+Version: 3.5.1
+Date: 2026-08-19 18:54:10 UTC
+SHA: 22aff871bdab46addbbd696ef0074e846e600f20

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: ggRandomForests
 Type: Package
 Title: Visually Exploring Random Forests
-Version: 3.5.1
-Date: 2026-08-05
+Version: 3.5.2
+Date: 2026-08-19
 Authors@R: person("John", "Ehrlinger",
   role = c("aut", "cre"),
   email = "john.ehrlinger@gmail.com",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,24 @@
 Package: ggRandomForests
-Version: 3.5.1
+Version: 3.5.2
+
+ggRandomForests v3.5.2
+======================
+* `?gg_partial_varpro` now documents varPro's missing-data contract, which
+  governs every fit this package plots. varPro has no imputation: each entry
+  point grows a stump through `randomForestSRC::rfsrc` and inherits its
+  `na.action = "na.omit"`, so any case missing a predictor or the outcome is
+  deleted before the fit, silently. `na.action = "na.impute"` passed to
+  `varpro()` lands in `...` and is discarded without remark. The loss
+  compounds as `0.95^p`, and the fitted object keeps only the post-deletion
+  count, so neither the user nor this package can recover the original from
+  the object -- the check has to happen before the fit.
+* The same section covers imputing beforehand without inventing outcomes.
+  `roughfix()` and `randomForestSRC::impute()` both fill every column handed
+  to them, the outcome included, so a frame with missing outcomes comes back
+  with manufactured responses and the release rules are fit partly to them.
+  Documents von Hippel's impute-then-delete, and the two cautions that follow:
+  outcome-informed imputation crosses fold boundaries in `cv.varpro()`, and a
+  completed frame carries no imputation uncertainty into the curves.
 
 ggRandomForests v3.5.1
 ======================

--- a/R/gg_partial_varpro.R
+++ b/R/gg_partial_varpro.R
@@ -159,6 +159,51 @@
 #' defaults when that sparser set is what you want.  \code{nvar} is not the
 #' knob here -- it only caps how much gets reported.
 #'
+#' **Which rows you actually get:** \pkg{varPro} has no imputation.  Every
+#' entry point opens by growing a one-node stump through
+#' \code{randomForestSRC::rfsrc} to settle the family and hand back cleaned
+#' data, and that call takes \code{rfsrc}'s default \code{na.action =
+#' "na.omit"}.  Any case with a missing value -- in a predictor or in the
+#' outcome -- is deleted before the fit, with no warning and no message.
+#' Passing \code{na.action = "na.impute"} to \code{varPro::varpro} does not
+#' change this: it lands in \code{...}, never reaches the stump, and is
+#' discarded without remark (varPro 3.1.0).
+#'
+#' The loss compounds across predictors rather than adding up.  At 5% missing
+#' per column, independently, retention is \eqn{0.95^p} -- 60% of rows at 10
+#' predictors, 36% at 20, 8% at 50.  On a wide clinical frame a little
+#' missingness everywhere can delete most of the cohort.  Nothing in the fit
+#' records it: \code{object$rf$n} is the count \emph{after} deletion and no
+#' original is kept, so neither you nor this package can recover the number
+#' from the object.  Check before you fit -- \code{nrow(dta)} against
+#' \code{sum(complete.cases(dta))}.
+#'
+#' **Imputing first, without inventing outcomes:** \code{varPro::roughfix}
+#' does mean and modal fill, \code{randomForestSRC::impute} does the
+#' forest-based job, and varPro's own help pages use the latter.  Both fill
+#' \strong{every} column they are handed, the outcome included -- so where the
+#' outcome is itself missing they manufacture it, and the release rules are
+#' then fit partly to invented responses.  Put the observed outcome back and
+#' drop the cases that never had one:
+#'
+#' \preformatted{
+#' imp   <- randomForestSRC::impute(y ~ ., data = dta)
+#' imp$y <- dta$y                    # restore the observed outcome
+#' imp   <- imp[!is.na(imp$y), ]     # drop cases with no real outcome
+#' }
+#'
+#' That is von Hippel's impute-then-delete: keep the outcome in the imputation
+#' model, since leaving it out attenuates the associations varPro is looking
+#' for, then discard the cases whose outcome was imputed, which carry no
+#' information about the response.  Only the deletion step depends on having
+#' missing outcomes; the imputation matters whenever a \emph{predictor} is
+#' missing.  Two cautions.  Imputing with the outcome stamps its signal into
+#' the filled predictor cells, which is right for a single fit but crosses
+#' fold boundaries in \code{varPro::cv.varpro} -- impute inside the folds if
+#' the selection error has to mean anything.  And a completed frame is one
+#' dataset, not many, so the curves here carry no uncertainty from the
+#' imputation; read them as conditional on it.
+#'
 #' **Scale detection:** with \code{scale = "auto"} and an \code{object} in
 #' hand, the scale resolves to \code{"mortality"} for a survival forest and
 #' \code{"generic"} for a regression or classification forest.  The RMST
@@ -225,6 +270,11 @@
 #' \code{xvar.names}, and \code{path}.
 #'
 #' @references
+#' von Hippel PT (2007).
+#' Regression with missing Ys: An improved strategy for analyzing multiply
+#' imputed data. \emph{Sociological Methodology}, \bold{37}(1), 83--117.
+#' \doi{10.1111/j.1467-9531.2007.00180.x}.
+#'
 #' Ishwaran H, Kogalur UB, Blackstone EH, Lauer MS (2008).
 #' Random survival forests. \emph{The Annals of Applied Statistics},
 #' \bold{2}(3), 841--860. \doi{10.1214/08-AOAS169}.

--- a/man/gg_partial_varpro.Rd
+++ b/man/gg_partial_varpro.Rd
@@ -144,6 +144,51 @@ the screened top.  Both are \pkg{varPro}'s own arguments, and its defaults
 defaults when that sparser set is what you want.  \code{nvar} is not the
 knob here -- it only caps how much gets reported.
 
+\strong{Which rows you actually get:} \pkg{varPro} has no imputation.  Every
+entry point opens by growing a one-node stump through
+\code{randomForestSRC::rfsrc} to settle the family and hand back cleaned
+data, and that call takes \code{rfsrc}'s default \code{na.action =
+"na.omit"}.  Any case with a missing value -- in a predictor or in the
+outcome -- is deleted before the fit, with no warning and no message.
+Passing \code{na.action = "na.impute"} to \code{varPro::varpro} does not
+change this: it lands in \code{...}, never reaches the stump, and is
+discarded without remark (varPro 3.1.0).
+
+The loss compounds across predictors rather than adding up.  At 5\% missing
+per column, independently, retention is \eqn{0.95^p} -- 60\% of rows at 10
+predictors, 36\% at 20, 8\% at 50.  On a wide clinical frame a little
+missingness everywhere can delete most of the cohort.  Nothing in the fit
+records it: \code{object$rf$n} is the count \emph{after} deletion and no
+original is kept, so neither you nor this package can recover the number
+from the object.  Check before you fit -- \code{nrow(dta)} against
+\code{sum(complete.cases(dta))}.
+
+\strong{Imputing first, without inventing outcomes:} \code{varPro::roughfix}
+does mean and modal fill, \code{randomForestSRC::impute} does the
+forest-based job, and varPro's own help pages use the latter.  Both fill
+\strong{every} column they are handed, the outcome included -- so where the
+outcome is itself missing they manufacture it, and the release rules are
+then fit partly to invented responses.  Put the observed outcome back and
+drop the cases that never had one:
+
+\preformatted{
+imp   <- randomForestSRC::impute(y ~ ., data = dta)
+imp$y <- dta$y                    # restore the observed outcome
+imp   <- imp[!is.na(imp$y), ]     # drop cases with no real outcome
+}
+
+That is von Hippel's impute-then-delete: keep the outcome in the imputation
+model, since leaving it out attenuates the associations varPro is looking
+for, then discard the cases whose outcome was imputed, which carry no
+information about the response.  Only the deletion step depends on having
+missing outcomes; the imputation matters whenever a \emph{predictor} is
+missing.  Two cautions.  Imputing with the outcome stamps its signal into
+the filled predictor cells, which is right for a single fit but crosses
+fold boundaries in \code{varPro::cv.varpro} -- impute inside the folds if
+the selection error has to mean anything.  And a completed frame is one
+dataset, not many, so the curves here carry no uncertainty from the
+imputation; read them as conditional on it.
+
 \strong{Scale detection:} with \code{scale = "auto"} and an \code{object} in
 hand, the scale resolves to \code{"mortality"} for a survival forest and
 \code{"generic"} for a regression or classification forest.  The RMST
@@ -332,6 +377,11 @@ setdiff(wanted, vp_all$xvar.names)   # empty; nothing to drop
 
 }
 \references{
+von Hippel PT (2007).
+Regression with missing Ys: An improved strategy for analyzing multiply
+imputed data. \emph{Sociological Methodology}, \bold{37}(1), 83--117.
+\doi{10.1111/j.1467-9531.2007.00180.x}.
+
 Ishwaran H, Kogalur UB, Blackstone EH, Lauer MS (2008).
 Random survival forests. \emph{The Annals of Applied Statistics},
 \bold{2}(3), 841--860. \doi{10.1214/08-AOAS169}.


### PR DESCRIPTION
## Why

Andrew hit this on a live analysis: `varPro` 3.1.0 has no imputation, and it does not tell you. Every entry point (`varpro`, `cv.varpro`, `isopro`, `importance`) opens by growing a one-node stump through `randomForestSRC::rfsrc`, inheriting its default `na.action = "na.omit"`. Any case missing a predictor **or the outcome** is deleted before the fit, with no warning and no message.

Measured on a synthetic frame, 400 rows, 5% MCAR per predictor across 10 predictors:

```
complete cases : 235
varpro n used  : 235      # 41% of the sample, gone silently
```

Three findings behind this section, all verified rather than inferred:

1. **`na.action = "na.impute"` passed to `varpro()` is silently ignored.** It lands in `...`, never reaches the hardcoded `get.stump()` call, and is discarded. Same defect class as the `partialpro()` `...` drop already reported upstream; that makes two instances in two different functions.
2. **The fitted object keeps no record of the loss.** `object$rf$n` is the post-deletion count and no original is stored, so this package cannot detect or report it. The check has to happen before the fit.
3. **`impute()` fills the outcome too.** Both `impute(y ~ ., data)` and the unsupervised form return `y` complete: on a test frame, all 40 missing outcomes were fabricated. varPro then fits release rules to invented responses.

On (3), the fix documented is von Hippel's impute-then-delete: keep the outcome in the imputation model, then drop the rows whose outcome was imputed. Dropping the outcome instead is *not* the answer. With `y` fully observed and missingness only in X, `cor(imputed x1, y)` at the missing cells is 0.403 supervised vs 0.051 unsupervised against a true 0.796. Unsupervised imputation flattens the very association varPro exists to detect.

## What changed

- `R/gg_partial_varpro.R`: new `@details` section, "Which rows you actually get", placed as sibling to the existing "Which variables you actually get". Added von Hippel 2007 to `@references`.
- `NEWS.md`, `DESCRIPTION`: bumped to 3.5.2 together.

This is documentation only. It is deliberately not a code guard: the concern is entirely pre-fit, and by the time this package sees an object the rows are unrecoverable.

## Verification

- `roxygen2::roxygenise()` clean; `tools::checkRd()` clean.
- Rendered with `Rd2txt` and read back. First pass had `5\%` rendering as `5\` and swallowing the rest of the sentence, because roxygen escapes `%` for you, so a source-level `\%` double-escapes. Rewritten bare, matching `R/gg_rfsrc.R:401`.

## Test status

`test_cran_comments.R:44` fails **when run from the source tree** (`devtools::test()`): `cran-comments.md` still leads with `## v3.5.1` while DESCRIPTION now reads 3.5.2. Verified the guard's own pattern directly: 3.5.2 gives `FALSE` against that heading. It clears when `cran-comments.md` is rewritten for 3.5.2 at submission time; a placeholder is not an option, since the sibling test rejects unfinished-work markers (cf. `a44acaec`).

It should **not** turn the R-CMD-check jobs red: `cran-comments.md` is `.Rbuildignore`d, so it is absent from the tarball, `cran_comments_path()` returns `NA`, and the test skips itself. `NOT_CRAN: "true"` is set in the workflow, so `skip_on_cran()` is not what saves it; the missing file is. Whether `test-coverage` (which runs closer to the source tree) also skips it is not something I confirmed; watch that job.

Note this failure is not fixable inside this PR. The fix is the `cran-comments.md` rewrite, which belongs to the 3.5.2 release branch.

`test_ggrandomforests_news.R` reports `FAIL 1` for `ggrandomforests.news` not being found. Pre-existing, reproduced identically on clean `main` with this branch stashed, caused by a stale 3.5.0 install.

## Merge timing

Draft. Not to be merged until CRAN accepts 3.5.1 and that release is tagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

