### PR TITLE
docs: report the 3.5.2 win-builder results, add the tarball verification gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -237,7 +237,7 @@ project context. Read it before writing user-facing text.
   3.5.2 (2026-08-20): locally about 100s of timed steps, vignette rebuild 37s,
   `--run-donttest` examples 32s, tests 14s; on win-builder, 265s of timed steps on r-devel
   and 277s on r-oldrelease, against 608s for the 3.5.1 pretest.
-  win-builder runs roughly 5x a local mac on tests and vignettes and about 3x on examples,
+  win-builder runs roughly 5x a local macOS box on tests and vignettes and about 3x on examples,
   so multiply per step rather than applying one factor. Watch that budget when adding to
   either.
 - Build `R CMD check` from a clean `git archive` export, not the working tree. An empty

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -230,10 +230,41 @@ project context. Read it before writing user-facing text.
   Do not assume 3rd-edition semantics.
 - `randomForestSRC` output structure varies by version (3.6.2 is installed; `DESCRIPTION`
   requires `>= 3.4.0`). Never index its fields by position.
-- CRAN rejects a package whose overall `R CMD check` exceeds about 10 minutes even at 0/0/0.
-  The current baseline is about 3.8 minutes of timed steps, dominated by the vignette rebuild
-  (53s) and `--run-donttest` examples (35s). Watch that budget when adding either.
+- CRAN rejects a package whose overall `R CMD check` exceeds about 10 minutes even at 0/0/0,
+  and the rule bites at the **incoming pretest**, not per-flavor afterwards. The released
+  3.5.0 sat at 673s on CRAN's own `r-devel-windows` marked OK, while 3.5.1 at 720s was
+  declined, so a green CRAN check results page is not evidence of headroom. Measured on
+  3.5.2 (2026-08-20): locally about 100s of timed steps, vignette rebuild 37s,
+  `--run-donttest` examples 32s, tests 14s; on win-builder, 265s of timed steps on r-devel
+  and 277s on r-oldrelease, against 608s for the 3.5.1 pretest.
+  win-builder runs roughly 5x a local mac on tests and vignettes and about 3x on examples,
+  so multiply per step rather than applying one factor. Watch that budget when adding to
+  either.
 - Build `R CMD check` from a clean `git archive` export, not the working tree. An empty
   `inst/doc` fabricates two vignette WARNINGs, and in a git worktree `.git` is a *file*, so
   the VCS exclusion misses it and it lands in the tarball as a spurious hidden-files NOTE.
   Both look like package defects and are not.
+- **Verify the tarball before it leaves, rather than reasoning about `.Rbuildignore`.** The
+  release-gate check is one line:
+
+  ```bash
+  tar tzf ggRandomForests_<version>.tar.gz | grep -E '/\.[^/]+'
+  ```
+
+  Anything other than `ggRandomForests/.Rinstignore` means stop and rebuild. This is the
+  check that would have caught the `.remember` directory win-builder reported on
+  2026-08-18. Also confirm `Version`/`Date` and that `cran-comments.md` is absent:
+
+  ```bash
+  tar xzf ggRandomForests_<version>.tar.gz -O ggRandomForests/DESCRIPTION | sed -n '4,5p'
+  tar tzf ggRandomForests_<version>.tar.gz | grep -c cran-comments   # expect 0
+  ```
+- A working-tree `R CMD build .` is **not** a reason to rebuild on its own. Measured
+  2026-08-20 at `26416c6c`: a build from the full working tree (71 MB of untracked
+  `.Rcheck`, `docs/`, `.claude/`, `.remember/`, `.Rproj.user/`) and a build from a clean
+  `git archive` export produced tarballs with an identical 247-entry file list, no
+  difference in either direction. The `(^|/)\.remember$`, `(^|/)\.Rhistory$` and
+  `(^|/)\.DS_Store$` guards at the foot of `.Rbuildignore` close the 2026-08-18 hole, and
+  `R CMD build` prunes matched *directories* wholesale, so `.claude/settings.local.json` and
+  the `.Rcheck` tree are never walked. Testing an ignore pattern against a full file path
+  wrongly reports those two as leaks. Run the `tar tzf` check above instead of predicting.

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -69,11 +69,39 @@ no code path changed.
 
 ### Test environments
 
-* **Local:** macOS (aarch64-apple-darwin), R 4.6.0, `R CMD check --as-cran`
+* **Local:** macOS (aarch64-apple-darwin), R 4.6.1, `R CMD check --as-cran`
   with the manual, built from a clean `git archive` export: **0 ERRORs,
-  0 WARNINGs, 1 NOTE**. The source tarball is 2.39 MB.
+  0 WARNINGs, 1 NOTE**. The source tarball is 2.37 MB. The full test suite, run
+  with `NOT_CRAN=true` so the `skip_on_cran()` tests execute too, is 1512
+  passing and 0 failing.
 * **Reverse-dependency check:** 0 reverse dependencies on CRAN.
 * **URL check:** `urlchecker::url_check()` reports all URLs correct.
+
+**win-builder:** x86_64-w64-mingw32, Windows Server 2022, all three branches
+run against this exact tarball. Each returns **Status: 1 NOTE**, the same
+`Number of updates in past 6 months: 7` reported locally, with no second NOTE
+and no ERRORs or WARNINGs. `checking for hidden files and directories` is OK on
+all three.
+
+| Step | R-devel (r90424) | R-release (4.6.1) | R-oldrelease (4.5.3) |
+|---|---|---|---|
+| CRAN incoming feasibility | 10s | 11s | 17s |
+| R code for possible problems | 24s | 19s | 24s |
+| examples | 31s | 29s | 36s |
+| tests | 45s | 35s | 43s |
+| re-building vignette outputs | 140s | 110s | 131s |
+| PDF version of manual | 15s | 15s | 13s |
+| HTML version of manual | | 15s | 13s |
+| **timed steps** | **265s** | **234s** | **277s** |
+
+`00check.log` does not report an overall time, so I am giving you the sum of
+the timed steps rather than a total I did not measure. For the comparison you
+care about: the 3.5.1 pretest that was declined had 608s of timed steps against
+a 720s overall, so on the same 112s of untimed overhead these land near six
+minutes, and R-devel is the branch the pretest gates on.
+
+The heaviest branch is R-oldrelease at 277s, and it is now the same shape as
+the other two rather than the outlier it was.
 
 ### NOTE disposition
 


### PR DESCRIPTION
Documentation only. `AGENTS.md` is `.Rbuildignore`d (line 69), so this cannot affect the 3.5.2 tarball already at win-builder.

Three Gotchas changes, all findings from the 3.5.2 round:

1. **Check-time bullet was stale and understated the rule.** It bites at the incoming pretest, not per-flavor. The released 3.5.0 sat at 673s on CRAN's own `r-devel-windows` marked OK while 3.5.1 at 720s was declined, so a green CRAN check results page is not evidence of headroom. Now carries the measured 3.5.2 numbers and the per-step win-builder/local ratios (about 5x on tests and vignettes, 3x on examples), which are not uniform and should be applied per step.
2. **New: verify the tarball before it leaves.** One line, `tar tzf ... | grep -E '/\\.[^/]+'`, expecting only `ggRandomForests/.Rinstignore`. This is the gate that would have caught the `.remember` directory win-builder reported on 2026-08-18.
3. **New: a working-tree `R CMD build .` is not on its own a reason to rebuild.** Measured at `26416c6c`: a build from the full working tree (71 MB of untracked `.Rcheck`, `docs/`, `.claude/`, `.remember/`, `.Rproj.user/`) and one from a clean `git archive` export produced an identical 247-entry file list, no difference either direction. Recorded because I reasoned my way to the wrong answer during this round: testing an ignore pattern against a full file path flags `.claude/settings.local.json` and the `.Rcheck` tree as leaks, but `R CMD build` prunes matched *directories* wholesale so neither is ever walked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)