### PR TITLE
fix: let gg_auct() reach the incident/dynamic AUC definition

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -59,6 +59,19 @@ ggRandomForests v4.0.0 (development)
   simulated data. The incident/dynamic definition compares subjects within a
   risk set and is unaffected. Reported upstream as
   kogalur/randomForestRHF#1; the section returns once that is settled.
+* `gg_auct()` gains a `method` argument and now forwards `...` to
+  `randomForestRHF::auct.rhf()`. `auct.rhf()` defaults `method` to
+  `"cumulative"`, and `gg_auct()` previously passed only `marker`, so the
+  incident/dynamic definition could not be reached from `gg_auct()` at all:
+  the only route was to call `auct.rhf()` directly and hand the result back
+  through `auct_fit`. That matters under randomForestRHF 2.0.0, where the
+  cumulative/dynamic curve inherits the flattened cumulative hazard and can
+  drop below the chance line. `?gg_auct` now carries a note naming the
+  upstream behavior and pointing at kogalur/randomForestRHF#1. Forwarding
+  `...` also makes `bootstrap.rep` reachable, so the confidence ribbon no
+  longer requires precomputing the fit. `method` sits after `auct_fit` in the
+  signature, so positional calls are unchanged, and the default behavior is
+  the same as before.
 
 ggRandomForests v3.5.2
 ======================

--- a/R/gg_auct.R
+++ b/R/gg_auct.R
@@ -12,7 +12,14 @@
 #' @param auct_fit Optional precomputed [randomForestRHF::auct.rhf()] result
 #'   (class `"auct.rhf"`) for the same `object`. `NULL` (default) computes it.
 #'   Supply it to reuse an expensive bootstrap run.
-#' @param ... Not currently used.
+#' @param method Which time-dependent AUC definition to compute, passed to
+#'   [randomForestRHF::auct.rhf()]. `"cumulative"` (default) ranks accumulated
+#'   risk through a horizon; `"incident"` ranks local failures within the risk
+#'   set at each time. See the note below before relying on the default.
+#'   Ignored when `auct_fit` is supplied.
+#' @param ... Further arguments passed to [randomForestRHF::auct.rhf()], for
+#'   example `bootstrap.rep` to request confidence bounds, or `riskset` for the
+#'   incident definition. Ignored when `auct_fit` is supplied.
 #'
 #' @return A `data.frame` of class `c("gg_auct", "data.frame")` with columns
 #'   `time`, `auc`, `se`, `lower`, `upper`, `marker` (CI columns `NA` when no
@@ -27,6 +34,24 @@
 #' Ishwaran H, Kogalur UB (2026). \emph{randomForestRHF: Random Hazard
 #' Forests}. R package version 2.0.0.
 #' \url{https://CRAN.R-project.org/package=randomForestRHF}.
+#'
+#' @note
+#' Cumulative/dynamic AUC is unreliable under \pkg{randomForestRHF} 2.0.0, so
+#' treat the `method = "cumulative"` default with care. That release holds the
+#' in-sample cumulative hazard flat once a subject's supplied records end,
+#' which `?randomForestRHF::rhf` documents. At a fixed grid point the marker
+#' then reflects how long a subject was observed as well as how much risk they
+#' carried, and the cumulative/dynamic definition compares subjects who have
+#' already failed against subjects still under follow-up. The curve can fall
+#' below the 0.5 chance line on data the forest fits well.
+#'
+#' The incident/dynamic definition does not inherit this, because it compares
+#' subjects within a risk set at each time, before any of them has left
+#' follow-up. It answers a different question rather than a better version of
+#' the same one, so reach for `method = "incident"` where that question is the
+#' one you are asking. The behavior is upstream, reported at
+#' \url{https://github.com/kogalur/randomForestRHF/issues/1}; `gg_auct()`
+#' passes the values through unchanged in every case.
 #'
 #' @seealso [plot.gg_auct()], [randomForestRHF::auct.rhf()]
 #'
@@ -48,15 +73,18 @@ gg_auct <- function(object, ...) {
 
 #' @rdname gg_auct
 #' @export
-gg_auct.rhf <- function(object, marker = c("chf", "haz"), auct_fit = NULL, ...) {
+gg_auct.rhf <- function(object, marker = c("chf", "haz"), auct_fit = NULL,
+                        method = c("cumulative", "incident"), ...) {
   marker <- match.arg(marker)
+  method <- match.arg(method)
 
   if (is.null(auct_fit)) {
     if (!requireNamespace("randomForestRHF", quietly = TRUE)) {
       stop("Install the 'randomForestRHF' package to use gg_auct(): ",
            "install.packages('randomForestRHF')", call. = FALSE)
     }
-    auct_fit <- randomForestRHF::auct.rhf(object, marker = marker)
+    auct_fit <- randomForestRHF::auct.rhf(object, marker = marker,
+                                          method = method, ...)
   }
   if (!inherits(auct_fit, "auct.rhf")) {
     stop("auct_fit must be an 'auct.rhf' object from ",

--- a/R/gg_auct.R
+++ b/R/gg_auct.R
@@ -8,15 +8,16 @@
 #'
 #' @param object A fitted `rhf` object from \pkg{randomForestRHF}.
 #' @param marker Risk marker for the AUC: `"chf"` (cumulative hazard, default)
-#'   or `"haz"` (hazard). Ignored when `auct_fit` is supplied.
+#'   or `"haz"` (hazard). Not used when `auct_fit` is supplied, though the
+#'   value is still validated.
 #' @param auct_fit Optional precomputed [randomForestRHF::auct.rhf()] result
 #'   (class `"auct.rhf"`) for the same `object`. `NULL` (default) computes it.
 #'   Supply it to reuse an expensive bootstrap run.
 #' @param method Which time-dependent AUC definition to compute, passed to
 #'   [randomForestRHF::auct.rhf()]. `"cumulative"` (default) ranks accumulated
 #'   risk through a horizon; `"incident"` ranks local failures within the risk
-#'   set at each time. See the note below before relying on the default.
-#'   Ignored when `auct_fit` is supplied.
+#'   set at each time. See the note below before relying on the default. Not
+#'   used when `auct_fit` is supplied, though the value is still validated.
 #' @param ... Further arguments passed to [randomForestRHF::auct.rhf()], for
 #'   example `bootstrap.rep` to request confidence bounds, or `riskset` for the
 #'   incident definition. Ignored when `auct_fit` is supplied.

--- a/man/gg_auct.Rd
+++ b/man/gg_auct.Rd
@@ -23,7 +23,8 @@ example \code{bootstrap.rep} to request confidence bounds, or \code{riskset} for
 incident definition. Ignored when \code{auct_fit} is supplied.}
 
 \item{marker}{Risk marker for the AUC: \code{"chf"} (cumulative hazard, default)
-or \code{"haz"} (hazard). Ignored when \code{auct_fit} is supplied.}
+or \code{"haz"} (hazard). Not used when \code{auct_fit} is supplied, though the
+value is still validated.}
 
 \item{auct_fit}{Optional precomputed \code{\link[randomForestRHF:auct.rhf]{randomForestRHF::auct.rhf()}} result
 (class \code{"auct.rhf"}) for the same \code{object}. \code{NULL} (default) computes it.
@@ -32,8 +33,8 @@ Supply it to reuse an expensive bootstrap run.}
 \item{method}{Which time-dependent AUC definition to compute, passed to
 \code{\link[randomForestRHF:auct.rhf]{randomForestRHF::auct.rhf()}}. \code{"cumulative"} (default) ranks accumulated
 risk through a horizon; \code{"incident"} ranks local failures within the risk
-set at each time. See the note below before relying on the default.
-Ignored when \code{auct_fit} is supplied.}
+set at each time. See the note below before relying on the default. Not
+used when \code{auct_fit} is supplied, though the value is still validated.}
 }
 \value{
 A \code{data.frame} of class \code{c("gg_auct", "data.frame")} with columns

--- a/man/gg_auct.Rd
+++ b/man/gg_auct.Rd
@@ -7,12 +7,20 @@
 \usage{
 gg_auct(object, ...)
 
-\method{gg_auct}{rhf}(object, marker = c("chf", "haz"), auct_fit = NULL, ...)
+\method{gg_auct}{rhf}(
+  object,
+  marker = c("chf", "haz"),
+  auct_fit = NULL,
+  method = c("cumulative", "incident"),
+  ...
+)
 }
 \arguments{
 \item{object}{A fitted \code{rhf} object from \pkg{randomForestRHF}.}
 
-\item{...}{Not currently used.}
+\item{...}{Further arguments passed to \code{\link[randomForestRHF:auct.rhf]{randomForestRHF::auct.rhf()}}, for
+example \code{bootstrap.rep} to request confidence bounds, or \code{riskset} for the
+incident definition. Ignored when \code{auct_fit} is supplied.}
 
 \item{marker}{Risk marker for the AUC: \code{"chf"} (cumulative hazard, default)
 or \code{"haz"} (hazard). Ignored when \code{auct_fit} is supplied.}
@@ -20,6 +28,12 @@ or \code{"haz"} (hazard). Ignored when \code{auct_fit} is supplied.}
 \item{auct_fit}{Optional precomputed \code{\link[randomForestRHF:auct.rhf]{randomForestRHF::auct.rhf()}} result
 (class \code{"auct.rhf"}) for the same \code{object}. \code{NULL} (default) computes it.
 Supply it to reuse an expensive bootstrap run.}
+
+\item{method}{Which time-dependent AUC definition to compute, passed to
+\code{\link[randomForestRHF:auct.rhf]{randomForestRHF::auct.rhf()}}. \code{"cumulative"} (default) ranks accumulated
+risk through a horizon; \code{"incident"} ranks local failures within the risk
+set at each time. See the note below before relying on the default.
+Ignored when \code{auct_fit} is supplied.}
 }
 \value{
 A \code{data.frame} of class \code{c("gg_auct", "data.frame")} with columns
@@ -33,6 +47,24 @@ Extracts the time-dependent AUC curve from \code{\link[randomForestRHF:auct.rhf]
 into a tidy long data frame, one row per time point, with bootstrap
 confidence bounds when available and the integrated AUC (iAUC) summary
 attached as an attribute.
+}
+\note{
+Cumulative/dynamic AUC is unreliable under \pkg{randomForestRHF} 2.0.0, so
+treat the \code{method = "cumulative"} default with care. That release holds the
+in-sample cumulative hazard flat once a subject's supplied records end,
+which \code{?randomForestRHF::rhf} documents. At a fixed grid point the marker
+then reflects how long a subject was observed as well as how much risk they
+carried, and the cumulative/dynamic definition compares subjects who have
+already failed against subjects still under follow-up. The curve can fall
+below the 0.5 chance line on data the forest fits well.
+
+The incident/dynamic definition does not inherit this, because it compares
+subjects within a risk set at each time, before any of them has left
+follow-up. It answers a different question rather than a better version of
+the same one, so reach for \code{method = "incident"} where that question is the
+one you are asking. The behavior is upstream, reported at
+\url{https://github.com/kogalur/randomForestRHF/issues/1}; \code{gg_auct()}
+passes the values through unchanged in every case.
 }
 \examples{
 \donttest{

--- a/tests/testthat/test_gg_auct.R
+++ b/tests/testthat/test_gg_auct.R
@@ -38,3 +38,41 @@ test_that("gg_auct attaches provenance from the rhf object", {
   expect_equal(prov$source, "randomForestRHF")
   expect_equal(prov$ntree, .rhf_pbc()$ntree)
 })
+
+test_that("gg_auct forwards method to auct.rhf", {
+  # auct.rhf()'s own method default is "cumulative", so without this argument
+  # the incident/dynamic path was unreachable through gg_auct(): the only route
+  # was to call auct.rhf() directly and hand the result back via auct_fit.
+  o <- .rhf_pbc()
+  set.seed(20260828L)
+  inc <- gg_auct(o, marker = "haz", method = "incident")
+  ref <- randomForestRHF::auct.rhf(o, marker = "haz", method = "incident")
+  expect_s3_class(inc, "gg_auct")
+  expect_equal(attr(inc, "iauc")$uno, ref$iAUC.uno)
+  expect_equal(inc$auc, ref$AUC.by.time$AUC)
+})
+
+test_that("gg_auct method='cumulative' stays the default", {
+  o <- .rhf_pbc()
+  expect_equal(
+    attr(gg_auct(o, marker = "chf"), "iauc")$uno,
+    attr(gg_auct(o, marker = "chf", method = "cumulative"), "iauc")$uno
+  )
+})
+
+test_that("gg_auct passes ... through to auct.rhf", {
+  # bootstrap.rep drives the CI ribbon in plot.gg_auct(), and before ... was
+  # forwarded there was no way to request it without precomputing the fit.
+  o <- .rhf_pbc()
+  set.seed(20260828L)
+  gg <- gg_auct(o, marker = "chf", bootstrap.rep = 5L)
+  expect_true(any(is.finite(gg$lower)))
+  expect_true(any(is.finite(gg$upper)))
+})
+
+test_that("gg_auct ignores method and ... when auct_fit is supplied", {
+  o <- .rhf_pbc()
+  fit <- .auct_pbc_noboot()
+  gg <- gg_auct(o, marker = "chf", method = "incident", auct_fit = fit)
+  expect_equal(attr(gg, "iauc")$uno, fit$iAUC.uno)
+})


### PR DESCRIPTION
Targets **ggRF RC2**. Follow-up to #231.

Started as a doc-only note about the randomForestRHF 2.0.0 chf issue, then
verifying the advice showed the note would have documented a dead end.

## What is actually wrong

`randomForestRHF::auct.rhf()` defaults `method` to `"cumulative"`.
`gg_auct.rhf()` had the signature `(object, marker, auct_fit, ...)` and called
`auct.rhf(object, marker = marker)`, forwarding neither `method` nor `...`.

So **the incident/dynamic definition was unreachable through `gg_auct()`**. The
only route was calling `auct.rhf()` directly and handing the result back via
`auct_fit`, which is exactly what the RHF vignette does.

Under randomForestRHF 2.0.0 that leaves both reachable live paths compromised.
Measured on the pbc fixture:

| call | runs | result |
|---|---|---|
| `gg_auct(o, marker = "chf")` | cumhaz + cumulative | iAUC **0.431**, inverted |
| `gg_auct(o, marker = "haz")` | hazard + cumulative | iAUC 0.552, but range **[0.013, 0.969]** |

The second is the degenerate combination, `n.cases` is 1 at 37 of 42 grid
times, so "use the hazard marker" is not a workaround. It looks plausible in a
plot and means nothing. This is why the change is not doc-only.

## Change

`method` forwarded, `...` forwarded. The sound paths are now reachable:

| call | iAUC | range |
|---|---:|---|
| `gg_auct(o, marker = "haz", method = "incident")` | 0.555 | [0.388, 0.927] |
| `gg_auct(o, marker = "chf", method = "incident")` | 0.627 | [0.515, 0.868] |

Incident/dynamic does not inherit the upstream problem because it compares
subjects within a risk set at each time, before any has left follow-up and had
its cumulative hazard frozen.

`?gg_auct` gains a `@note` naming the upstream behaviour, citing `?rhf` for the
flat-after-follow-up rule and pointing at kogalur/randomForestRHF#1. It states
that incident answers a different question rather than a better version of the
same one, so it is not offered as a drop-in replacement.

## Compatibility

Additive only. `method` sits **after** `auct_fit` in the signature so positional
calls are unchanged, and the default `"cumulative"` preserves existing
behaviour. No class, element or column names change. Forwarding `...` also makes
`bootstrap.rep` and `riskset` reachable, so the confidence ribbon no longer
requires precomputing the fit.

## Tests

Four added: `method` reaches `auct.rhf()` and matches a direct call; the
cumulative default is unchanged; `...` carries `bootstrap.rep` through to finite
CI bounds; both are ignored when `auct_fit` is supplied.

## Verification

- `devtools::test()`: **0 failures, 1783 passing**
- `lintr::lint_package()`: **0 lints**
- 54 vdiffr baselines, **0 deletions**
- `R CMD check --as-cran` from a clean export: running, will report
