### PR TITLE
fix: unescape % in three roxygen prose lines

### DIFF
--- a/R/calc_roc.R
+++ b/R/calc_roc.R
@@ -299,7 +299,7 @@ calc_roc.randomForest <-
 #'
 #' @param x \code{\link{gg_roc}} object
 #'
-#' @return AUC. 50\% is random guessing, higher is better.
+#' @return AUC. 50% is random guessing, higher is better.
 #'
 # @importFrom dplyr lead
 #'

--- a/R/gg_isopro.R
+++ b/R/gg_isopro.R
@@ -76,7 +76,7 @@
 #'     distribution.
 #' }
 #' The score is a \emph{rank}, not a probability of being an outlier: two
-#' observations with \code{howbad = 0.92} are both unusual, not "92\%
+#' observations with \code{howbad = 0.92} are both unusual, not "92%
 #' likely to be anomalous". Pick a cutoff by looking at where the elbow
 #' rises; \code{\link{plot.gg_isopro}} can annotate either a score
 #' (\code{threshold}) or a top-percent (\code{top_n_pct}) for you.

--- a/R/plot.gg_isopro.R
+++ b/R/plot.gg_isopro.R
@@ -18,7 +18,7 @@
 #' the anomalous observations live. The point of the plot is not to read
 #' off a single score, it is to \emph{see where the curve breaks}. Pick a
 #' cutoff there. Pass it back in as \code{threshold} (for a score) or
-#' \code{top_n_pct} (for "the top 5\%") and the plot draws a dashed
+#' \code{top_n_pct} (for "the top 5%") and the plot draws a dashed
 #' reference line so you can record the choice you made.
 #'
 #' @section Reading the density:

--- a/man/calc_auc.Rd
+++ b/man/calc_auc.Rd
@@ -11,7 +11,7 @@ calc_auc(x)
 \item{x}{\code{\link{gg_roc}} object}
 }
 \value{
-AUC. 50\\% is random guessing, higher is better.
+AUC. 50\% is random guessing, higher is better.
 }
 \description{
 Area Under the ROC Curve calculator

--- a/man/gg_isopro.Rd
+++ b/man/gg_isopro.Rd
@@ -114,7 +114,7 @@ against a fitted model and compare the test scores to the training
 distribution.
 }
 The score is a \emph{rank}, not a probability of being an outlier: two
-observations with \code{howbad = 0.92} are both unusual, not "92\\%
+observations with \code{howbad = 0.92} are both unusual, not "92\%
 likely to be anomalous". Pick a cutoff by looking at where the elbow
 rises; \code{\link{plot.gg_isopro}} can annotate either a score
 (\code{threshold}) or a top-percent (\code{top_n_pct}) for you.

--- a/man/plot.gg_isopro.Rd
+++ b/man/plot.gg_isopro.Rd
@@ -50,7 +50,7 @@ and then bends sharply upward in the right tail; that bend is where
 the anomalous observations live. The point of the plot is not to read
 off a single score, it is to \emph{see where the curve breaks}. Pick a
 cutoff there. Pass it back in as \code{threshold} (for a score) or
-\code{top_n_pct} (for "the top 5\\%") and the plot draws a dashed
+\code{top_n_pct} (for "the top 5\%") and the plot draws a dashed
 reference line so you can record the choice you made.
 }
 


### PR DESCRIPTION
## What

Three roxygen blocks wrote `\%` where a bare `%` is correct.

roxygen2 escapes `%` itself when generating Rd, so a `\%` in the source
comes out as `\\%` in the `.Rd` — a literal backslash followed by a live
comment character. Rd inherits `%` as its comment marker from TeX, so
everything from there to end-of-line is silently swallowed. No parser
error, just a truncated sentence.

`?calc_auc` was rendering its Value section as:

```
_V_a_l_u_e:

     AUC. 50\
```

The rest of the sentence — "% is random guessing, higher is better." — was gone.

## Changed

| Source | Was | Now |
|---|---|---|
| [R/calc_roc.R:302](R/calc_roc.R#L302) | `50\%` | `50%` |
| [R/gg_isopro.R:79](R/gg_isopro.R#L79) | `"92\%` | `"92%` |
| [R/plot.gg_isopro.R:21](R/plot.gg_isopro.R#L21) | `the top 5\%` | `the top 5%` |

`man/calc_auc.Rd`, `man/gg_isopro.Rd` and `man/plot.gg_isopro.Rd`
regenerated with `roxygen2::roxygenise()` — exactly those three, no other
`man/` churn.

The bare form matches the convention already in use at `R/gg_rfsrc.R:401`
(`95%`), which renders correctly.

## Deliberately not touched

`\%` **inside** `\code{}` is correct and stays: `\code{\%in\%}` in
`gg_partial_varpro.R` / `plot.gg_partial_varpro.R`, `\code{\%IncMSE}` in
`gg_vimp.R`. roxygen passes `\code{}` contents through verbatim rather
than re-escaping them, so those reach the Rd as a single `\%` — which is
what Rd wants. Verified: `grep -rn '\\\\%' man/` returns nothing after
this change, and it returned only the three broken sites before it.

No version bump. `main` is at 3.5.1 and neither of the other two open
candidate branches has bumped, so the 3.5.2 roll belongs to whoever cuts
the release rather than to a candidate branch.

## Verification

Rendered output, after:

```
calc_auc        AUC. 50% is random guessing, higher is better.
gg_isopro       observations with 'howbad = 0.92' are both unusual, not "92%
plot.gg_isopro  ... or 'top_n_pct' (for "the top 5%") and the plot draws
```

- `roxygen2::roxygenise()` — 3 files written
- `lintr::lint_package()` — 0 lints
- `NOT_CRAN=true VDIFFR_RUN_TESTS=true devtools::test()` — **FAIL 0 | WARN 58 | SKIP 5 | PASS 1512**; all 49 vdiffr baselines intact afterwards
- `R CMD check --as-cran` with the manual, built from a clean `git archive`
  export — **1 NOTE**, the benign incoming-feasibility one
  (`Number of updates in past 6 months: 7`). Tarball 2.3M, check 3:19 total.

Candidate for 3.5.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)