### PR TITLE
ci: drop paths-ignore from the pull_request triggers so required checks can work

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,18 +1,21 @@
 # Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
-  # A commit that only touches the generated house-style artifact cannot change
-  # the package: .claude is in .Rbuildignore, so it is excluded from the built
-  # package, and no step in this workflow reads it from the checkout. Running
-  # this on such a commit burns runner minutes and queues ahead of checks that
-  # can actually fail.
+  # A push that only touches the generated house-style artifact cannot change the
+  # package: .claude is in .Rbuildignore, so it is excluded from the built package,
+  # and no step here reads it from the checkout. Skipping those pushes saves runner
+  # minutes.
+  #
+  # The pull_request trigger deliberately carries NO paths-ignore. These jobs are
+  # required status checks on main and dev_rhf, and a required check that never
+  # runs is reported as permanently pending, so a .claude-only PR would be blocked
+  # with no way to merge it. Paying for a full matrix on those rare PRs is the
+  # price of having the gate work at all.
   push:
     paths-ignore:
       - '.claude/**'
     branches: [main]
   pull_request:
-    paths-ignore:
-      - '.claude/**'
 
 name: R-CMD-check.yaml
 

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -1,18 +1,21 @@
 # Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
-  # A commit that only touches the generated house-style artifact cannot change
-  # the package: .claude is in .Rbuildignore, so it is excluded from the built
-  # package, and no step in this workflow reads it from the checkout. Running
-  # this on such a commit burns runner minutes and queues ahead of checks that
-  # can actually fail.
+  # A push that only touches the generated house-style artifact cannot change the
+  # package: .claude is in .Rbuildignore, so it is excluded from the built package,
+  # and no step here reads it from the checkout. Skipping those pushes saves runner
+  # minutes.
+  #
+  # The pull_request trigger deliberately carries NO paths-ignore. These jobs are
+  # required status checks on main and dev_rhf, and a required check that never
+  # runs is reported as permanently pending, so a .claude-only PR would be blocked
+  # with no way to merge it. Paying for a full matrix on those rare PRs is the
+  # price of having the gate work at all.
   push:
     paths-ignore:
       - '.claude/**'
     branches: [main]
   pull_request:
-    paths-ignore:
-      - '.claude/**'
   release:
     types: [published]
   workflow_dispatch:

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -1,18 +1,21 @@
 # Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
-  # A commit that only touches the generated house-style artifact cannot change
-  # the package: .claude is in .Rbuildignore, so it is excluded from the built
-  # package, and no step in this workflow reads it from the checkout. Running
-  # this on such a commit burns runner minutes and queues ahead of checks that
-  # can actually fail.
+  # A push that only touches the generated house-style artifact cannot change the
+  # package: .claude is in .Rbuildignore, so it is excluded from the built package,
+  # and no step here reads it from the checkout. Skipping those pushes saves runner
+  # minutes.
+  #
+  # The pull_request trigger deliberately carries NO paths-ignore. These jobs are
+  # required status checks on main and dev_rhf, and a required check that never
+  # runs is reported as permanently pending, so a .claude-only PR would be blocked
+  # with no way to merge it. Paying for a full matrix on those rare PRs is the
+  # price of having the gate work at all.
   push:
     paths-ignore:
       - '.claude/**'
     branches: [main]
   pull_request:
-    paths-ignore:
-      - '.claude/**'
 
 name: test-coverage.yaml
 


### PR DESCRIPTION
Prerequisite for requiring `R CMD check` on `main` and `dev_rhf`. Workflow triggers only; no package code, no version bump.

## The problem

`main`'s ruleset requires **no status checks at all**, so a red PR can be merged onto the CRAN release branch. That looked like an oversight, but it is at least self-consistent: `R-CMD-check`, `pkgdown` and `test-coverage` all carry `paths-ignore: '.claude/**'` on their `pull_request` trigger, and **a required check that never runs is reported as permanently pending**, not skipped. Requiring them today would make any `.claude`-only PR unmergeable.

That is not hypothetical: `.claude/house-style.md` is generated by the house-style composer, so `.claude`-only PRs are a recurring category in this repo.

`dev_rhf` is exposed to exactly this right now — it was converted to a ruleset today that requires the three `(release)` legs, while still carrying the `paths-ignore` triggers. This PR is what makes that safe, and it needs to reach `dev_rhf` via forward-merge #9.

## The change

| Trigger | Before | After |
|---|---|---|
| `push` | `paths-ignore: '.claude/**'` | unchanged |
| `pull_request` | `paths-ignore: '.claude/**'` | **no filter** |

The runner-minute saving lives on `push`, which has no required-check semantics, so nothing deadlocks there. The cost is a full matrix on the rare `.claude`-only PR. The comment block in each file now says which trigger is which and why, so the next person does not re-add the filter.

Which checks always report on a PR, for the record:

| Check | On a PR |
|---|---|
| `lint`, `house-style` | always (bare `pull_request:`) |
| `ubuntu/macos/windows (release)`, `ubuntu (devel/oldrel-1)` | **skippable today**, always after this PR |
| `pkgdown`, `test-coverage`, `codecov/patch` | same |
| `workflow-order` | only when workflows change (`paths:`) |

## After this merges

1. Add `required_status_checks` (`ubuntu-latest (release)`, `macos-latest (release)`, `windows-latest (release)`, strict) to the `protect main` ruleset.
2. Forward-merge `main` into `dev_rhf` (#9) so its workflows match, which closes the exposure noted above.

`check-workflow-order.py` passes: 9 workflow files, setup-r ordering OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)