### PR TITLE
test(cran-comments): skip the heading check on a development version

### DIFF
--- a/tests/testthat/test_cran_comments.R
+++ b/tests/testthat/test_cran_comments.R
@@ -40,6 +40,25 @@ test_that("cran-comments.md carries no unfinished-work markers", {
   )
 })
 
+# A version whose NEWS section is marked "(development)" has not been submitted
+# and is not about to be: cran-comments.md carries the history of the release
+# line, not a section for it. The v4 line on dev_rhf is exactly this case, so
+# without the guard the assertion below fails on every run of that branch and
+# stops meaning anything.
+#
+# Deliberately keyed on the NEWS marker rather than the branch name. The test
+# runs from a tarball and an installed package too, where no branch is
+# visible, and "(development)" is a claim the maintainer makes in a tracked
+# file rather than something inferred from the checkout.
+news_marks_development <- function(version) {
+  p <- testthat::test_path("..", "..", "NEWS.md")
+  if (!file.exists(p)) return(FALSE)
+  txt <- readLines(p, warn = FALSE)
+  head <- grep(paste0("^ggRandomForests v", gsub(".", "[.]", version, fixed = TRUE),
+                      "([^0-9.]|$)"), txt, value = TRUE, perl = TRUE)
+  length(head) > 0L && grepl("(development)", head[1], fixed = TRUE)
+}
+
 test_that("cran-comments.md leads with the version being submitted", {
   skip_on_cran()
   p <- cran_comments_path()
@@ -48,6 +67,10 @@ test_that("cran-comments.md leads with the version being submitted", {
   desc_path <- system.file("DESCRIPTION", package = "ggRandomForests")
   if (!nzchar(desc_path)) desc_path <- testthat::test_path("..", "..", "DESCRIPTION")
   version <- unname(read.dcf(desc_path, fields = "Version")[1, 1])
+
+  skip_if(news_marks_development(version),
+          paste0("DESCRIPTION ", version, " is a development version per NEWS.md; ",
+                 "cran-comments.md documents the release line, not this tree"))
 
   # The first "## vX.Y.Z" heading is the release being submitted; older
   # releases are kept below it as history.


### PR DESCRIPTION
Test-only. Fixes the one failure that has been red on every `dev_rhf` run, including #212 and #214.

## The problem

`test_cran_comments.R:65` asserts that `cran-comments.md` leads with the version in `DESCRIPTION`. That catches the stale-heading copy-paste error before it reaches CRAN, and it is a good test, but on the v4 line it cannot hold: `DESCRIPTION` is `4.0.0` and `cran-comments.md` carries the 3.x release history, because 4.0.0 has never been submitted. So it failed on every `dev_rhf` run and had stopped carrying information there.

## The fix

Skip when `NEWS.md` marks the `DESCRIPTION` version's section `(development)`:

| branch | NEWS heading for the DESCRIPTION version | guard |
|---|---|---|
| `main` | `ggRandomForests v3.5.2` | false, assertion runs |
| `dev_rhf` | `ggRandomForests v4.0.0 (development)` | true, skips |

Keyed on the NEWS marker rather than the branch name deliberately. The suite runs from a tarball and an installed package as well as a checkout, where no branch is visible, and `(development)` is a claim the maintainer makes in a tracked file rather than something inferred from the working copy.

## Verification

**A guard that silently skips the test it is protecting is worse than the failure it fixes**, so I checked that rather than assuming it:

- On `main`, the block still reports **2 passed / 0 skipped** — the assertion is live, not neutered.
- Guard truth table, exercised directly against both branches' real `NEWS.md`:

```
[PASS] main NEWS,  DESCRIPTION 3.5.2 (release)      skip=FALSE
[PASS] dev NEWS,   DESCRIPTION 4.0.0 (development)  skip=TRUE
[PASS] dev NEWS,   DESCRIPTION 3.5.2 (release sec)  skip=FALSE
[PASS] main NEWS,  version absent from NEWS         skip=FALSE
[PASS] prefix trap: 4.0.0 vs a 4.0.01 heading       skip=FALSE
```

The third case matters: on `dev_rhf` the guard is keyed to the *DESCRIPTION* version, so a release section further down the same file does not switch it on. The fifth is the same prefix trap the assertion below already guards against.

Full gate on `main`: **0 lints, FAIL 0 | PASS 1512 | SKIP 5**, 49 vdiffr baselines intact.

## Reaching dev_rhf

Lands on `main` first and reaches `dev_rhf` by forward-merge #10, per the standing rule that `dev_rhf` takes main's work only through `merge/main-into-dev_rhf-N` PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)