### PR TITLE
Add labels= to plot.gg_rhf_importance()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -83,6 +83,15 @@ ggRandomForests v4.0.0 (development)
   the class-conditional panel, and `plot.gg_partial_varpro()` honours it on
   survival path-C objects (those extracted with `scale = "surv"` or `"chf"`),
   which are handed off to `plot.gg_partial_rfsrc()`.
+* `plot.gg_rhf_importance()` also gains `labels`, so the RHF priority matrix can
+  carry human-readable variable names. It takes the same three shapes and falls
+  back to the raw name per variable. The variable axis here is `y`, not a
+  flipped `x`, so the labelled scale is the y scale. The q90 variable ordering
+  and the raw names in the returned data are untouched, and
+  `autoplot.gg_rhf_importance()` forwards the argument. Previously `labels` fell
+  through `...` into `ggplot2::geom_point()` and was dropped with only ggplot2's
+  generic "Ignoring unknown parameters" warning, so the call looked accepted and
+  did nothing.
 * `plot.gg_vimp()`: `lbls` is **deprecated** in favour of `labels` and will be
   removed in a future release. Its old `length(lbls) >= length(vars)` gate is
   also gone, so a partial label set is now honoured, falling back to the raw

--- a/R/plot.gg_rhf_importance.R
+++ b/R/plot.gg_rhf_importance.R
@@ -20,6 +20,11 @@
 #'   of `1` applies no cap.
 #' @param display_note Logical; if `TRUE`, an applied size or color cap is
 #'   reported in the caption.
+#' @param labels Optional variable labels for the variable axis. One of: a
+#'   named character vector (`c(bili = "Serum bilirubin")`); a labelled data
+#'   frame, whose `attr(col, "label")` values are read; or a two-column
+#'   `key`/`label` data frame. Variables with no label keep their raw name.
+#'   Defaults to `NULL` (raw names).
 #' @param ... Additional arguments passed to [ggplot2::geom_point()].
 #'
 #' @details
@@ -62,7 +67,7 @@
 plot.gg_rhf_importance <- function(x, vars = NULL, top_n_union = 15L,
                                    transform = c("none", "log10"),
                                    size_cap = 0.99, color_cap = 0.99,
-                                   display_note = TRUE, ...) {
+                                   display_note = TRUE, labels = NULL, ...) {
   if (!inherits(x, "gg_rhf_importance")) {
     stop("plot.gg_rhf_importance() requires a 'gg_rhf_importance' object.",
          call. = FALSE)
@@ -96,7 +101,7 @@ plot.gg_rhf_importance <- function(x, vars = NULL, top_n_union = 15L,
     point_args$alpha <- 0.9
   }
 
-  ggplot2::ggplot(d, ggplot2::aes(
+  gg_plt <- ggplot2::ggplot(d, ggplot2::aes(
     x = .data[["time_window"]],
     y = .data[["variable"]],
     size = .data[["size_display"]],
@@ -116,6 +121,19 @@ plot.gg_rhf_importance <- function(x, vars = NULL, top_n_union = 15L,
     ggplot2::theme(
       axis.text.x = ggplot2::element_text(angle = 45, hjust = 1)
     )
+
+  # Labels are a display concern only: the variable factor keeps its raw names
+  # and its q90 ordering, and the scale renames the axis text.  Unlike the other
+  # importance methods there is no coord_flip() here, so the variable axis is y.
+  lab_lookup <- .forest_labels(labels)
+  if (!is.null(lab_lookup)) {
+    gg_plt <- gg_plt +
+      ggplot2::scale_y_discrete(
+        labels = function(v) .apply_forest_labels(v, lab_lookup)
+      )
+  }
+
+  gg_plt
 }
 
 .rhf_priority_plot_data <- function(x, vars, top_n_union) {

--- a/man/plot.gg_rhf_importance.Rd
+++ b/man/plot.gg_rhf_importance.Rd
@@ -12,6 +12,7 @@
   size_cap = 0.99,
   color_cap = 0.99,
   display_note = TRUE,
+  labels = NULL,
   ...
 )
 }
@@ -36,6 +37,12 @@ of \code{1} applies no cap.}
 
 \item{display_note}{Logical; if \code{TRUE}, an applied size or color cap is
 reported in the caption.}
+
+\item{labels}{Optional variable labels for the variable axis. One of: a
+named character vector (\code{c(bili = "Serum bilirubin")}); a labelled data
+frame, whose \code{attr(col, "label")} values are read; or a two-column
+\code{key}/\code{label} data frame. Variables with no label keep their raw name.
+Defaults to \code{NULL} (raw names).}
 
 \item{...}{Additional arguments passed to \code{\link[ggplot2:geom_point]{ggplot2::geom_point()}}.}
 }

--- a/tests/testthat/test_plot_gg_rhf_importance.R
+++ b/tests/testthat/test_plot_gg_rhf_importance.R
@@ -119,3 +119,87 @@ test_that("plot.gg_rhf_importance rejects wrong and empty inputs", {
   x$priority[] <- NA_real_
   expect_error(plot(x, top_n_union = NULL), "No finite RHF priority values")
 })
+
+## ---- labels= on the variable axis -----------------------------------------
+## Unlike the other importance methods, this one draws variables on y directly
+## (no coord_flip), so the labelled scale is scale_y_discrete.
+
+.rhf_priority_axis_labels <- function(p) {
+  built <- ggplot2::ggplot_build(p)
+  unlist(lapply(built$layout$panel_params,
+                function(pp) as.character(pp$y$get_labels())))
+}
+
+test_that("plot.gg_rhf_importance labels the variable axis", {
+  p <- plot(.rhf_priority_test_object(), top_n_union = NULL,
+            labels = c(x1 = "Serum bilirubin"))
+
+  expect_true("Serum bilirubin" %in% .rhf_priority_axis_labels(p))
+})
+
+test_that("plot.gg_rhf_importance falls back to the raw name per variable", {
+  p <- plot(.rhf_priority_test_object(), top_n_union = NULL,
+            labels = c(x1 = "Serum bilirubin"))
+  axis <- .rhf_priority_axis_labels(p)
+
+  expect_true(all(c("x2", "x3") %in% axis))
+  expect_false("x1" %in% axis)
+})
+
+test_that("plot.gg_rhf_importance accepts a labelled data frame", {
+  d <- data.frame(x1 = 1:2, x2 = 3:4)
+  attr(d$x1, "label") <- "Serum bilirubin"
+  attr(d$x2, "label") <- "Prothrombin time"
+  p <- plot(.rhf_priority_test_object(), top_n_union = NULL, labels = d)
+
+  expect_true(all(c("Serum bilirubin", "Prothrombin time") %in%
+                    .rhf_priority_axis_labels(p)))
+})
+
+test_that("plot.gg_rhf_importance accepts a key/label data frame", {
+  m <- data.frame(key = "x1", label = "Serum bilirubin",
+                  stringsAsFactors = FALSE)
+  p <- plot(.rhf_priority_test_object(), top_n_union = NULL, labels = m)
+
+  expect_true("Serum bilirubin" %in% .rhf_priority_axis_labels(p))
+})
+
+test_that("plot.gg_rhf_importance with labels = NULL keeps the raw names", {
+  p <- plot(.rhf_priority_test_object(), top_n_union = NULL)
+
+  expect_setequal(.rhf_priority_axis_labels(p), c("x1", "x2", "x3"))
+})
+
+test_that("plot.gg_rhf_importance warns once when no label resolves", {
+  expect_warning(
+    plot(.rhf_priority_test_object(), top_n_union = NULL,
+         labels = c(x1 = "")),
+    "No variable labels"
+  )
+})
+
+test_that("plot.gg_rhf_importance keeps raw names in the returned data", {
+  # Labels are a display concern: the plot's data must still carry the raw
+  # variable names, so downstream code reading p$data is unaffected.
+  p <- plot(.rhf_priority_test_object(), top_n_union = NULL,
+            labels = c(x1 = "Serum bilirubin"))
+
+  expect_setequal(as.character(unique(p$data$variable)), c("x1", "x2", "x3"))
+})
+
+test_that("plot.gg_rhf_importance preserves importance order under labels", {
+  # The q90 ordering lives in the factor levels; relabelling the scale must
+  # not disturb it. Highest-ranked variable stays the last level (top of axis).
+  p <- plot(.rhf_priority_test_object(), top_n_union = NULL,
+            labels = c(x1 = "Serum bilirubin"))
+
+  expect_equal(tail(levels(p$data$variable), 1L), "x1")
+  expect_equal(tail(.rhf_priority_axis_labels(p), 1L), "Serum bilirubin")
+})
+
+test_that("autoplot.gg_rhf_importance forwards labels to the plot method", {
+  p <- ggplot2::autoplot(.rhf_priority_test_object(), top_n_union = NULL,
+                         labels = c(x1 = "Serum bilirubin"))
+
+  expect_true("Serum bilirubin" %in% .rhf_priority_axis_labels(p))
+})


### PR DESCRIPTION
Closes the RHF follow-up that [#236](https://github.com/ehrlinger/ggRandomForests/pull/236) deliberately left out. Its design doc records the exclusion at [`dev/specs/2026-08-28-forest-plot-labels-design.md:169`](dev/specs/2026-08-28-forest-plot-labels-design.md#L169):

> **Excluded: RHF** (`gg_rhf_importance.R`, `plot.gg_rhf_importance.R`). A parallel session owns those files. Follow-up once it lands.

That parallel session merged as #231, so the files are free.

## What changed

`plot.gg_rhf_importance()` gains a `labels` argument, reusing the `.forest_labels()` / `.apply_forest_labels()` helpers landed in #236. All three input shapes (named character vector, labelled data frame, `key`/`label` frame) and the per-variable raw-name fallback come from the shared helpers, so there is no new label-resolution logic.

Two things are specific to this method:

- **The variable axis is `y`, not a flipped `x`.** The other importance plots label `scale_x_discrete()` under `coord_flip()`; this one is a point matrix with no flip, so the labelled scale is `scale_y_discrete()`.
- **`labels` was previously swallowed, not merely absent.** The method collects `point_args <- list(...)` and `do.call(geom_point, point_args)`, so a caller passing `labels=` had it forwarded into the geom and dropped with only ggplot2's generic `Ignoring unknown parameters: labels`. The call looked accepted and did nothing.

`labels` is appended after `display_note` rather than inserted early as in `plot.gg_varpro()`. This method has six defaulted formals ahead of `...`, so a mid-signature insert would silently reassign positional calls; appending is purely additive.

`autoplot.gg_rhf_importance()` already forwards `...`, so it needed no change. A test pins that.

## Scope

Only `plot.gg_rhf_importance.R` changes. `gg_rhf_importance.R` needed nothing: labelling is a draw-time concern and the extractor already carries raw names and the q90 ordering in the `variable` factor levels.

No version bump. `4.0.0` is an unreleased development line with an open `v4.0.0 (development)` NEWS section, so the entry goes under it and the NEWS-vs-DESCRIPTION version grep stays satisfied.

Following #236's precedent, `@param` is documented but no `@examples` were added, keeping the check-time budget untouched.

## Tests

Nine new blocks in `test_plot_gg_rhf_importance.R`, all data-carrying assertions against built scale labels rather than `expect_s3_class(p, "ggplot")`:

- each of the three `labels=` shapes resolves onto the axis
- an unlabelled variable falls back to its raw name
- `labels = NULL` reproduces the raw names
- a lookup resolving nothing warns once
- the q90 ordering survives relabelling (highest-ranked stays the last level, top of axis)
- `p$data$variable` still carries **raw** names after plotting with labels
- `autoplot()` forwards the argument

They run on the existing `.fake_rhf_importance()` fixture, which needs no `randomForestRHF` and touches no RNG.

## Definition of done

| Gate | Result |
|---|---|
| `devtools::document()` | regenerated `man/plot.gg_rhf_importance.Rd` |
| `lintr::lint_package()` | 0 lints |
| `NOT_CRAN=true VDIFFR_RUN_TESTS=true devtools::test()` | 0 failures, 0 errors, 1867 pass, 6 skips |
| vdiffr baselines | 54 before, 54 after; working tree byte-identical, no pruning |
| `R CMD check --as-cran` (with manual, from a clean `git archive` export) | **1 NOTE**, 0 WARNING, 0 ERROR |

The NOTE is `checking CRAN incoming feasibility` — "Number of updates in past 6 months: 8", the maintainer-cadence note. Check wall time 3:23.

Tarball gate: only `ggRandomForests/.Rinstignore` matches `/\.[^/]+`, and `cran-comments` count is 0.

## Not in this PR

`labels=` is now on 7 of 23 exported `plot.gg_*` methods. Three importance plots still lack it: `plot.gg_beta_varpro()`, `plot.gg_ivarpro()` and `plot.gg_beta_uvarpro()`. The first two share the importance-ordering contract pinned by `test_plot_conventions.R` alongside `gg_vimp` and `gg_varpro`, so they are the natural next step. They were never in #236's scope and are not recorded under its *Out of scope* list, so unlike RHF they are untracked. Kept out here rather than widening scope mid-branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)