### PR TITLE
chore(cran): set DESCRIPTION Date to the 2026-08-20 submission date

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: ggRandomForests
 Type: Package
 Title: Visually Exploring Random Forests
 Version: 3.5.2
-Date: 2026-08-19
+Date: 2026-08-20
 Authors@R: person("John", "Ehrlinger",
   role = c("aut", "cre"),
   email = "john.ehrlinger@gmail.com",


### PR DESCRIPTION
One-line metadata change ahead of the 3.5.2 win-builder round: `Date: 2026-08-19` -> `Date: 2026-08-20`, the day the tarball is actually submitted. Version is untouched at 3.5.2, so `NEWS.md` needs no edit and `test_ggrandomforests_news.R` still matches.

`cran-comments.md:3` still reads 2026-08-19 and is correct: that is the date of the 3.5.1 submission this one replaces, not this release's date.

## Release sweep run against `main` before this change

Scoped to what the 3.5.2 diff could invalidate rather than a full re-audit, since 3.5.0/3.5.1 were swept in full.

| Gate item | Result |
|---|---|
| `R CMD check --as-cran` with the manual, clean `git archive` export | **0 ERRORs, 0 WARNINGs, 1 NOTE** (`Number of updates in past 6 months: 7`) |
| `urlchecker::url_check()` | all 17 URLs OK |
| New DOI `10.1111/j.1467-9531.2007.00180.x` (von Hippel 2007) | doi.org 302 -> Sage, resolves. A bare `curl` HEAD returns 403 because Sage blocks non-browser clients; that is not a dead DOI |
| Reverse dependencies on CRAN | 0 |
| `\dontrun` | none; only `\donttest` |
| `<<-`, `setwd()`, `par()`, `options()` in `R/` | none |
| Core settings in `R/` | none |
| Tarball size | 2.39 MB against the 5 MB limit |
| DESCRIPTION 3.5.2 vs NEWS 3.5.2 | match |
| `devtools::test()` | FAIL 0, PASS 1512, SKIP 5; 49 vdiffr baselines intact |

Four `\value` misses turned up and are all false positives: `.build_varpro_imp_dfs`, `.build_varpro_imp_tree` and `.varpro_imp_stats` are absent from `NAMESPACE` and carry `\keyword{internal}` (the CRAN rule covers exported objects), and `ggRandomForests-package.Rd` is the `_PACKAGE` page. A `.GlobalEnv` hit in `R/gg_error.R:420` is a **read** inside an environment search, introduced in `50775c3` (2026-02-19), not a write.

🤖 Generated with [Claude Code](https://claude.com/claude-code)