### PR TITLE
fix: pin randomForestRHF below 2.0.0 to unblock macOS CI

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -50,6 +50,7 @@ Suggests:
     quarto,
     ragg,
     randomForestRHF (>= 1.0.1),
+    randomForestRHF (< 2.0.0),
     RColorBrewer,
     rmarkdown,
     testthat,

--- a/NEWS.md
+++ b/NEWS.md
@@ -36,6 +36,13 @@ ggRandomForests v4.0.0 (development)
   `treesize / metric / value / se / selected`; the plot marks the selected
   size and draws an iAUC standard-error ribbon only when finite supplied iAUC
   standard errors are available. `gg_tune_rhf()` never recalculates tuning.
+* Pin `randomForestRHF (< 2.0.0)` in Suggests. 2.0.0 reached CRAN on
+  2026-08-28 and the macOS arm64 binary fails the `gg_rhf()` non-negativity
+  check -- `hazard` comes back with a value below zero while `chf`, its
+  cumulative sum, stays non-negative, which points at a small negative rather
+  than a non-finite one. The same 2.0.0 built from source on Linux passes, so
+  the pin is a CI unblock while the cause is settled upstream, not a verdict
+  on 2.0.0. See issue #229.
 
 ggRandomForests v3.5.2
 ======================


### PR DESCRIPTION
Unblocks macOS CI. Closes nothing — [#229](https://github.com/ehrlinger/ggRandomForests/issues/229) stays open until the cause is settled upstream.

## What changed

`Suggests` gains an upper bound on `randomForestRHF`:

```
     randomForestRHF (>= 1.0.1),
+    randomForestRHF (< 2.0.0),
```

Plus a NEWS bullet under the existing v4.0.0 development section.

## Why

`randomForestRHF` 2.0.0 reached CRAN on 2026-08-28, between run
[33132551758](https://github.com/ehrlinger/ggRandomForests/actions/runs/33132551758)
(01:20Z, green) and run
[33163500873](https://github.com/ehrlinger/ggRandomForests/actions/runs/33163500873)
(10:28Z, red). With no upper bound, each job took 2.0.0 as soon as its repository served it.

Within that single failing run the resolution split maps exactly onto the results:

| job | randomForestRHF | result |
|---|---|---|
| macos-latest (release) | **2.0.0** (arm64 binary) | **fail** |
| ubuntu-latest (devel) | **2.0.0** (built from source) | pass |
| ubuntu-latest (release) | 1.0.1 | pass |
| ubuntu-latest (oldrel-1) | 1.0.1 | pass |
| windows-latest (release) | 1.0.1 | pass |

This is not scoped to one PR — every run that resolves the arm64 binary is red, so without
the pin this reddens every open and future PR.

## Why two entries, not one

`randomForestRHF (>= 1.0.1, < 2.0.0)` looks like the natural spelling but is **not valid
DCF**. `tools:::.split_dependencies` splits the field on commas before it parses parentheses,
so that form yields a package named `randomForestRHF (>= 1.0.1` — a malformed *name*, not a
parse error, so it fails quietly rather than loudly. I hit exactly this on the first attempt.

Verified the two-entry form:

```
entries found: 2
  randomForestRHF >= 1.0.1
  randomForestRHF < 2.0.0
  1.0.0  satisfies pin: FALSE
  1.0.1  satisfies pin: TRUE
  1.9.9  satisfies pin: TRUE
  2.0.0  satisfies pin: FALSE
  2.1.0  satisfies pin: FALSE
```

## Known limitation

The pin governs what CI *installs*. It does not change
`tests/testthat/test_gg_tune_rhf.R:34`, whose guard is
`skip_if_not_installed("randomForestRHF", minimum_version = "1.0.1")` with no upper bound —
so a developer with 2.0.0 installed locally will still run those tests against it and still
see the failure. That is the right behaviour while #229 is open (it keeps the problem
visible), but worth knowing. My local install is 1.0.1.

## Verification

- `test_ggrandomforests_news.R` — `FAIL 0 | WARN 0 | SKIP 0 | PASS 5`.
- `DESCRIPTION` and `NEWS.md` still agree at `4.0.0`.
- No version bump: 4.0.0 is an unreleased development line, so this accumulates under it
  rather than rolling a digit.
- Other references to `randomForestRHF 1.0.1` (README, `R/help.R`, release checklist) describe
  the supported *minimum* and remain accurate; left untouched.
