### PR TITLE
Document v4 RC branch topology

### DIFF
--- a/release-checklist-v4.0.0.md
+++ b/release-checklist-v4.0.0.md
@@ -209,3 +209,15 @@ maintainer authorization, submission, and CRAN acceptance remain pending, and
 the overall release status remains **HOLD**. This check does not authorize a
 release, CRAN submission, tag, version change, merge to `main`, or closure of
 CRAN acceptance.
+
+## RC topology verification evidence: 2026-08-26
+
+- Before recording the internal release-candidate topology,
+  `devtools::document()`, `lintr::lint_package()`, and the guarded full suite
+  exited 0 in that order. The suite reported 1,766 passes, 0 failures,
+  59 existing warnings, and 6 documented skips.
+- Scoped snapshot status and name-status diff were empty before and after the
+  suite. No vdiffr baseline changed or was deleted.
+- This run verifies the documentation-only topology record. It does not
+  advance the UBSAN, full release-verification, submission, or CRAN-acceptance
+  gates.

--- a/release-checklist-v4.0.0.md
+++ b/release-checklist-v4.0.0.md
@@ -92,6 +92,20 @@ unsupervised variable priority where that method is discussed.
 - Dependency floors are **retained** because they state supported
   compatibility, while this checklist separately states current CRAN versions.
 
+## Internal release-candidate topology
+
+- `maint/v3` preserves the v3 line from the last pre-v4 `main` commit. A v3
+  correction is made and released there, then forward-ported to the v4 line.
+- After v4 integration, `main` is the internal release-candidate channel.
+  `hvtiR::install()` therefore installs the v4 candidate from GitHub even while
+  CRAN remains on v3.
+- **hvtiR follow-up:** make `hvtiR::status()` and `hvtiR::update()` commit-aware.
+  Their current version comparison cannot distinguish two candidate commits
+  that both declare `Version: 4.0.0`. Until that work lands, internal testers
+  need an explicit reinstall to move between v4 release-candidate commits.
+  This tooling follow-up does not replace or advance any ggRandomForests CRAN
+  release gate.
+
 ## Verification evidence: 2026-08-25
 
 - The working tree and `tests/testthat/_snaps` were clean before verification.


### PR DESCRIPTION
## Summary
- record `maint/v3` as the preserved v3 hotfix line
- record `main` as the internal v4 release-candidate channel after integration
- log the hvtiR follow-up for commit-aware status and updates

## Release boundary
This documentation-only PR does not advance the UBSAN, full verification,
submission, or CRAN-acceptance gates.

## Verification
- `Rscript -e 'devtools::document()'`
- `Rscript -e 'lintr::lint_package()'` (0 lints)
- `NOT_CRAN=true VDIFFR_RUN_TESTS=true Rscript -e 'devtools::test()'`
  (1,766 passes, 0 failures, 59 existing warnings, 6 expected skips)
- vdiffr snapshot status and diff empty before and after the suite
