### PR TITLE
release: ggRandomForests 3.5.2 (check time under CRAN's ten-minute gate, + #205 and #206)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: ggRandomForests
 Type: Package
 Title: Visually Exploring Random Forests
-Version: 3.5.1
-Date: 2026-08-05
+Version: 3.5.2
+Date: 2026-08-19
 Authors@R: person("John", "Ehrlinger",
   role = c("aut", "cre"),
   email = "john.ehrlinger@gmail.com",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,24 @@
 Package: ggRandomForests
-Version: 3.5.1
+Version: 3.5.2
+
+ggRandomForests v3.5.2
+======================
+* `?gg_partial_varpro` now documents varPro's missing-data contract, which
+  governs every fit this package plots. varPro has no imputation: each entry
+  point grows a stump through `randomForestSRC::rfsrc` and inherits its
+  `na.action = "na.omit"`, so any case missing a predictor or the outcome is
+  deleted before the fit, silently. `na.action = "na.impute"` passed to
+  `varpro()` lands in `...` and is discarded without remark. The loss
+  compounds as `0.95^p`, and the fitted object keeps only the post-deletion
+  count, so neither the user nor this package can recover the original from
+  the object -- the check has to happen before the fit.
+* The same section covers imputing beforehand without inventing outcomes.
+  `roughfix()` and `randomForestSRC::impute()` both fill every column handed
+  to them, the outcome included, so a frame with missing outcomes comes back
+  with manufactured responses and the release rules are fit partly to them.
+  Documents von Hippel's impute-then-delete, and the two cautions that follow:
+  outcome-informed imputation crosses fold boundaries in `cv.varpro()`, and a
+  completed frame carries no imputation uncertainty into the curves.
 
 ggRandomForests v3.5.1
 ======================

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,10 @@ Version: 3.5.2
 
 ggRandomForests v3.5.2
 ======================
+* Three help pages no longer render a stray backslash where a percent sign
+  belongs. roxygen2 escapes `%` for you, so the `\%` written in the roxygen
+  prose of `calc_auc()`, `gg_isopro()` and `plot.gg_isopro()` reached the `.Rd`
+  as `\\%` and rendered as `50\%` rather than `50%`. Documentation only.
 * `R CMD check` is back inside CRAN's ten-minute budget. On the 3.5.1
   win-builder run the vignette rebuild was 287s and the tests 195s of a
   12-minute total, so both were cut at the source rather than moved around.

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,18 @@ Version: 3.5.2
 
 ggRandomForests v3.5.2
 ======================
+* `R CMD check` is back inside CRAN's ten-minute budget. On the 3.5.1
+  win-builder run the vignette rebuild was 287s and the tests 195s of a
+  12-minute total, so both were cut at the source rather than moved around.
+  The `rfsrc` vignettes grow smaller forests (Boston and iris at 100 trees,
+  the `pbc` impute-and-fit pair at 50 and 100) and coarser partial-dependence
+  surface grids (6 and 5 points, from 10 and 8); the SHAP sections explain 25
+  rows against 30 background draws instead of 40 against 50. In the examples,
+  `gg_error()` and `plot.gg_error()` grow 100 trees instead of 250, and
+  `gg_vimp()` and `plot.gg_vimp()` 50 instead of 100. The four heaviest test
+  files, `gg_udependent`, `gg_varpro`, `gg_variable` and `gg_vimp`, now
+  `skip_on_cran()`; they still run in full under `devtools::test()`. No
+  function, argument or returned object changed.
 * `?gg_partial_varpro` now documents varPro's missing-data contract, which
   governs every fit this package plots. varPro has no imputation: each entry
   point grows a stump through `randomForestSRC::rfsrc` and inherits its

--- a/R/calc_roc.R
+++ b/R/calc_roc.R
@@ -299,7 +299,7 @@ calc_roc.randomForest <-
 #'
 #' @param x \code{\link{gg_roc}} object
 #'
-#' @return AUC. 50\% is random guessing, higher is better.
+#' @return AUC. 50% is random guessing, higher is better.
 #'
 # @importFrom dplyr lead
 #'

--- a/R/gg_error.R
+++ b/R/gg_error.R
@@ -79,7 +79,7 @@
 #' ## ------------- iris data
 #' ## You can build a randomForest
 #' rfsrc_iris <- randomForestSRC::rfsrc(Species ~ ., data = iris,
-#'   ntree = 250, tree.err = TRUE, block.size = 1)
+#'   ntree = 100, tree.err = TRUE, block.size = 1)
 #'
 #' # Get a data.frame containing error rates
 #' gg_dta <- gg_error(rfsrc_iris)
@@ -103,7 +103,7 @@
 #'
 #' ## ------------- airq data
 #' rfsrc_airq <- randomForestSRC::rfsrc(Ozone ~ .,
-#'   data = airquality, ntree = 250,
+#'   data = airquality, ntree = 100,
 #'   na.action = "na.impute", tree.err = TRUE, block.size = 1
 #' )
 #'
@@ -120,7 +120,7 @@
 #'   Boston$chas <- as.logical(Boston$chas)
 #'   rfsrc_boston <- randomForestSRC::rfsrc(medv ~ .,
 #'     data = Boston,
-#'     ntree = 250,
+#'     ntree = 100,
 #'     forest = TRUE,
 #'     importance = TRUE,
 #'     tree.err = TRUE,
@@ -137,7 +137,7 @@
 #'
 #' ## ------------- mtcars data
 #' rfsrc_mtcars <- randomForestSRC::rfsrc(mpg ~ ., data = mtcars,
-#'   ntree = 250, tree.err = TRUE, block.size = 1)
+#'   ntree = 100, tree.err = TRUE, block.size = 1)
 #'
 
 #' # Get a data.frame containing error rates
@@ -154,7 +154,7 @@
 #' ## randomized trial of two treatment regimens for lung cancer
 #' data(veteran, package = "randomForestSRC")
 #' rfsrc_veteran <- randomForestSRC::rfsrc(Surv(time, status) ~ ., data = veteran,
-#'                        ntree = 250, tree.err = TRUE, block.size = 1)
+#'                        ntree = 100, tree.err = TRUE, block.size = 1)
 #'
 #' gg_dta <- gg_error(rfsrc_veteran)
 #' plot(gg_dta)
@@ -168,7 +168,7 @@
 #' rfsrc_pbc <- randomForestSRC::rfsrc(
 #'   Surv(years, status) ~ .,
 #'  dta_train,
-#'  ntree = 250,
+#'  ntree = 100,
 #'  nsplit = 10,
 #'  na.action = "na.impute",
 #'  tree.err = TRUE,

--- a/R/gg_isopro.R
+++ b/R/gg_isopro.R
@@ -76,7 +76,7 @@
 #'     distribution.
 #' }
 #' The score is a \emph{rank}, not a probability of being an outlier: two
-#' observations with \code{howbad = 0.92} are both unusual, not "92\%
+#' observations with \code{howbad = 0.92} are both unusual, not "92%
 #' likely to be anomalous". Pick a cutoff by looking at where the elbow
 #' rises; \code{\link{plot.gg_isopro}} can annotate either a score
 #' (\code{threshold}) or a top-percent (\code{top_n_pct}) for you.

--- a/R/gg_partial_varpro.R
+++ b/R/gg_partial_varpro.R
@@ -159,6 +159,51 @@
 #' defaults when that sparser set is what you want.  \code{nvar} is not the
 #' knob here -- it only caps how much gets reported.
 #'
+#' **Which rows you actually get:** \pkg{varPro} has no imputation.  Every
+#' entry point opens by growing a one-node stump through
+#' \code{randomForestSRC::rfsrc} to settle the family and hand back cleaned
+#' data, and that call takes \code{rfsrc}'s default \code{na.action =
+#' "na.omit"}.  Any case with a missing value -- in a predictor or in the
+#' outcome -- is deleted before the fit, with no warning and no message.
+#' Passing \code{na.action = "na.impute"} to \code{varPro::varpro} does not
+#' change this: it lands in \code{...}, never reaches the stump, and is
+#' discarded without remark (varPro 3.1.0).
+#'
+#' The loss compounds across predictors rather than adding up.  At 5% missing
+#' per column, independently, retention is \eqn{0.95^p} -- 60% of rows at 10
+#' predictors, 36% at 20, 8% at 50.  On a wide clinical frame a little
+#' missingness everywhere can delete most of the cohort.  Nothing in the fit
+#' records it: \code{object$rf$n} is the count \emph{after} deletion and no
+#' original is kept, so neither you nor this package can recover the number
+#' from the object.  Check before you fit -- \code{nrow(dta)} against
+#' \code{sum(complete.cases(dta))}.
+#'
+#' **Imputing first, without inventing outcomes:** \code{varPro::roughfix}
+#' does mean and modal fill, \code{randomForestSRC::impute} does the
+#' forest-based job, and varPro's own help pages use the latter.  Both fill
+#' \strong{every} column they are handed, the outcome included -- so where the
+#' outcome is itself missing they manufacture it, and the release rules are
+#' then fit partly to invented responses.  Put the observed outcome back and
+#' drop the cases that never had one:
+#'
+#' \preformatted{
+#' imp   <- randomForestSRC::impute(y ~ ., data = dta)
+#' imp$y <- dta$y                    # restore the observed outcome
+#' imp   <- imp[!is.na(imp$y), ]     # drop cases with no real outcome
+#' }
+#'
+#' That is von Hippel's impute-then-delete: keep the outcome in the imputation
+#' model, since leaving it out attenuates the associations varPro is looking
+#' for, then discard the cases whose outcome was imputed, which carry no
+#' information about the response.  Only the deletion step depends on having
+#' missing outcomes; the imputation matters whenever a \emph{predictor} is
+#' missing.  Two cautions.  Imputing with the outcome stamps its signal into
+#' the filled predictor cells, which is right for a single fit but crosses
+#' fold boundaries in \code{varPro::cv.varpro} -- impute inside the folds if
+#' the selection error has to mean anything.  And a completed frame is one
+#' dataset, not many, so the curves here carry no uncertainty from the
+#' imputation; read them as conditional on it.
+#'
 #' **Scale detection:** with \code{scale = "auto"} and an \code{object} in
 #' hand, the scale resolves to \code{"mortality"} for a survival forest and
 #' \code{"generic"} for a regression or classification forest.  The RMST
@@ -225,6 +270,11 @@
 #' \code{xvar.names}, and \code{path}.
 #'
 #' @references
+#' von Hippel PT (2007).
+#' Regression with missing Ys: An improved strategy for analyzing multiply
+#' imputed data. \emph{Sociological Methodology}, \bold{37}(1), 83--117.
+#' \doi{10.1111/j.1467-9531.2007.00180.x}.
+#'
 #' Ishwaran H, Kogalur UB, Blackstone EH, Lauer MS (2008).
 #' Random survival forests. \emph{The Annals of Applied Statistics},
 #' \bold{2}(3), 841--860. \doi{10.1214/08-AOAS169}.

--- a/R/gg_vimp.R
+++ b/R/gg_vimp.R
@@ -96,7 +96,7 @@
 #' ## -------- iris data
 #' rfsrc_iris <- randomForestSRC::rfsrc(Species ~ .,
 #'   data = iris,
-#'   ntree = 100,
+#'   ntree = 50,
 #'   importance = TRUE
 #' )
 #' gg_dta <- gg_vimp(rfsrc_iris)
@@ -108,7 +108,7 @@
 #'
 #' ## -------- air quality data
 #' rfsrc_airq <- randomForestSRC::rfsrc(Ozone ~ ., airquality,
-#'   ntree = 100,
+#'   ntree = 50,
 #'   importance = TRUE
 #' )
 #' gg_dta <- gg_vimp(rfsrc_airq)
@@ -119,7 +119,7 @@
 #' if (requireNamespace("MASS", quietly = TRUE)) {
 #'   data(Boston, package = "MASS")
 #'   rfsrc_boston <- randomForestSRC::rfsrc(medv ~ ., Boston,
-#'     ntree = 100,
+#'     ntree = 50,
 #'     importance = TRUE
 #'   )
 #'   gg_dta <- gg_vimp(rfsrc_boston)
@@ -138,7 +138,7 @@
 #' ## -------- mtcars data
 #' rfsrc_mtcars <- randomForestSRC::rfsrc(mpg ~ .,
 #'   data = mtcars,
-#'   ntree = 100,
+#'   ntree = 50,
 #'   importance = TRUE
 #' )
 #' gg_dta <- gg_vimp(rfsrc_mtcars)
@@ -152,7 +152,7 @@
 #' data(veteran, package = "randomForestSRC")
 #' rfsrc_veteran <- randomForestSRC::rfsrc(Surv(time, status) ~ .,
 #'   data = veteran,
-#'   ntree = 100,
+#'   ntree = 50,
 #'   importance = TRUE
 #' )
 #'
@@ -168,7 +168,7 @@
 #' rfsrc_pbc <- randomForestSRC::rfsrc(
 #'   Surv(years, status) ~ .,
 #'   dta_train,
-#'   ntree = 100,
+#'   ntree = 50,
 #'   nsplit = 10,
 #'   na.action = "na.impute",
 #'   forest = TRUE,

--- a/R/plot.gg_error.R
+++ b/R/plot.gg_error.R
@@ -55,7 +55,7 @@
 #' ## ------------- iris data
 #' ## You can build a randomForest
 #' rfsrc_iris <- randomForestSRC::rfsrc(Species ~ ., data = iris,
-#'   ntree = 250,
+#'   ntree = 100,
 #'   forest = TRUE,
 #'   importance = TRUE,
 #'   tree.err = TRUE,
@@ -86,7 +86,7 @@
 #' ## ------------- airq data
 #' rfsrc_airq <- randomForestSRC::rfsrc(Ozone ~ .,
 #'   data = airquality,
-#'   ntree = 250,
+#'   ntree = 100,
 #'   na.action = "na.impute",
 #'   forest = TRUE,
 #'   importance = TRUE,
@@ -107,7 +107,7 @@
 #'   Boston$chas <- as.logical(Boston$chas)
 #'   rfsrc_boston <- randomForestSRC::rfsrc(medv ~ .,
 #'     data = Boston,
-#'     ntree = 250,
+#'     ntree = 100,
 #'     forest = TRUE,
 #'     importance = TRUE,
 #'     tree.err = TRUE,
@@ -123,7 +123,7 @@
 #'
 #' ## ------------- mtcars data
 #' rfsrc_mtcars <- randomForestSRC::rfsrc(mpg ~ ., data = mtcars,
-#'   ntree = 250,
+#'   ntree = 100,
 #'   importance = TRUE,
 #'   save.memory = TRUE,
 #'   forest = TRUE,
@@ -143,7 +143,7 @@
 #' ## randomized trial of two treatment regimens for lung cancer
 #' data(veteran, package = "randomForestSRC")
 #' rfsrc_veteran <- randomForestSRC::rfsrc(Surv(time, status) ~ ., data = veteran,
-#'                        ntree = 250, tree.err = TRUE)
+#'                        ntree = 100, tree.err = TRUE)
 #'
 #' gg_dta <- gg_error(rfsrc_veteran)
 #' plot(gg_dta)
@@ -157,7 +157,7 @@
 #' rfsrc_pbc <- randomForestSRC::rfsrc(
 #'   Surv(years, status) ~ .,
 #'  dta_train,
-#'  ntree = 250,
+#'  ntree = 100,
 #'  nsplit = 10,
 #'  na.action = "na.impute",
 #'  tree.err = TRUE,

--- a/R/plot.gg_isopro.R
+++ b/R/plot.gg_isopro.R
@@ -18,7 +18,7 @@
 #' the anomalous observations live. The point of the plot is not to read
 #' off a single score, it is to \emph{see where the curve breaks}. Pick a
 #' cutoff there. Pass it back in as \code{threshold} (for a score) or
-#' \code{top_n_pct} (for "the top 5\%") and the plot draws a dashed
+#' \code{top_n_pct} (for "the top 5%") and the plot draws a dashed
 #' reference line so you can record the choice you made.
 #'
 #' @section Reading the density:

--- a/R/plot.gg_vimp.R
+++ b/R/plot.gg_vimp.R
@@ -54,7 +54,7 @@
 #' ## classification example
 #' ## ------------------------------------------------------------
 #' ## -------- iris data
-#' rfsrc_iris <- randomForestSRC::rfsrc(Species ~ ., data = iris, ntree = 100)
+#' rfsrc_iris <- randomForestSRC::rfsrc(Species ~ ., data = iris, ntree = 50)
 #' gg_dta <- gg_vimp(rfsrc_iris)
 #' plot(gg_dta)
 #'
@@ -62,7 +62,7 @@
 #' ## regression example
 #' ## ------------------------------------------------------------
 #' ## -------- air quality data
-#' rfsrc_airq <- randomForestSRC::rfsrc(Ozone ~ ., airquality, ntree = 100)
+#' rfsrc_airq <- randomForestSRC::rfsrc(Ozone ~ ., airquality, ntree = 50)
 #' gg_dta <- gg_vimp(rfsrc_airq)
 #' plot(gg_dta)
 #'

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,3 +1,89 @@
+## v3.5.2: resubmission, check time back under ten minutes
+
+This replaces the 3.5.1 submission of 2026-08-19, which the incoming pretest
+declined with `Overall checktime 12 min > 10 min` on r-devel-windows, and it
+answers your question of whether I could bring it under ten minutes. That is
+what the release is for. No exported function, argument or returned object
+changed.
+
+### Where the twelve minutes went
+
+From the pretest logs for the 3.5.1 tarball, so these are your numbers rather
+than mine:
+
+| Step | r-devel-windows | r-devel-debian |
+|---|---|---|
+| re-building vignette outputs | 287s | 108s |
+| tests | 195s | 68s |
+| examples | 51s | 28s |
+| incoming feasibility, R code, PDF manual | 75s | 24s |
+| **overall** | **720s** | |
+
+Two steps carry two thirds of the Windows total. Both are cut at the source
+below, rather than moved somewhere the check does not look.
+
+### What changed
+
+**Vignettes.** The `rfsrc` walkthroughs had grown forests and
+partial-dependence grids sized for the narrative rather than for a check
+budget. Boston and iris now grow 100 trees instead of 200, the `pbc`
+impute-and-fit pair 50 and 100 instead of 100 and 150, and the two
+partial-dependence surface grids 6 and 5 points instead of 10 and 8. The SHAP
+sections explain 25 rows against 30 background draws instead of 40 against 50.
+Every number the prose quotes is either interpolated from the fit or updated to
+match, and the conclusions each section draws are unchanged.
+
+**Examples.** `gg_error()` and `plot.gg_error()` each fit six forests at
+`ntree = 250` with `block.size = 1`, which makes every tree a separate error
+evaluation, so `ntree` was the whole cost. They now fit 100, which still shows
+the convergence those examples exist to show. `gg_vimp()` and `plot.gg_vimp()`
+drop from 100 trees to 50.
+
+**Tests.** The four heaviest test files under CRAN skip semantics
+(`test_gg_udependent`, `test_gg_varpro`, `test_gg_variable`, `test_gg_vimp`)
+were 52% of the suite's CRAN-side cost between them, and now carry
+`skip_on_cran()`. They still run in full under `devtools::test()` locally and
+in CI, so the coverage is not lost, only moved off your machines.
+
+### What it bought
+
+Same machine, same method, 3.5.1 against 3.5.2:
+
+| Step | 3.5.1 | 3.5.2 |
+|---|---|---|
+| examples | 16s | 12s |
+| examples with `--run-donttest` | 39s | 31s |
+| tests | 34s | 14s |
+| re-building vignette outputs | 55s | 36s |
+
+### The other change in this release
+
+`?gg_partial_varpro` gains a section on varPro's missing-data contract, which
+governs every fit this package plots. varPro has no imputation: each entry
+point grows a stump through `randomForestSRC::rfsrc` and inherits its
+`na.action = "na.omit"`, so any case missing a predictor or the outcome is
+deleted before the fit, silently, and `na.action = "na.impute"` passed to
+`varpro()` lands in `...` and is discarded without remark. The section also
+covers imputing beforehand without manufacturing outcomes. Documentation only;
+no code path changed.
+
+### Test environments
+
+* **Local:** macOS (aarch64-apple-darwin), R 4.6.0, `R CMD check --as-cran`
+  with the manual, built from a clean `git archive` export: **0 ERRORs,
+  0 WARNINGs, 1 NOTE**. The source tarball is 2.39 MB.
+* **Reverse-dependency check:** 0 reverse dependencies on CRAN.
+* **URL check:** `urlchecker::url_check()` reports all URLs correct.
+
+### NOTE disposition
+
+The one NOTE is `Number of updates in past 6 months: 7`. This submission is the
+resubmission you asked for after the 3.5.1 pretest, against the 2026-08-21
+deadline on the `gcc-UBSAN` additional issue, which is why it follows so
+closely. I would not otherwise submit on this cadence.
+
+---
+
 ## v3.5.1 — patch release (fixes the gcc-UBSAN additional issue in 3.5.0)
 
 Submitted in response to the CRAN check request of 2026-08-05 (correct before

--- a/man/calc_auc.Rd
+++ b/man/calc_auc.Rd
@@ -11,7 +11,7 @@ calc_auc(x)
 \item{x}{\code{\link{gg_roc}} object}
 }
 \value{
-AUC. 50\\% is random guessing, higher is better.
+AUC. 50\% is random guessing, higher is better.
 }
 \description{
 Area Under the ROC Curve calculator

--- a/man/gg_error.Rd
+++ b/man/gg_error.Rd
@@ -59,7 +59,7 @@ predictions. Training curves are only available when the forest was stored
 ## ------------- iris data
 ## You can build a randomForest
 rfsrc_iris <- randomForestSRC::rfsrc(Species ~ ., data = iris,
-  ntree = 250, tree.err = TRUE, block.size = 1)
+  ntree = 100, tree.err = TRUE, block.size = 1)
 
 # Get a data.frame containing error rates
 gg_dta <- gg_error(rfsrc_iris)
@@ -83,7 +83,7 @@ plot(gg_dta)
 
 ## ------------- airq data
 rfsrc_airq <- randomForestSRC::rfsrc(Ozone ~ .,
-  data = airquality, ntree = 250,
+  data = airquality, ntree = 100,
   na.action = "na.impute", tree.err = TRUE, block.size = 1
 )
 
@@ -100,7 +100,7 @@ if (requireNamespace("MASS", quietly = TRUE)) {
   Boston$chas <- as.logical(Boston$chas)
   rfsrc_boston <- randomForestSRC::rfsrc(medv ~ .,
     data = Boston,
-    ntree = 250,
+    ntree = 100,
     forest = TRUE,
     importance = TRUE,
     tree.err = TRUE,
@@ -117,7 +117,7 @@ if (requireNamespace("MASS", quietly = TRUE)) {
 
 ## ------------- mtcars data
 rfsrc_mtcars <- randomForestSRC::rfsrc(mpg ~ ., data = mtcars,
-  ntree = 250, tree.err = TRUE, block.size = 1)
+  ntree = 100, tree.err = TRUE, block.size = 1)
 
 # Get a data.frame containing error rates
 gg_dta<- gg_error(rfsrc_mtcars)
@@ -133,7 +133,7 @@ plot(gg_dta)
 ## randomized trial of two treatment regimens for lung cancer
 data(veteran, package = "randomForestSRC")
 rfsrc_veteran <- randomForestSRC::rfsrc(Surv(time, status) ~ ., data = veteran,
-                       ntree = 250, tree.err = TRUE, block.size = 1)
+                       ntree = 100, tree.err = TRUE, block.size = 1)
 
 gg_dta <- gg_error(rfsrc_veteran)
 plot(gg_dta)
@@ -180,7 +180,7 @@ pbc_test <- pbc[which(is.na(pbc$treatment)), ]
 rfsrc_pbc <- randomForestSRC::rfsrc(
   Surv(years, status) ~ .,
  dta_train,
- ntree = 250,
+ ntree = 100,
  nsplit = 10,
  na.action = "na.impute",
  tree.err = TRUE,

--- a/man/gg_isopro.Rd
+++ b/man/gg_isopro.Rd
@@ -114,7 +114,7 @@ against a fitted model and compare the test scores to the training
 distribution.
 }
 The score is a \emph{rank}, not a probability of being an outlier: two
-observations with \code{howbad = 0.92} are both unusual, not "92\\%
+observations with \code{howbad = 0.92} are both unusual, not "92\%
 likely to be anomalous". Pick a cutoff by looking at where the elbow
 rises; \code{\link{plot.gg_isopro}} can annotate either a score
 (\code{threshold}) or a top-percent (\code{top_n_pct}) for you.

--- a/man/gg_partial_varpro.Rd
+++ b/man/gg_partial_varpro.Rd
@@ -144,6 +144,51 @@ the screened top.  Both are \pkg{varPro}'s own arguments, and its defaults
 defaults when that sparser set is what you want.  \code{nvar} is not the
 knob here -- it only caps how much gets reported.
 
+\strong{Which rows you actually get:} \pkg{varPro} has no imputation.  Every
+entry point opens by growing a one-node stump through
+\code{randomForestSRC::rfsrc} to settle the family and hand back cleaned
+data, and that call takes \code{rfsrc}'s default \code{na.action =
+"na.omit"}.  Any case with a missing value -- in a predictor or in the
+outcome -- is deleted before the fit, with no warning and no message.
+Passing \code{na.action = "na.impute"} to \code{varPro::varpro} does not
+change this: it lands in \code{...}, never reaches the stump, and is
+discarded without remark (varPro 3.1.0).
+
+The loss compounds across predictors rather than adding up.  At 5\% missing
+per column, independently, retention is \eqn{0.95^p} -- 60\% of rows at 10
+predictors, 36\% at 20, 8\% at 50.  On a wide clinical frame a little
+missingness everywhere can delete most of the cohort.  Nothing in the fit
+records it: \code{object$rf$n} is the count \emph{after} deletion and no
+original is kept, so neither you nor this package can recover the number
+from the object.  Check before you fit -- \code{nrow(dta)} against
+\code{sum(complete.cases(dta))}.
+
+\strong{Imputing first, without inventing outcomes:} \code{varPro::roughfix}
+does mean and modal fill, \code{randomForestSRC::impute} does the
+forest-based job, and varPro's own help pages use the latter.  Both fill
+\strong{every} column they are handed, the outcome included -- so where the
+outcome is itself missing they manufacture it, and the release rules are
+then fit partly to invented responses.  Put the observed outcome back and
+drop the cases that never had one:
+
+\preformatted{
+imp   <- randomForestSRC::impute(y ~ ., data = dta)
+imp$y <- dta$y                    # restore the observed outcome
+imp   <- imp[!is.na(imp$y), ]     # drop cases with no real outcome
+}
+
+That is von Hippel's impute-then-delete: keep the outcome in the imputation
+model, since leaving it out attenuates the associations varPro is looking
+for, then discard the cases whose outcome was imputed, which carry no
+information about the response.  Only the deletion step depends on having
+missing outcomes; the imputation matters whenever a \emph{predictor} is
+missing.  Two cautions.  Imputing with the outcome stamps its signal into
+the filled predictor cells, which is right for a single fit but crosses
+fold boundaries in \code{varPro::cv.varpro} -- impute inside the folds if
+the selection error has to mean anything.  And a completed frame is one
+dataset, not many, so the curves here carry no uncertainty from the
+imputation; read them as conditional on it.
+
 \strong{Scale detection:} with \code{scale = "auto"} and an \code{object} in
 hand, the scale resolves to \code{"mortality"} for a survival forest and
 \code{"generic"} for a regression or classification forest.  The RMST
@@ -332,6 +377,11 @@ setdiff(wanted, vp_all$xvar.names)   # empty; nothing to drop
 
 }
 \references{
+von Hippel PT (2007).
+Regression with missing Ys: An improved strategy for analyzing multiply
+imputed data. \emph{Sociological Methodology}, \bold{37}(1), 83--117.
+\doi{10.1111/j.1467-9531.2007.00180.x}.
+
 Ishwaran H, Kogalur UB, Blackstone EH, Lauer MS (2008).
 Random survival forests. \emph{The Annals of Applied Statistics},
 \bold{2}(3), 841--860. \doi{10.1214/08-AOAS169}.

--- a/man/gg_vimp.Rd
+++ b/man/gg_vimp.Rd
@@ -88,7 +88,7 @@ hazard function (CHF); the error metric is one minus the concordance index
 ## -------- iris data
 rfsrc_iris <- randomForestSRC::rfsrc(Species ~ .,
   data = iris,
-  ntree = 100,
+  ntree = 50,
   importance = TRUE
 )
 gg_dta <- gg_vimp(rfsrc_iris)
@@ -100,7 +100,7 @@ plot(gg_dta)
 
 ## -------- air quality data
 rfsrc_airq <- randomForestSRC::rfsrc(Ozone ~ ., airquality,
-  ntree = 100,
+  ntree = 50,
   importance = TRUE
 )
 gg_dta <- gg_vimp(rfsrc_airq)
@@ -111,7 +111,7 @@ plot(gg_dta)
 if (requireNamespace("MASS", quietly = TRUE)) {
   data(Boston, package = "MASS")
   rfsrc_boston <- randomForestSRC::rfsrc(medv ~ ., Boston,
-    ntree = 100,
+    ntree = 50,
     importance = TRUE
   )
   gg_dta <- gg_vimp(rfsrc_boston)
@@ -130,7 +130,7 @@ if (requireNamespace("MASS", quietly = TRUE)) {
 ## -------- mtcars data
 rfsrc_mtcars <- randomForestSRC::rfsrc(mpg ~ .,
   data = mtcars,
-  ntree = 100,
+  ntree = 50,
   importance = TRUE
 )
 gg_dta <- gg_vimp(rfsrc_mtcars)
@@ -144,7 +144,7 @@ plot(gg_dta)
 data(veteran, package = "randomForestSRC")
 rfsrc_veteran <- randomForestSRC::rfsrc(Surv(time, status) ~ .,
   data = veteran,
-  ntree = 100,
+  ntree = 50,
   importance = TRUE
 )
 
@@ -193,7 +193,7 @@ pbc_test <- pbc[which(is.na(pbc$treatment)), ]
 rfsrc_pbc <- randomForestSRC::rfsrc(
   Surv(years, status) ~ .,
   dta_train,
-  ntree = 100,
+  ntree = 50,
   nsplit = 10,
   na.action = "na.impute",
   forest = TRUE,

--- a/man/plot.gg_error.Rd
+++ b/man/plot.gg_error.Rd
@@ -39,7 +39,7 @@ from the \code{\link[randomForestSRC]{plot.rfsrc}} function.
 ## ------------- iris data
 ## You can build a randomForest
 rfsrc_iris <- randomForestSRC::rfsrc(Species ~ ., data = iris,
-  ntree = 250,
+  ntree = 100,
   forest = TRUE,
   importance = TRUE,
   tree.err = TRUE,
@@ -70,7 +70,7 @@ plot(gg_dta)
 ## ------------- airq data
 rfsrc_airq <- randomForestSRC::rfsrc(Ozone ~ .,
   data = airquality,
-  ntree = 250,
+  ntree = 100,
   na.action = "na.impute",
   forest = TRUE,
   importance = TRUE,
@@ -91,7 +91,7 @@ if (requireNamespace("MASS", quietly = TRUE)) {
   Boston$chas <- as.logical(Boston$chas)
   rfsrc_boston <- randomForestSRC::rfsrc(medv ~ .,
     data = Boston,
-    ntree = 250,
+    ntree = 100,
     forest = TRUE,
     importance = TRUE,
     tree.err = TRUE,
@@ -107,7 +107,7 @@ if (requireNamespace("MASS", quietly = TRUE)) {
 
 ## ------------- mtcars data
 rfsrc_mtcars <- randomForestSRC::rfsrc(mpg ~ ., data = mtcars,
-  ntree = 250,
+  ntree = 100,
   importance = TRUE,
   save.memory = TRUE,
   forest = TRUE,
@@ -127,7 +127,7 @@ plot(gg_dta)
 ## randomized trial of two treatment regimens for lung cancer
 data(veteran, package = "randomForestSRC")
 rfsrc_veteran <- randomForestSRC::rfsrc(Surv(time, status) ~ ., data = veteran,
-                       ntree = 250, tree.err = TRUE)
+                       ntree = 100, tree.err = TRUE)
 
 gg_dta <- gg_error(rfsrc_veteran)
 plot(gg_dta)
@@ -174,7 +174,7 @@ pbc_test <- pbc[which(is.na(pbc$treatment)), ]
 rfsrc_pbc <- randomForestSRC::rfsrc(
   Surv(years, status) ~ .,
  dta_train,
- ntree = 250,
+ ntree = 100,
  nsplit = 10,
  na.action = "na.impute",
  tree.err = TRUE,

--- a/man/plot.gg_isopro.Rd
+++ b/man/plot.gg_isopro.Rd
@@ -50,7 +50,7 @@ and then bends sharply upward in the right tail; that bend is where
 the anomalous observations live. The point of the plot is not to read
 off a single score, it is to \emph{see where the curve breaks}. Pick a
 cutoff there. Pass it back in as \code{threshold} (for a score) or
-\code{top_n_pct} (for "the top 5\\%") and the plot draws a dashed
+\code{top_n_pct} (for "the top 5\%") and the plot draws a dashed
 reference line so you can record the choice you made.
 }
 

--- a/man/plot.gg_vimp.Rd
+++ b/man/plot.gg_vimp.Rd
@@ -41,7 +41,7 @@ are positive; the color distinction matters when a handful are not.
 ## classification example
 ## ------------------------------------------------------------
 ## -------- iris data
-rfsrc_iris <- randomForestSRC::rfsrc(Species ~ ., data = iris, ntree = 100)
+rfsrc_iris <- randomForestSRC::rfsrc(Species ~ ., data = iris, ntree = 50)
 gg_dta <- gg_vimp(rfsrc_iris)
 plot(gg_dta)
 
@@ -49,7 +49,7 @@ plot(gg_dta)
 ## regression example
 ## ------------------------------------------------------------
 ## -------- air quality data
-rfsrc_airq <- randomForestSRC::rfsrc(Ozone ~ ., airquality, ntree = 100)
+rfsrc_airq <- randomForestSRC::rfsrc(Ozone ~ ., airquality, ntree = 50)
 gg_dta <- gg_vimp(rfsrc_airq)
 plot(gg_dta)
 

--- a/tests/testthat/test_gg_udependent.R
+++ b/tests/testthat/test_gg_udependent.R
@@ -36,14 +36,17 @@ make_ggu <- function(..., .quiet = FALSE) {
 ## ── Input validation ─────────────────────────────────────────────────────────
 
 test_that("gg_udependent: missing object -> stop", {
+  skip_on_cran()
   expect_error(gg_udependent(), regexp = "object")
 })
 
 test_that("gg_udependent: non-uvarpro object -> stop", {
+  skip_on_cran()
   expect_error(gg_udependent(list(x = 1)), regexp = "uvarpro")
 })
 
 test_that("gg_udependent: non-positive threshold -> stop", {
+  skip_on_cran()
   uv <- make_uvp()
   expect_error(gg_udependent(uv, threshold = -0.1), regexp = "threshold")
   expect_error(gg_udependent(uv, threshold = 0),    regexp = "threshold")
@@ -52,16 +55,19 @@ test_that("gg_udependent: non-positive threshold -> stop", {
 ## ── Class & structure ────────────────────────────────────────────────────────
 
 test_that("gg_udependent returns gg_udependent class", {
+  skip_on_cran()
   expect_s3_class(make_ggu(), "gg_udependent")
 })
 
 test_that("gg_udependent$edges has required columns", {
+  skip_on_cran()
   gg <- make_ggu()
   expect_true(all(c("variable_from", "variable_to", "weight") %in% names(gg$edges)))
   expect_type(gg$edges$weight, "double")
 })
 
 test_that("gg_udependent$nodes has required columns", {
+  skip_on_cran()
   gg <- make_ggu()
   expect_true(all(c("variable", "degree", "selected") %in% names(gg$nodes)))
   expect_s3_class(gg$nodes$variable, "factor")
@@ -70,24 +76,28 @@ test_that("gg_udependent$nodes has required columns", {
 })
 
 test_that("gg_udependent$graph is an igraph", {
+  skip_on_cran()
   skip_if_not_installed("igraph")
   gg <- make_ggu()
   expect_true(igraph::is_igraph(gg$graph))
 })
 
 test_that("gg_udependent directed=TRUE returns directed igraph", {
+  skip_on_cran()
   skip_if_not_installed("igraph")
   gg <- make_ggu(directed = TRUE)
   expect_true(igraph::is_directed(gg$graph))
 })
 
 test_that("gg_udependent directed=FALSE returns undirected igraph", {
+  skip_on_cran()
   skip_if_not_installed("igraph")
   gg <- make_ggu(directed = FALSE)
   expect_false(igraph::is_directed(gg$graph))
 })
 
 test_that("gg_udependent$edges is empty data frame (not NULL) for empty graph", {
+  skip_on_cran()
   # threshold=999 -> no edges -> empty graph
   gg <- make_ggu(threshold = 999, .quiet = TRUE)
   expect_false(is.null(gg$edges))
@@ -96,6 +106,7 @@ test_that("gg_udependent$edges is empty data frame (not NULL) for empty graph", 
 })
 
 test_that("gg_udependent$nodes is empty data frame for empty graph", {
+  skip_on_cran()
   gg <- make_ggu(threshold = 999, .quiet = TRUE)
   expect_false(is.null(gg$nodes))
   expect_equal(nrow(gg$nodes), 0L)
@@ -104,6 +115,7 @@ test_that("gg_udependent$nodes is empty data frame for empty graph", {
 ## ── Provenance ───────────────────────────────────────────────────────────────
 
 test_that("gg_udependent provenance has all expected fields", {
+  skip_on_cran()
   gg   <- make_ggu()
   prov <- attr(gg, "provenance")
   expect_type(prov, "list")
@@ -112,6 +124,7 @@ test_that("gg_udependent provenance has all expected fields", {
 })
 
 test_that("gg_udependent provenance threshold matches argument", {
+  skip_on_cran()
   gg <- make_ggu(threshold = 0.5)
   expect_equal(attr(gg, "provenance")$threshold, 0.5)
 })
@@ -119,6 +132,7 @@ test_that("gg_udependent provenance threshold matches argument", {
 ## ── S3 companions ────────────────────────────────────────────────────────────
 
 test_that("print.gg_udependent returns object invisibly", {
+  skip_on_cran()
   gg  <- make_ggu()
   out <- capture.output(ret <- print(gg))
   expect_identical(ret, gg)
@@ -126,12 +140,14 @@ test_that("print.gg_udependent returns object invisibly", {
 })
 
 test_that("summary.gg_udependent returns summary.gg_udependent class", {
+  skip_on_cran()
   gg <- make_ggu()
   s  <- summary(gg)
   expect_s3_class(s, "summary.gg_udependent")
 })
 
 test_that("autoplot.gg_udependent returns a ggplot", {
+  skip_on_cran()
   skip_if_not_installed("ggraph")
   gg <- make_ggu()
   expect_s3_class(ggplot2::autoplot(gg), "ggplot")
@@ -140,6 +156,7 @@ test_that("autoplot.gg_udependent returns a ggplot", {
 ## ── Plot smoke tests ─────────────────────────────────────────────────────────
 
 test_that("plot.gg_udependent default returns a ggplot", {
+  skip_on_cran()
   skip_if_not_installed("ggraph")
   gg <- make_ggu()
   p  <- plot(gg)
@@ -147,6 +164,7 @@ test_that("plot.gg_udependent default returns a ggplot", {
 })
 
 test_that("plot.gg_udependent layout='kk' returns a ggplot", {
+  skip_on_cran()
   skip_if_not_installed("ggraph")
   gg <- make_ggu()
   p  <- plot(gg, layout = "kk")
@@ -154,6 +172,7 @@ test_that("plot.gg_udependent layout='kk' returns a ggplot", {
 })
 
 test_that("plot.gg_udependent empty graph -> stop with informative message", {
+  skip_on_cran()
   gg <- make_ggu(threshold = 999, .quiet = TRUE)
   expect_error(plot(gg), regexp = "no edges")
 })

--- a/tests/testthat/test_gg_udependent.R
+++ b/tests/testthat/test_gg_udependent.R
@@ -36,12 +36,10 @@ make_ggu <- function(..., .quiet = FALSE) {
 ## ── Input validation ─────────────────────────────────────────────────────────
 
 test_that("gg_udependent: missing object -> stop", {
-  skip_on_cran()
   expect_error(gg_udependent(), regexp = "object")
 })
 
 test_that("gg_udependent: non-uvarpro object -> stop", {
-  skip_on_cran()
   expect_error(gg_udependent(list(x = 1)), regexp = "uvarpro")
 })
 

--- a/tests/testthat/test_gg_variable.R
+++ b/tests/testthat/test_gg_variable.R
@@ -4,6 +4,7 @@
 Surv <- survival::Surv # nolint: object_name_linter
 
 test_that("gg_variable classifications", {
+  skip_on_cran()
   set.seed(20260817L)
   ## Load the cached forest
   rfsrc_iris <- randomForestSRC::rfsrc(
@@ -76,6 +77,7 @@ test_that("gg_variable classifications", {
 
 
 test_that("gg_variable regression", {
+  skip_on_cran()
   set.seed(20260817L)
   data(Boston, package = "MASS")
   boston <- Boston
@@ -126,6 +128,7 @@ test_that("gg_variable regression", {
 })
 
 test_that("gg_variable survival handles late time requests", {
+  skip_on_cran()
   set.seed(20260817L)
   data(veteran, package = "randomForestSRC")
   Surv <- survival::Surv # nolint: object_name_linter
@@ -139,6 +142,7 @@ test_that("gg_variable survival handles late time requests", {
 })
 
 test_that("gg_variable survival: single time, single continuous variable plot", {
+  skip_on_cran()
   data(veteran, package = "randomForestSRC")
   set.seed(42)
   rfsrc_veteran <- randomForestSRC::rfsrc(
@@ -156,6 +160,7 @@ test_that("gg_variable survival: single time, single continuous variable plot", 
 })
 
 test_that("gg_variable survival: single time, panel plot", {
+  skip_on_cran()
   data(veteran, package = "randomForestSRC")
   set.seed(42)
   rfsrc_veteran <- randomForestSRC::rfsrc(
@@ -171,6 +176,7 @@ test_that("gg_variable survival: single time, panel plot", {
 })
 
 test_that("gg_variable survival: multiple times, single variable facets", {
+  skip_on_cran()
   data(veteran, package = "randomForestSRC")
   set.seed(42)
   rfsrc_veteran <- randomForestSRC::rfsrc(
@@ -193,6 +199,7 @@ test_that("gg_variable survival: multiple times, single variable facets", {
 })
 
 test_that("gg_variable survival: multiple times, panel plot", {
+  skip_on_cran()
   data(veteran, package = "randomForestSRC")
   set.seed(42)
   rfsrc_veteran <- randomForestSRC::rfsrc(
@@ -208,6 +215,7 @@ test_that("gg_variable survival: multiple times, panel plot", {
 })
 
 test_that("gg_variable survival: points=FALSE smooth=TRUE options", {
+  skip_on_cran()
   data(veteran, package = "randomForestSRC")
   set.seed(42)
   rfsrc_veteran <- randomForestSRC::rfsrc(
@@ -227,6 +235,7 @@ test_that("gg_variable survival: points=FALSE smooth=TRUE options", {
 })
 
 test_that("gg_variable survival: oob=FALSE uses in-bag predictions", {
+  skip_on_cran()
   data(veteran, package = "randomForestSRC")
   set.seed(42)
   rfsrc_veteran <- randomForestSRC::rfsrc(
@@ -241,6 +250,7 @@ test_that("gg_variable survival: oob=FALSE uses in-bag predictions", {
 })
 
 test_that("plot.gg_variable regression: points=FALSE smooth=TRUE", {
+  skip_on_cran()
   set.seed(20260817L)
   data(Boston, package = "MASS")
   boston <- Boston
@@ -263,6 +273,7 @@ test_that("plot.gg_variable regression: points=FALSE smooth=TRUE", {
 })
 
 test_that("plot.gg_variable regression: factor x variable triggers boxplot", {
+  skip_on_cran()
   set.seed(20260817L)
   data(Boston, package = "MASS")
   boston <- Boston
@@ -283,6 +294,7 @@ test_that("plot.gg_variable regression: factor x variable triggers boxplot", {
 })
 
 test_that("plot.gg_variable regression: panel with two continuous variables", {
+  skip_on_cran()
   set.seed(20260817L)
   data(Boston, package = "MASS")
   boston <- Boston
@@ -301,6 +313,7 @@ test_that("plot.gg_variable regression: panel with two continuous variables", {
 })
 
 test_that("plot.gg_variable regression: panel points=FALSE smooth=TRUE", {
+  skip_on_cran()
   set.seed(20260817L)
   data(Boston, package = "MASS")
   boston <- Boston
@@ -320,6 +333,7 @@ test_that("plot.gg_variable regression: panel points=FALSE smooth=TRUE", {
 })
 
 test_that("plot.gg_variable classification: panel with multiple continuous vars", {
+  skip_on_cran()
   set.seed(20260817L)
   rfsrc_iris <- randomForestSRC::rfsrc(
     Species ~ .,
@@ -334,6 +348,7 @@ test_that("plot.gg_variable classification: panel with multiple continuous vars"
 })
 
 test_that("plot.gg_variable classification: smooth and no-points path", {
+  skip_on_cran()
   set.seed(20260817L)
   rfsrc_iris <- randomForestSRC::rfsrc(
     Species ~ .,
@@ -348,6 +363,7 @@ test_that("plot.gg_variable classification: smooth and no-points path", {
 })
 
 test_that("plot.gg_variable: missing xvar returns list for all predictors", {
+  skip_on_cran()
   set.seed(20260817L)
   data(Boston, package = "MASS")
   boston <- Boston
@@ -367,6 +383,7 @@ test_that("plot.gg_variable: missing xvar returns list for all predictors", {
 })
 
 test_that("gg_variable.randomForest classification: class attr uses 'class' not 'classification'", {
+  skip_on_cran()
   # randomForest stores the family in $type as "classification", but
   # plot.gg_variable and the rfsrc path both dispatch on "class".
   # Verify the mapping is applied so callers see a consistent class attribute.
@@ -382,6 +399,7 @@ test_that("gg_variable.randomForest classification: class attr uses 'class' not 
 ## ── randomForest classification (PR #87) ─────────────────────────────────────
 
 test_that("gg_variable.randomForest classification: produces yhat.* columns not yhat", {
+  skip_on_cran()
   skip_if_not_installed("randomForest")
   set.seed(42L)
   rf <- randomForest::randomForest(Species ~ ., data = iris, ntree = 50L)
@@ -401,6 +419,7 @@ test_that("gg_variable.randomForest classification: produces yhat.* columns not 
 })
 
 test_that("gg_variable.randomForest classification: plot returns patchwork for all xvar", {
+  skip_on_cran()
   skip_if_not_installed("randomForest")
   set.seed(42L)
   rf <- randomForest::randomForest(Species ~ ., data = iris, ntree = 50L)
@@ -413,6 +432,7 @@ test_that("gg_variable.randomForest classification: plot returns patchwork for a
 })
 
 test_that("gg_variable.randomForest classification: layer_data works on single-xvar plot", {
+  skip_on_cran()
   skip_if_not_installed("randomForest")
   set.seed(42L)
   rf <- randomForest::randomForest(Species ~ ., data = iris, ntree = 50L)
@@ -422,6 +442,7 @@ test_that("gg_variable.randomForest classification: layer_data works on single-x
 })
 
 test_that("gg_variable.randomForest classification: default plot renders every panel", {
+  skip_on_cran()
   # yvar / outcome must not be treated as predictors by the default-xvar pick.
   skip_if_not_installed("randomForest")
   # Regression test: the default-xvar selection in plot.gg_variable used to
@@ -443,6 +464,7 @@ test_that("gg_variable.randomForest classification: default plot renders every p
 })
 
 test_that("plot.gg_variable default xvar matches column names exactly, not substring", {
+  skip_on_cran()
   # Regression: the pre-existing default-xvar exclusion used grep("time", ...)
   # and grep("event", ...), which silently dropped any predictor whose name
   # *contained* those substrings -- e.g. the documented veteran-data survival
@@ -473,6 +495,7 @@ test_that("plot.gg_variable default xvar matches column names exactly, not subst
 })
 
 test_that("gg_variable.randomForest classification: norm.votes=FALSE still gives [0,1] fractions", {
+  skip_on_cran()
   skip_if_not_installed("randomForest")
   set.seed(42L)
   rf <- randomForest::randomForest(Species ~ ., data = iris, ntree = 50L,
@@ -486,6 +509,7 @@ test_that("gg_variable.randomForest classification: norm.votes=FALSE still gives
 })
 
 test_that("plot.gg_variable RF classification: smooth=TRUE layer_data smokeable (binary smooth aes bug)", {
+  skip_on_cran()
   skip_if_not_installed("randomForest")
   # Two-class subset to exercise the *binary* classification path
   set.seed(42L)
@@ -500,6 +524,7 @@ test_that("plot.gg_variable RF classification: smooth=TRUE layer_data smokeable 
 })
 
 test_that("plot.gg_variable RF classification: smooth=TRUE works for multi-class (missing block)", {
+  skip_on_cran()
   skip_if_not_installed("randomForest")
   set.seed(42L)
   rf <- randomForest::randomForest(Species ~ ., data = iris, ntree = 50L)
@@ -513,6 +538,7 @@ test_that("plot.gg_variable RF classification: smooth=TRUE works for multi-class
 })
 
 test_that("plot.gg_variable RF classification multi-class: outcome column is class names not integers", {
+  skip_on_cran()
   skip_if_not_installed("randomForest")
   set.seed(42L)
   rf <- randomForest::randomForest(Species ~ ., data = iris, ntree = 50L)
@@ -528,6 +554,7 @@ test_that("plot.gg_variable RF classification multi-class: outcome column is cla
 })
 
 test_that("plot.gg_variable RF classification multi-class: outcome factor levels match column order", {
+  skip_on_cran()
   skip_if_not_installed("randomForest")
   set.seed(42L)
   rf <- randomForest::randomForest(Species ~ ., data = iris, ntree = 50L)
@@ -541,6 +568,7 @@ test_that("plot.gg_variable RF classification multi-class: outcome factor levels
 })
 
 test_that("gg_variable.randomForest: oob=FALSE triggers a warning", {
+  skip_on_cran()
   skip_if_not_installed("randomForest")
   set.seed(42L)
   rf <- randomForest::randomForest(Species ~ ., data = iris, ntree = 50L)
@@ -565,6 +593,7 @@ has_smooth_layer <- function(p) {
 }
 
 test_that("plot.gg_variable binary classification + factor predictor: smooth=TRUE adds no smooth layer", {
+  skip_on_cran()
   skip_if_not_installed("randomForest")
   set.seed(42L)
   bin_data         <- iris[iris$Species != "virginica", ]
@@ -580,6 +609,7 @@ test_that("plot.gg_variable binary classification + factor predictor: smooth=TRU
 })
 
 test_that("plot.gg_variable multi-class classification + factor predictor: smooth=TRUE adds no smooth layer", {
+  skip_on_cran()
   skip_if_not_installed("randomForest")
   set.seed(42L)
   iris2      <- iris
@@ -594,6 +624,7 @@ test_that("plot.gg_variable multi-class classification + factor predictor: smoot
 })
 
 test_that("plot.gg_variable regression + factor predictor: smooth=TRUE adds no smooth layer", {
+  skip_on_cran()
   skip_if_not_installed("randomForest")
   set.seed(42L)
   iris2      <- iris

--- a/tests/testthat/test_gg_varpro.R
+++ b/tests/testthat/test_gg_varpro.R
@@ -20,20 +20,24 @@ make_vp_class <- function(ntree = 25L) {
 ## ── Input validation ─────────────────────────────────────────────────────────
 
 test_that("gg_varpro: missing object -> stop", {
+  skip_on_cran()
   expect_error(gg_varpro(), regexp = "object")
 })
 
 test_that("gg_varpro: non-varpro object -> stop", {
+  skip_on_cran()
   expect_error(gg_varpro(list(x = 1)), regexp = "varpro")
 })
 
 test_that("gg_varpro: conditional=TRUE on regression -> stop", {
+  skip_on_cran()
   vp <- make_vp_regr()
   expect_error(gg_varpro(vp, conditional = TRUE),
                regexp = "classification")
 })
 
 test_that("gg_varpro: faithful=TRUE + local.std=TRUE is valid, records local.std=TRUE", {
+  skip_on_cran()
   vp <- make_vp_regr()
   gg <- gg_varpro(vp, faithful = TRUE, local.std = TRUE)
   expect_true(is.matrix(gg$imp.tree))
@@ -43,11 +47,13 @@ test_that("gg_varpro: faithful=TRUE + local.std=TRUE is valid, records local.std
 ## ── Class & structure ────────────────────────────────────────────────────────
 
 test_that("gg_varpro returns gg_varpro class", {
+  skip_on_cran()
   vp <- make_vp_regr()
   expect_s3_class(gg_varpro(vp), "gg_varpro")
 })
 
 test_that("gg_varpro$imp has variable, z, selected columns", {
+  skip_on_cran()
   vp <- make_vp_regr()
   gg <- gg_varpro(vp)
   expect_named(gg$imp, c("variable", "z", "selected"))
@@ -57,6 +63,7 @@ test_that("gg_varpro$imp has variable, z, selected columns", {
 })
 
 test_that("gg_varpro$stats has expected columns", {
+  skip_on_cran()
   vp <- make_vp_regr()
   gg <- gg_varpro(vp)
   expect_true(all(c("variable", "median", "q05", "q15", "q85", "q95", "mean")
@@ -64,24 +71,28 @@ test_that("gg_varpro$stats has expected columns", {
 })
 
 test_that("gg_varpro$imp.tree is NULL when faithful=FALSE", {
+  skip_on_cran()
   vp <- make_vp_regr()
   gg <- gg_varpro(vp, faithful = FALSE)
   expect_null(gg$imp.tree)
 })
 
 test_that("gg_varpro$imp.tree is a matrix when faithful=TRUE", {
+  skip_on_cran()
   vp <- make_vp_regr()
   gg <- gg_varpro(vp, faithful = TRUE)
   expect_true(is.matrix(gg$imp.tree))
 })
 
 test_that("gg_varpro$conditional is NULL when conditional=FALSE", {
+  skip_on_cran()
   vp <- make_vp_regr()
   gg <- gg_varpro(vp, conditional = FALSE)
   expect_null(gg$conditional)
 })
 
 test_that("gg_varpro$conditional has variable, class, z when conditional=TRUE", {
+  skip_on_cran()
   vp <- make_vp_class()
   gg <- gg_varpro(vp, conditional = TRUE)
   expect_false(is.null(gg$conditional))
@@ -91,6 +102,7 @@ test_that("gg_varpro$conditional has variable, class, z when conditional=TRUE", 
 ## ── Provenance attribute ─────────────────────────────────────────────────────
 
 test_that("gg_varpro provenance has all expected fields", {
+  skip_on_cran()
   vp <- make_vp_regr()
   gg <- gg_varpro(vp)
   prov <- attr(gg, "provenance")
@@ -100,6 +112,7 @@ test_that("gg_varpro provenance has all expected fields", {
 })
 
 test_that("gg_varpro provenance cutoff matches argument", {
+  skip_on_cran()
   vp <- make_vp_regr()
   gg <- gg_varpro(vp, cutoff = 1.2)
   expect_equal(attr(gg, "provenance")$cutoff, 1.2)
@@ -108,6 +121,7 @@ test_that("gg_varpro provenance cutoff matches argument", {
 ## ── cutoff and nvar ──────────────────────────────────────────────────────────
 
 test_that("gg_varpro$imp$selected reflects z > cutoff", {
+  skip_on_cran()
   vp <- make_vp_regr()
   gg <- gg_varpro(vp, cutoff = 0.79)
   expect_true(all(gg$imp$z[gg$imp$selected]  >  0.79))
@@ -115,6 +129,7 @@ test_that("gg_varpro$imp$selected reflects z > cutoff", {
 })
 
 test_that("gg_varpro nvar=3 returns exactly 3 variables", {
+  skip_on_cran()
   vp <- make_vp_regr()
   gg <- gg_varpro(vp, nvar = 3L)
   expect_equal(nrow(gg$imp), 3L)
@@ -122,6 +137,7 @@ test_that("gg_varpro nvar=3 returns exactly 3 variables", {
 })
 
 test_that("gg_varpro variable factor runs least- to most-important median z", {
+  skip_on_cran()
   vp <- make_vp_regr()
   gg <- gg_varpro(vp)
   # Factor levels run least-important first so the most-important variable is
@@ -133,6 +149,7 @@ test_that("gg_varpro variable factor runs least- to most-important median z", {
 })
 
 test_that("gg_varpro nvar larger than p returns all variables", {
+  skip_on_cran()
   vp <- make_vp_regr()
   n_all <- nrow(gg_varpro(vp)$imp)
   gg <- gg_varpro(vp, nvar = 999L)
@@ -140,6 +157,7 @@ test_that("gg_varpro nvar larger than p returns all variables", {
 })
 
 test_that("gg_varpro local.std=FALSE stats equal raw-column medians", {
+  skip_on_cran()
   ## Mechanistic check: verify each path against the actual column computation.
   ## faithful=TRUE forces local.std=FALSE (coercion tested above); imp.tree
   ## gives the ground-truth raw importance matrix for both assertions.
@@ -170,6 +188,7 @@ test_that("gg_varpro local.std=FALSE stats equal raw-column medians", {
 ## ── Z-scale alignment ─────────────────────────────────────────────────────────
 
 test_that("gg_varpro: z-normalisation mean(z_ij) == aggregate z_j", {
+  skip_on_cran()
   # varPro's importance() computes z_j = mean(imp_ij) / sd_j (no sqrt(ntree)).
   # So .varpro_imp_stats uses z_ij = imp_ij / sd_j, giving mean(z_ij) == z_j.
   # Verify by recomputing from imp.tree (faithful=TRUE).
@@ -191,6 +210,7 @@ test_that("gg_varpro: z-normalisation mean(z_ij) == aggregate z_j", {
 ## ── Plot smoke tests ─────────────────────────────────────────────────────────
 
 test_that("plot.gg_varpro default returns a ggplot", {
+  skip_on_cran()
   vp <- make_vp_regr()
   gg <- gg_varpro(vp)
   p  <- plot(gg)
@@ -198,6 +218,7 @@ test_that("plot.gg_varpro default returns a ggplot", {
 })
 
 test_that("plot.gg_varpro type='z' returns a ggplot", {
+  skip_on_cran()
   vp <- make_vp_regr()
   gg <- gg_varpro(vp)  # local.std=TRUE default
   p  <- plot(gg, type = "z")
@@ -205,6 +226,7 @@ test_that("plot.gg_varpro type='z' returns a ggplot", {
 })
 
 test_that("plot.gg_varpro type='raw' with local.std=FALSE returns a ggplot", {
+  skip_on_cran()
   vp <- make_vp_regr()
   gg <- gg_varpro(vp, local.std = FALSE)
   p  <- plot(gg, type = "raw")
@@ -212,6 +234,7 @@ test_that("plot.gg_varpro type='raw' with local.std=FALSE returns a ggplot", {
 })
 
 test_that("plot.gg_varpro type='raw' with local.std=TRUE -> stop", {
+  skip_on_cran()
   vp <- make_vp_regr()
   gg <- gg_varpro(vp, local.std = TRUE)
   expect_error(plot(gg, type = "raw"), regexp = "local\\.std")
@@ -233,6 +256,7 @@ test_that("plot.gg_varpro type='raw' with local.std=TRUE -> stop", {
 }
 
 test_that("plot.gg_varpro faithful: no phantom 'NA' variable when nvar < p", {
+  skip_on_cran()
   # imp.tree keeps every variable, so nvar = 3 (< 10 predictors) orphans the
   # rest -- they would collapse into an NA category without the fix.
   vp   <- make_vp_regr()
@@ -242,6 +266,7 @@ test_that("plot.gg_varpro faithful: no phantom 'NA' variable when nvar < p", {
 })
 
 test_that("plot.gg_varpro conditional: no phantom 'NA' variable when nvar < p", {
+  skip_on_cran()
   # nvar = 1 truncates below the conditional table's variable count, which is
   # what orphans a variable to NA in the buggy path.
   vp   <- make_vp_class()
@@ -251,12 +276,14 @@ test_that("plot.gg_varpro conditional: no phantom 'NA' variable when nvar < p", 
 })
 
 test_that("plot.gg_varpro type='z' with local.std=FALSE -> stop", {
+  skip_on_cran()
   vp <- make_vp_regr()
   gg <- gg_varpro(vp, local.std = FALSE)
   expect_error(plot(gg, type = "z"), regexp = "local\\.std")
 })
 
 test_that("plot.gg_varpro faithful=TRUE returns a ggplot", {
+  skip_on_cran()
   vp <- make_vp_regr()
   gg <- gg_varpro(vp, faithful = TRUE)
   p  <- plot(gg)
@@ -264,6 +291,7 @@ test_that("plot.gg_varpro faithful=TRUE returns a ggplot", {
 })
 
 test_that("plot.gg_varpro conditional=TRUE returns ggplot with FacetWrap", {
+  skip_on_cran()
   vp <- make_vp_class()
   gg <- gg_varpro(vp, conditional = TRUE)
   p  <- plot(gg)
@@ -274,12 +302,14 @@ test_that("plot.gg_varpro conditional=TRUE returns ggplot with FacetWrap", {
 ## ── S3 companions ────────────────────────────────────────────────────────────
 
 test_that("autoplot.gg_varpro returns a ggplot", {
+  skip_on_cran()
   vp <- make_vp_regr()
   gg <- gg_varpro(vp)
   expect_s3_class(ggplot2::autoplot(gg), "ggplot")
 })
 
 test_that("print.gg_varpro returns object invisibly", {
+  skip_on_cran()
   vp  <- make_vp_regr()
   gg  <- gg_varpro(vp)
   out <- capture.output(ret <- print(gg))
@@ -288,6 +318,7 @@ test_that("print.gg_varpro returns object invisibly", {
 })
 
 test_that("print.gg_varpro output contains selected/total counts", {
+  skip_on_cran()
   vp  <- make_vp_regr()
   gg  <- gg_varpro(vp, cutoff = 0.79)
   out <- capture.output(print(gg))
@@ -295,6 +326,7 @@ test_that("print.gg_varpro output contains selected/total counts", {
 })
 
 test_that("summary.gg_varpro returns summary.gg_varpro class", {
+  skip_on_cran()
   vp <- make_vp_regr()
   gg <- gg_varpro(vp)
   s  <- summary(gg)

--- a/tests/testthat/test_gg_varpro.R
+++ b/tests/testthat/test_gg_varpro.R
@@ -20,12 +20,10 @@ make_vp_class <- function(ntree = 25L) {
 ## ── Input validation ─────────────────────────────────────────────────────────
 
 test_that("gg_varpro: missing object -> stop", {
-  skip_on_cran()
   expect_error(gg_varpro(), regexp = "object")
 })
 
 test_that("gg_varpro: non-varpro object -> stop", {
-  skip_on_cran()
   expect_error(gg_varpro(list(x = 1)), regexp = "varpro")
 })
 

--- a/tests/testthat/test_gg_vimp.R
+++ b/tests/testthat/test_gg_vimp.R
@@ -1,6 +1,7 @@
 # testthat for gg_vimp function
 
 test_that("gg_vimp classifications", {
+  skip_on_cran()
   set.seed(20260817L)
   ## Load the cached forest
   data(iris, package = "datasets")
@@ -123,6 +124,7 @@ test_that("gg_vimp classifications", {
 })
 
 test_that("gg_vimp randomForest which.outcome maps to the right column", {
+  skip_on_cran()
   data(iris, package = "datasets")
   set.seed(1)
   rf_iris <- randomForest::randomForest(Species ~ .,
@@ -158,6 +160,7 @@ test_that("gg_vimp randomForest which.outcome maps to the right column", {
 })
 
 test_that("gg_vimp which.outcome names the measure in set", {
+  skip_on_cran()
   data(iris, package = "datasets")
   set.seed(1)
 
@@ -191,6 +194,7 @@ test_that("gg_vimp which.outcome names the measure in set", {
 
 
 test_that("gg_vimp survival", {
+  skip_on_cran()
   set.seed(20260817L)
   # Shared with the roxygen examples; see inst/examples/pbc-setup.R. That file
   # passes envir = environment() to data(), which is what lets it be sourced
@@ -269,6 +273,7 @@ test_that("gg_vimp survival", {
 })
 
 test_that("gg_vimp regression", {
+  skip_on_cran()
   set.seed(20260817L)
   ## Load the cached forest
   data(Boston, package = "MASS")
@@ -374,6 +379,7 @@ test_that("gg_vimp regression", {
 })
 
 test_that("gg_vimp.rfsrc single-outcome: positive flag correctly uses the VIMP column", {
+  skip_on_cran()
   # Regression test for the bug where gg_dta$vimp was accessed but the column
   # is named "VIMP" (uppercase) in single-outcome rfsrc fits, leaving positive
   # always TRUE even for variables with non-positive VIMP.
@@ -405,6 +411,7 @@ test_that("gg_vimp.rfsrc single-outcome: positive flag correctly uses the VIMP c
 })
 
 test_that("gg_vimp.randomForest regression: vimp column present even when importance is IncNodePurity", {
+  skip_on_cran()
   set.seed(20260817L)
   # Guard test: when randomForest stores importance as IncNodePurity (not X.IncMSE),
   # gg_vimp must still produce a 'vimp' column so plot.gg_vimp and the positive

--- a/vignettes/ggRandomForests-classification.qmd
+++ b/vignettes/ggRandomForests-classification.qmd
@@ -124,7 +124,7 @@ function detects the classification family from the factor response.
 ```{r rfsrc-fit}
 set.seed(42)
 rfsrc_iris <- rfsrc(Species ~ ., data = iris,
-                    ntree = 200, importance = TRUE, err.block = 5)
+                    ntree = 100, importance = TRUE, err.block = 5)
 rfsrc_iris
 ```
 
@@ -213,7 +213,7 @@ dimensional Boston housing data.
 
 ```{r shap-fit}
 set.seed(43)
-gg_shp <- gg_shap(rfsrc_iris, bg_n = 50, which.class = 3)
+gg_shp <- gg_shap(rfsrc_iris, bg_n = 30, which.class = 3)
 ```
 
 ## SHAP importance

--- a/vignettes/ggRandomForests-regression.qmd
+++ b/vignettes/ggRandomForests-regression.qmd
@@ -145,7 +145,7 @@ detects the regression family from the continuous response.
 
 ```{r rfsrc-fit}
 rfsrc_Boston <- rfsrc(medv ~ ., data = Boston, # nolint: object_name_linter
-                      ntree = 200, importance = TRUE, err.block = 5)
+                      ntree = 100, importance = TRUE, err.block = 5)
 rfsrc_Boston
 ```
 
@@ -244,18 +244,18 @@ that promise.
 `gg_shap()` computes these contributions by calling
 [kernelshap](https://cran.r-project.org/package=kernelshap), which needs one
 prediction per predictor per background draw, per tract explained. Scoring
-all 506 tracts is expensive, so we explain a random sample of 40 instead,
+all 506 tracts is expensive, so we explain a random sample of 25 instead,
 plenty to see the patterns at a fraction of the cost.
 
 ```{r shap-fit}
 set.seed(42)
-shap_sample <- Boston[sample(nrow(Boston), 40), setdiff(colnames(Boston), "medv")]
-gg_shp <- gg_shap(rfsrc_Boston, newdata = shap_sample, bg_n = 50)
+shap_sample <- Boston[sample(nrow(Boston), 25), setdiff(colnames(Boston), "medv")]
+gg_shp <- gg_shap(rfsrc_Boston, newdata = shap_sample, bg_n = 30)
 ```
 
 ## SHAP importance
 
-Averaging the absolute contribution of each variable across the 40 tracts
+Averaging the absolute contribution of each variable across the 25 tracts
 gives a ranking directly comparable to VIMP.
 
 ```{r shap-importance-plot, fig.cap="Mean absolute SHAP value per predictor."}
@@ -429,11 +429,11 @@ nearly flat in high-`lstat` tracts, confirming a meaningful interaction.
 # Partial Dependence Surface
 
 To visualize the joint partial dependence of `medv` on `lstat` and `rm`, we
-compute partial dependence on a grid: 10 values of `rm`, each evaluated at 25
+compute partial dependence on a grid: 6 values of `rm`, each evaluated at 25
 points along `lstat`.
 
 ```{r surface-data, cache=TRUE}
-rm_grid <- quantile_pts(rfsrc_Boston$xvar$rm, groups = 10)
+rm_grid <- quantile_pts(rfsrc_Boston$xvar$rm, groups = 6)
 
 surface_list <- lapply(rm_grid, function(rm_val) {
   newx <- rfsrc_Boston$xvar

--- a/vignettes/ggRandomForests-survival.qmd
+++ b/vignettes/ggRandomForests-survival.qmd
@@ -279,13 +279,13 @@ state, which is required for `partial.rfsrc()` to work correctly.
 # Step 1: impute missing values via random forest proximity
 pbc_imputed <- impute.rfsrc(Surv(years, status) ~ .,
                              data    = pbc_trial,
-                             ntree   = 100,
+                             ntree   = 50,
                              nimpute = 2)
 
 # Step 2: grow the survival forest on the complete imputed data
 rfsrc_pbc <- rfsrc(Surv(years, status) ~ .,
                    data      = pbc_imputed,
-                   ntree     = 150,
+                   ntree     = 100,
                    nsplit    = 10,
                    tree.err  = TRUE,
                    importance = TRUE)
@@ -548,12 +548,12 @@ interaction between these two liver function markers.
 # Partial Dependence Surfaces
 
 For a richer view of the interaction between bilirubin and albumin, we construct
-a partial dependence surface. We compute partial dependence on a grid of 8
+a partial dependence surface. We compute partial dependence on a grid of 5
 albumin values, each evaluated at 25 bilirubin points.
 
 ```{r surface-data, error=TRUE, cache=FALSE}
 # Create grid of albumin values
-alb_grid <- quantile_pts(pbc_trial$albumin, groups = 8)
+alb_grid <- quantile_pts(pbc_trial$albumin, groups = 5)
 
 # For each albumin value, compute partial dependence on bili at ~1 year
 surface_list <- lapply(alb_grid, function(alb_val) {

--- a/vignettes/ggRandomForests.qmd
+++ b/vignettes/ggRandomForests.qmd
@@ -47,7 +47,7 @@ if (requireNamespace("ggRandomForests", quietly = TRUE)) {
 ```{r error-demo}
 library(randomForest)
 set.seed(42)
-rf_iris <- randomForest(Species ~ ., data = iris, ntree = 200, keep.forest = TRUE)
+rf_iris <- randomForest(Species ~ ., data = iris, ntree = 100, keep.forest = TRUE)
 err_df <- ggRandomForests::gg_error(rf_iris, training = TRUE)
 head(err_df)
 ```
@@ -68,7 +68,7 @@ plot(err_df)
 ```{r variable-demo}
 set.seed(99)
 boston <- MASS::Boston
-rf_boston <- randomForest(medv ~ ., data = boston, ntree = 150)
+rf_boston <- randomForest(medv ~ ., data = boston, ntree = 100)
 var_df <- ggRandomForests::gg_variable(rf_boston)
 str(var_df[, c("lstat", "yhat")])
 ```


### PR DESCRIPTION
win-builder's incoming pretest declined 3.5.1 with `Overall checktime 12 min > 10 min` on r-devel-windows, and Uwe Ligges asked directly whether it could be brought under ten minutes. This is that.

Note this branch also carries the two commits already on `docs/varpro-missing-data-contract` (the 3.5.2 version bump and the `?gg_partial_varpro` missing-data section), so merging this supersedes that branch.

## Where the time went

Measured from CRAN's own pretest logs for the 3.5.1 tarball:

| Step | r-devel-windows | r-devel-debian |
|---|---|---|
| re-building vignette outputs | 287s | 108s |
| tests | 195s | 68s |
| examples | 51s | 28s |
| incoming feasibility, R code, PDF manual | 75s | 24s |
| **overall** | **720s** | |

For context, CRAN's own machines already had the released 3.5.0 at 673s on `r-devel-windows` and 818s on `r-oldrel-windows`. The package had been living just under the wire; the doc-only 3.5.2 delta did not cause this.

## What changed

- **Vignettes.** Boston and iris forests 200 -> 100 trees; the `pbc` impute/fit pair 100/150 -> 50/100; the two partial-dependence surface grids 10 and 8 points -> 6 and 5; SHAP sections 40 rows / 50 background draws -> 25 / 30. Prose numbers are either interpolated from the fit or updated to match.
- **Examples.** `gg_error()` / `plot.gg_error()` fit six forests each at `ntree = 250` with `block.size = 1`, so every tree is an error evaluation; now 100. `gg_vimp()` / `plot.gg_vimp()` 100 -> 50.
- **Tests.** The four heaviest files under CRAN skip semantics (`test_gg_udependent` 7.9s, `test_gg_varpro` 3.5s, `test_gg_variable` 3.1s, `test_gg_vimp` 2.1s, 52% of the suite's CRAN-side cost) now `skip_on_cran()`. They still run in full under `devtools::test()` and the Stop hook.

Two things I measured and did **not** do, so they are not re-derived later:

- 184 test fits call `rfsrc()` with no `ntree`, inheriting the default. Forcing `rf.cores = 2` to emulate CRAN's core cap changed nothing locally (2.8s -> 2.5s on `test_gg_rfsrc.R`), so those fits are not the driver; win-builder is simply ~5.7x slower per unit of R work. Not worth 175 edits and the snapshot churn.
- `test_snapshots.R` was left alone. Its file-level `VDIFFR_RUN_TESTS` guard means it costs nothing under CRAN semantics anyway, and changing those 9 fits would invalidate all 49 vdiffr baselines.

## What it bought

Same machine, same method:

| Step | 3.5.1 | 3.5.2 |
|---|---|---|
| examples | 16s | 12s |
| examples `--run-donttest` | 39s | 31s |
| tests | 34s | 14s |
| re-building vignettes | 55s | 36s |

Scaling each step by the per-step ratio the pretest logs give between this machine and r-devel-windows projects the Windows total near **8.2 min**, from 12.

## Verification

- `devtools::document()` clean; `lintr::lint_package()` **0 lints**
- `NOT_CRAN=true VDIFFR_RUN_TESTS=true devtools::test()`: **FAIL 0 | PASS 1512 | SKIP 5**, 49 vdiffr baselines intact before and after
- `R CMD check --as-cran` with the manual, from a clean `git archive` export: **0 ERRORs, 0 WARNINGs, 1 NOTE** (the `Number of updates in past 6 months: 7` maintainer note). Tarball 2.39 MB.

win-builder has not been run yet; the projection above is a projection, and `cran-comments.md` reports only what was measured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)