### PR TITLE
Add upstream GCC UBSAN release gate

### DIFF
--- a/.github/workflows/upstream-ubsan.yaml
+++ b/.github/workflows/upstream-ubsan.yaml
@@ -1,0 +1,65 @@
+# Release-only sanitizer probe for native code in upstream forest engines.
+# This is intentionally manual: randomForestSRC has a known UBSAN defect in
+# unsupervised growth, so the workflow first confirms that calibration signal
+# and then requires the supported ggRandomForests paths to remain clean.
+on:
+  workflow_dispatch:
+
+name: Upstream GCC UBSAN
+
+permissions:
+  contents: read
+
+jobs:
+  upstream-ubsan:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/r-hub/containers/gcc16:latest
+    env:
+      R_LIBS_USER: ${{ github.workspace }}/.ubsan-library
+      R_MAKEVARS_USER: ${{ github.workspace }}/tools/Makevars.ubsan
+      UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Record sanitizer toolchain
+        run: |
+          gcc --version
+          R --version
+          cat "$R_MAKEVARS_USER"
+
+      - name: Install dependencies and upstream engines from source
+        shell: bash
+        run: |
+          mkdir -p "$R_LIBS_USER"
+          Rscript -e 'install.packages("remotes", repos = "https://cloud.r-project.org", type = "source")'
+          Rscript -e 'remotes::install_deps(dependencies = c("Depends", "Imports", "LinkingTo"), upgrade = "never")'
+          Rscript -e 'install.packages(c("randomForestSRC", "randomForestRHF", "varPro"), repos = "https://cloud.r-project.org", type = "source")'
+          R CMD INSTALL .
+
+      - name: Confirm the known randomForestSRC sanitizer signal
+        shell: bash
+        run: |
+          set +e
+          Rscript tools/check-upstream-ubsan.R --known-rfsrc 2>&1 | tee known-rfsrc-ubsan.log
+          probe_status=${PIPESTATUS[0]}
+          set -e
+          if [[ "$probe_status" -eq 0 ]]; then
+            echo "The calibration probe returned without a UBSAN failure."
+            exit 1
+          fi
+          Rscript tools/check-upstream-ubsan.R --check-known known-rfsrc-ubsan.log
+
+      - name: Run supported rfsrc, varpro, and RHF workflows
+        shell: bash
+        run: |
+          Rscript tools/check-upstream-ubsan.R 2>&1 | tee supported-ubsan.log
+          Rscript tools/check-upstream-ubsan.R --check-clean supported-ubsan.log
+
+      - name: Upload sanitizer logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: upstream-gcc16-ubsan-logs
+          path: '*-ubsan.log'

--- a/release-checklist-v4.0.0.md
+++ b/release-checklist-v4.0.0.md
@@ -78,6 +78,7 @@ unsupervised variable priority where that method is discussed.
 |---|---|---|---|
 | [x] | RHF vignette | verified | `vignettes/rhf.qmd` rendered after Tasks 2 and 3 with `Rscript -e 'quarto::quarto_render("vignettes/rhf.qmd")'`; focused review of the complete article was clean at `06d939ae`; public links are in `_pkgdown.yml`, `README.md`, and `R/help.R`. |
 | [x] | Consistency sweep | verified | All audit rows have a disposition; fresh documentation, lint, guarded-suite, spelling, vignette, pkgdown, and archive evidence was recorded on 2026-08-25. |
+| [ ] | Upstream Linux GCC UBSAN execution | pending | Manually run `upstream-ubsan.yaml` on the release candidate. It builds `randomForestSRC`, `randomForestRHF`, and `varPro` from source with GCC 16 and `-fsanitize=undefined,bounds-strict`, confirms the contained unsupervised `randomForestSRC` finding, and requires the supported `rfsrc`, `varpro`, and RHF paths to remain clean. |
 | [ ] | Full release verification | pending | Requires a maintainer-authorized release verification after the remaining release gates are complete. Fresh consistency-sweep command evidence is recorded above. |
 | [ ] | Explicit maintainer authorization | pending | Maintainer approval recorded |
 | [ ] | Submission | pending | CRAN submission record |

--- a/tests/testthat/test_ubsan_release_gate.R
+++ b/tests/testthat/test_ubsan_release_gate.R
@@ -78,3 +78,21 @@ test_that("the release probe completes supported upstream workflows", {
 
   expect_invisible(run_supported_workflows())
 })
+
+test_that("the release probe seeds the RHF simulation directly", {
+  source_root <- normalizePath(
+    file.path(testthat::test_path(), "..", ".."),
+    mustWork = FALSE
+  )
+  if (!file.exists(file.path(source_root, ".git"))) {
+    skip("repository-only release probe")
+  }
+
+  probe <- readLines(
+    file.path(source_root, "tools", "check-upstream-ubsan.R"),
+    warn = FALSE
+  )
+  simulation_line <- grep("hazard\\.simulation", probe, fixed = FALSE)
+  expect_length(simulation_line, 1L)
+  expect_match(probe[[simulation_line - 1L]], "set.seed\\(20260826L\\)")
+})

--- a/tests/testthat/test_ubsan_release_gate.R
+++ b/tests/testthat/test_ubsan_release_gate.R
@@ -1,0 +1,80 @@
+test_that("the release probe rejects UBSAN diagnostics", {
+  source_root <- normalizePath(
+    file.path(testthat::test_path(), "..", ".."),
+    mustWork = FALSE
+  )
+  if (!file.exists(file.path(source_root, ".git"))) {
+    skip("repository-only release probe")
+  }
+  if (!file.exists(file.path(source_root, "DESCRIPTION"))) {
+    skip("source-only release probe")
+  }
+  probe <- file.path(source_root, "tools", "check-upstream-ubsan.R")
+  expect_true(file.exists(probe), info = "release probe must be tracked")
+
+  old <- Sys.getenv("GGRF_UBSAN_SOURCE_ONLY", unset = NA_character_)
+  on.exit({
+    if (is.na(old)) {
+      Sys.unsetenv("GGRF_UBSAN_SOURCE_ONLY")
+    } else {
+      Sys.setenv(GGRF_UBSAN_SOURCE_ONLY = old)
+    }
+  })
+  Sys.setenv(GGRF_UBSAN_SOURCE_ONLY = "true")
+  source(probe, local = TRUE)
+
+  clean_log <- tempfile()
+  writeLines("Supported upstream workflows completed", clean_log)
+  expect_invisible(assert_ubsan_clean(clean_log))
+
+  bad_log <- tempfile()
+  writeLines(
+    "entry.c:184:55: runtime error: pointer index expression overflowed",
+    bad_log
+  )
+  expect_error(
+    assert_ubsan_clean(bad_log),
+    "UndefinedBehaviorSanitizer diagnostic",
+    fixed = TRUE
+  )
+  expect_invisible(assert_known_rfsrc_ubsan(bad_log))
+
+  expect_error(
+    assert_known_rfsrc_ubsan(clean_log),
+    "known randomForestSRC UBSAN diagnostic",
+    fixed = TRUE
+  )
+})
+
+test_that("the release probe completes supported upstream workflows", {
+  skip_on_cran()
+  skip_if_not_installed("randomForestRHF")
+  skip_if_not_installed("varPro")
+
+  source_root <- normalizePath(
+    file.path(testthat::test_path(), "..", ".."),
+    mustWork = FALSE
+  )
+  if (!file.exists(file.path(source_root, ".git"))) {
+    skip("repository-only release probe")
+  }
+  if (!file.exists(file.path(source_root, "DESCRIPTION"))) {
+    skip("source-only release probe")
+  }
+
+  old <- Sys.getenv("GGRF_UBSAN_SOURCE_ONLY", unset = NA_character_)
+  on.exit({
+    if (is.na(old)) {
+      Sys.unsetenv("GGRF_UBSAN_SOURCE_ONLY")
+    } else {
+      Sys.setenv(GGRF_UBSAN_SOURCE_ONLY = old)
+    }
+  })
+  Sys.setenv(GGRF_UBSAN_SOURCE_ONLY = "true")
+  source(
+    file.path(source_root, "tools", "check-upstream-ubsan.R"),
+    local = TRUE
+  )
+
+  expect_invisible(run_supported_workflows())
+})

--- a/tools/Makevars.ubsan
+++ b/tools/Makevars.ubsan
@@ -1,0 +1,7 @@
+CFLAGS += -fsanitize=undefined,bounds-strict -fno-omit-frame-pointer
+CXXFLAGS += -fsanitize=undefined,bounds-strict -fno-omit-frame-pointer
+CXX11FLAGS += -fsanitize=undefined,bounds-strict -fno-omit-frame-pointer
+CXX14FLAGS += -fsanitize=undefined,bounds-strict -fno-omit-frame-pointer
+CXX17FLAGS += -fsanitize=undefined,bounds-strict -fno-omit-frame-pointer
+CXX20FLAGS += -fsanitize=undefined,bounds-strict -fno-omit-frame-pointer
+LDFLAGS += -fsanitize=undefined,bounds-strict

--- a/tools/check-upstream-ubsan.R
+++ b/tools/check-upstream-ubsan.R
@@ -56,6 +56,7 @@ run_supported_workflows <- function() {
     inherits(plot(varpro_view), "ggplot")
   )
 
+  set.seed(20260826L)
   simulated <- randomForestRHF::hazard.simulation(1)
   rhf_formula <- "Surv(id, start, stop, event) ~ ."
   set.seed(20260826L)

--- a/tools/check-upstream-ubsan.R
+++ b/tools/check-upstream-ubsan.R
@@ -1,0 +1,155 @@
+# Release-only execution probe for native code in the three upstream engines.
+
+.ubsan_pattern <- "runtime error:|UndefinedBehaviorSanitizer"
+
+assert_ubsan_clean <- function(path) {
+  output <- readLines(path, warn = FALSE)
+  if (any(grepl(.ubsan_pattern, output, perl = TRUE))) {
+    stop(
+      "Supported workflow emitted an UndefinedBehaviorSanitizer diagnostic.",
+      call. = FALSE
+    )
+  }
+  invisible()
+}
+
+assert_known_rfsrc_ubsan <- function(path) {
+  output <- readLines(path, warn = FALSE)
+  known <- grepl(
+    "entry\\.c:[0-9]+.*runtime error: pointer index expression",
+    output,
+    perl = TRUE
+  )
+  if (!any(known)) {
+    stop("Did not observe the known randomForestSRC UBSAN diagnostic.",
+         call. = FALSE)
+  }
+  invisible()
+}
+
+run_known_rfsrc_probe <- function() {
+  randomForestSRC::rfsrc(
+    randomForestSRC::Unsupervised() ~ .,
+    data = mtcars,
+    ntree = 1L
+  )
+  stop("The known randomForestSRC UBSAN probe unexpectedly returned.",
+       call. = FALSE)
+}
+
+run_supported_workflows <- function() {
+  set.seed(20260826L)
+  rfsrc_fit <- randomForestSRC::rfsrc(mpg ~ ., data = mtcars, ntree = 20L)
+  rfsrc_view <- ggRandomForests::gg_rfsrc(rfsrc_fit)
+  stopifnot(
+    inherits(rfsrc_fit, "rfsrc"),
+    inherits(rfsrc_view, "gg_rfsrc"),
+    inherits(plot(rfsrc_view), "ggplot")
+  )
+
+  set.seed(20260826L)
+  varpro_fit <- varPro::varpro(mpg ~ ., data = mtcars, ntree = 20L)
+  varpro_view <- ggRandomForests::gg_varpro(varpro_fit)
+  stopifnot(
+    inherits(varpro_fit, "varpro"),
+    inherits(varpro_view, "gg_varpro"),
+    inherits(plot(varpro_view), "ggplot")
+  )
+
+  simulated <- randomForestRHF::hazard.simulation(1)
+  rhf_formula <- "Surv(id, start, stop, event) ~ ."
+  set.seed(20260826L)
+  rhf_fit <- randomForestRHF::rhf(
+    rhf_formula,
+    simulated$dta,
+    ntree = 20L,
+    seed = -1L
+  )
+  rhf_prediction <- predict(rhf_fit)
+
+  cumulative_auc <- randomForestRHF::auct.rhf(
+    rhf_fit,
+    marker = "cumhaz",
+    method = "cumulative",
+    verbose = FALSE
+  )
+  incident_auc <- randomForestRHF::auct.rhf(
+    rhf_fit,
+    marker = "hazard",
+    method = "incident",
+    riskset = "subject",
+    verbose = FALSE
+  )
+
+  priority_cache <- randomForestRHF::varpro.cache.rhf(
+    rhf_fit,
+    max.rules.tree = 10L,
+    max.tree = 5L,
+    verbose = FALSE
+  )
+  time_index <- unique(as.integer(round(seq.int(
+    1L,
+    priority_cache$K,
+    length.out = 3L
+  ))))
+  priority_fit <- randomForestRHF::importance.rhf(
+    rhf_fit,
+    cache = priority_cache,
+    time.index = time_index,
+    verbose = FALSE
+  )
+
+  tune_fit <- randomForestRHF::tune.iAUC.rhf(
+    rhf_formula,
+    simulated$dta,
+    ntree = 10L,
+    lower = 2L,
+    upper = 4L,
+    max.evals = 3L,
+    seed = 20260826L,
+    verbose = FALSE,
+    forest = FALSE
+  )
+
+  rhf_view <- ggRandomForests::gg_rhf(rhf_fit)
+  auc_view <- ggRandomForests::gg_auct(
+    rhf_fit,
+    marker = "chf",
+    auct_fit = cumulative_auc
+  )
+  priority_view <- ggRandomForests::gg_rhf_importance(
+    rhf_fit,
+    importance_fit = priority_fit
+  )
+  tune_view <- ggRandomForests::gg_tune_rhf(tune_fit)
+  stopifnot(
+    inherits(rhf_fit, "rhf"),
+    inherits(rhf_prediction, "rhf"),
+    inherits(cumulative_auc, "auct.rhf"),
+    inherits(incident_auc, "auct.rhf"),
+    inherits(priority_fit, "importance.rhf"),
+    inherits(tune_fit, "tune.treesize.rhf"),
+    inherits(plot(rhf_view, idx = 1L), "ggplot"),
+    inherits(plot(auc_view), "ggplot"),
+    inherits(plot(priority_view), "ggplot"),
+    inherits(plot(tune_view), "ggplot")
+  )
+
+  message("Supported rfsrc, varpro, and RHF UBSAN workflows completed.")
+  invisible()
+}
+
+if (!identical(Sys.getenv("GGRF_UBSAN_SOURCE_ONLY"), "true")) {
+  args <- commandArgs(trailingOnly = TRUE)
+  if (identical(args, "--known-rfsrc")) {
+    run_known_rfsrc_probe()
+  } else if (length(args) == 2L && identical(args[[1L]], "--check-clean")) {
+    assert_ubsan_clean(args[[2L]])
+  } else if (length(args) == 2L && identical(args[[1L]], "--check-known")) {
+    assert_known_rfsrc_ubsan(args[[2L]])
+  } else if (!length(args)) {
+    run_supported_workflows()
+  } else {
+    stop("Unknown arguments for check-upstream-ubsan.R.", call. = FALSE)
+  }
+}


### PR DESCRIPTION
## Summary
- add a manual, release-only GCC 16 UBSAN workflow
- rebuild randomForestSRC, randomForestRHF, and varPro from source with undefined and bounds-strict sanitizers
- calibrate against the contained unsupervised randomForestSRC defect, then require supported rfsrc, varpro, and RHF workflows to remain clean
- add repository-only tests for log classification and supported-path execution
- retain the v4 release HOLD and record sanitizer execution as a pending release gate

## Verification
- Rscript -e 'devtools::document()'
- Rscript -e 'lintr::lint_package()' (0 lints)
- NOT_CRAN=true VDIFFR_RUN_TESTS=true Rscript -e 'devtools::test()' (1,764 passes, 59 existing warnings, 6 documented skips, 0 failures, 0 errors)
- snapshot status and name-status diff empty before and after
- workflow-order check and actionlint passed
- clean git-archive tarball: 3,867,600 bytes, correct version/date, only .Rinstignore hidden, no cran-comments, release-only tools excluded
- R CMD check --as-cran with manual: 0 errors, 0 warnings, 1 incoming-feasibility NOTE

The actual GCC 16 execution remains deliberately pending until the workflow is run on the release candidate; this PR does not authorize release, submission, or merge to main.