### PR TITLE
Add labels= to the three remaining varPro importance plots

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -92,6 +92,13 @@ ggRandomForests v4.0.0 (development)
   through `...` into `ggplot2::geom_point()` and was dropped with only ggplot2's
   generic "Ignoring unknown parameters" warning, so the call looked accepted and
   did nothing.
+* `plot.gg_beta_varpro()`, `plot.gg_ivarpro()` and `plot.gg_beta_uvarpro()`
+  gain `labels` on the same terms, completing the varPro importance family.
+  These three had been dropping the argument in complete silence: each declares
+  `...` and does not use it, so `labels` was absorbed with no warning, no
+  error, and an unlabelled plot as the only symptom. Their facets are per class
+  rather than per variable, so the class strips are left alone and only the
+  variable axis is relabelled; in a faceted plot every panel is relabelled.
 * `plot.gg_vimp()`: `lbls` is **deprecated** in favour of `labels` and will be
   removed in a future release. Its old `length(lbls) >= length(vars)` gate is
   also gone, so a partial label set is now honoured, falling back to the raw

--- a/R/plot.gg_beta_uvarpro.R
+++ b/R/plot.gg_beta_uvarpro.R
@@ -19,6 +19,11 @@
 #' variables on very different scales.
 #'
 #' @param x A `gg_beta_uvarpro` object from [gg_beta_uvarpro()].
+#' @param labels Optional variable labels for the variable axis. One of: a
+#'   named character vector (`c(wt = "Weight")`); a labelled data frame, whose
+#'   `attr(col, "label")` values are read; or a two-column `key`/`label` data
+#'   frame. Variables with no label keep their raw name. Defaults to `NULL`
+#'   (raw names).
 #' @param ... Not currently used.
 #'
 #' @return A `ggplot` object.
@@ -38,7 +43,7 @@
 #' @importFrom ggplot2 ggplot aes geom_col geom_hline coord_flip
 #' @importFrom ggplot2 scale_fill_manual labs theme_minimal
 #' @export
-plot.gg_beta_uvarpro <- function(x, ...) {
+plot.gg_beta_uvarpro <- function(x, labels = NULL, ...) {
   if (nrow(x) == 0L) {
     stop("plot.gg_beta_uvarpro: nothing to plot (gg_beta_uvarpro has 0 rows).",
          call. = FALSE)
@@ -58,7 +63,7 @@ plot.gg_beta_uvarpro <- function(x, ...) {
     format(n_var), cutoff
   )
 
-  ggplot2::ggplot(
+  p <- ggplot2::ggplot(
     x,
     ggplot2::aes(
       x    = .data[["variable"]],
@@ -84,4 +89,14 @@ plot.gg_beta_uvarpro <- function(x, ...) {
       caption = caption_txt
     ) +
     ggplot2::theme_minimal()
+
+  # Labels rename the axis text only: the variable factor keeps its raw names
+  # and its importance ordering.
+  lab_lookup <- .forest_labels(labels)
+  if (!is.null(lab_lookup)) {
+    p <- p + ggplot2::scale_x_discrete(
+      labels = function(v) .apply_forest_labels(v, lab_lookup)
+    )
+  }
+  p
 }

--- a/R/plot.gg_beta_varpro.R
+++ b/R/plot.gg_beta_varpro.R
@@ -35,6 +35,11 @@
 #' interesting signal.
 #'
 #' @param x A `gg_beta_varpro` object from [gg_beta_varpro()].
+#' @param labels Optional variable labels for the variable axis. One of: a
+#'   named character vector (`c(wt = "Weight")`); a labelled data frame, whose
+#'   `attr(col, "label")` values are read; or a two-column `key`/`label` data
+#'   frame. Variables with no label keep their raw name. Defaults to `NULL`
+#'   (raw names).
 #' @param ... Not currently used.
 #'
 #' @return A `ggplot` object.
@@ -54,7 +59,7 @@
 #' @importFrom ggplot2 ggplot aes geom_col geom_hline coord_flip
 #' @importFrom ggplot2 scale_fill_manual labs theme_minimal
 #' @export
-plot.gg_beta_varpro <- function(x, ...) {
+plot.gg_beta_varpro <- function(x, labels = NULL, ...) {
   if (nrow(x) == 0L) {
     stop("plot.gg_beta_varpro: nothing to plot (gg_beta_varpro has 0 rows).",
          call. = FALSE)
@@ -118,6 +123,16 @@ plot.gg_beta_varpro <- function(x, ...) {
       linetype   = "dashed",
       color      = "#e74c3c",
       linewidth  = 0.7
+    )
+  }
+
+  # Labels rename the axis text only: the variable factor keeps its raw names
+  # and its importance ordering.  Facets here are per class, not per variable,
+  # so the strips are left alone.
+  lab_lookup <- .forest_labels(labels)
+  if (!is.null(lab_lookup)) {
+    p <- p + ggplot2::scale_x_discrete(
+      labels = function(v) .apply_forest_labels(v, lab_lookup)
     )
   }
   p

--- a/R/plot.gg_ivarpro.R
+++ b/R/plot.gg_ivarpro.R
@@ -27,6 +27,11 @@
 #' data, not Shapley values and not permutation-based.
 #'
 #' @param x A `gg_ivarpro` object from [gg_ivarpro()].
+#' @param labels Optional variable labels for the variable axis. One of: a
+#'   named character vector (`c(wt = "Weight")`); a labelled data frame, whose
+#'   `attr(col, "label")` values are read; or a two-column `key`/`label` data
+#'   frame. Variables with no label keep their raw name. Defaults to `NULL`
+#'   (raw names).
 #' @param ... Not currently used.
 #'
 #' @return A `ggplot` object.
@@ -47,7 +52,7 @@
 #' @importFrom ggplot2 ggplot aes geom_col geom_jitter geom_hline coord_flip
 #' @importFrom ggplot2 facet_wrap scale_fill_manual scale_color_manual labs theme_minimal
 #' @export
-plot.gg_ivarpro <- function(x, ...) {
+plot.gg_ivarpro <- function(x, labels = NULL, ...) {
   if (nrow(x) == 0L) {
     stop("plot.gg_ivarpro: nothing to plot (gg_ivarpro has 0 rows).",
          call. = FALSE)
@@ -127,9 +132,20 @@ plot.gg_ivarpro <- function(x, ...) {
     if (which_obs_set) sprintf(" obs = %d.", prov$which_obs) else ""
   )
 
-  p + ggplot2::labs(
+  p <- p + ggplot2::labs(
     x = NULL,
     y = "Local importance",
     caption = caption_txt
   ) + ggplot2::theme_minimal()
+
+  # Labels rename the axis text only: the variable factor keeps its raw names
+  # and its importance ordering.  Facets here are per class, not per variable,
+  # so the strips are left alone.
+  lab_lookup <- .forest_labels(labels)
+  if (!is.null(lab_lookup)) {
+    p <- p + ggplot2::scale_x_discrete(
+      labels = function(v) .apply_forest_labels(v, lab_lookup)
+    )
+  }
+  p
 }

--- a/man/plot.gg_beta_uvarpro.Rd
+++ b/man/plot.gg_beta_uvarpro.Rd
@@ -4,10 +4,16 @@
 \alias{plot.gg_beta_uvarpro}
 \title{Plot a \code{gg_beta_uvarpro} object}
 \usage{
-\method{plot}{gg_beta_uvarpro}(x, ...)
+\method{plot}{gg_beta_uvarpro}(x, labels = NULL, ...)
 }
 \arguments{
 \item{x}{A \code{gg_beta_uvarpro} object from \code{\link[=gg_beta_uvarpro]{gg_beta_uvarpro()}}.}
+
+\item{labels}{Optional variable labels for the variable axis. One of: a
+named character vector (\code{c(wt = "Weight")}); a labelled data frame, whose
+\code{attr(col, "label")} values are read; or a two-column \code{key}/\code{label} data
+frame. Variables with no label keep their raw name. Defaults to \code{NULL}
+(raw names).}
 
 \item{...}{Not currently used.}
 }

--- a/man/plot.gg_beta_varpro.Rd
+++ b/man/plot.gg_beta_varpro.Rd
@@ -4,10 +4,16 @@
 \alias{plot.gg_beta_varpro}
 \title{Plot a \code{gg_beta_varpro} object}
 \usage{
-\method{plot}{gg_beta_varpro}(x, ...)
+\method{plot}{gg_beta_varpro}(x, labels = NULL, ...)
 }
 \arguments{
 \item{x}{A \code{gg_beta_varpro} object from \code{\link[=gg_beta_varpro]{gg_beta_varpro()}}.}
+
+\item{labels}{Optional variable labels for the variable axis. One of: a
+named character vector (\code{c(wt = "Weight")}); a labelled data frame, whose
+\code{attr(col, "label")} values are read; or a two-column \code{key}/\code{label} data
+frame. Variables with no label keep their raw name. Defaults to \code{NULL}
+(raw names).}
 
 \item{...}{Not currently used.}
 }

--- a/man/plot.gg_ivarpro.Rd
+++ b/man/plot.gg_ivarpro.Rd
@@ -4,10 +4,16 @@
 \alias{plot.gg_ivarpro}
 \title{Plot a \code{gg_ivarpro} object}
 \usage{
-\method{plot}{gg_ivarpro}(x, ...)
+\method{plot}{gg_ivarpro}(x, labels = NULL, ...)
 }
 \arguments{
 \item{x}{A \code{gg_ivarpro} object from \code{\link[=gg_ivarpro]{gg_ivarpro()}}.}
+
+\item{labels}{Optional variable labels for the variable axis. One of: a
+named character vector (\code{c(wt = "Weight")}); a labelled data frame, whose
+\code{attr(col, "label")} values are read; or a two-column \code{key}/\code{label} data
+frame. Variables with no label keep their raw name. Defaults to \code{NULL}
+(raw names).}
 
 \item{...}{Not currently used.}
 }

--- a/tests/testthat/helper-varpro-fixtures.R
+++ b/tests/testthat/helper-varpro-fixtures.R
@@ -176,3 +176,12 @@ make_mock_gg_varpro <- function(vars = c("bpd", "vis", "age"), conditional = FAL
                                   n           = 200L)
   out
 }
+
+# Variable-axis tick labels from a built plot.  These methods coord_flip(), so
+# the variable categories land on the y scale.  Faceted plots have one panel
+# per class, so collect across every panel.
+.varpro_axis_labels <- function(p) {
+  built <- ggplot2::ggplot_build(p)
+  unlist(lapply(built$layout$panel_params,
+                function(pp) as.character(pp$y$get_labels())))
+}

--- a/tests/testthat/test_gg_beta_uvarpro.R
+++ b/tests/testthat/test_gg_beta_uvarpro.R
@@ -158,3 +158,57 @@ test_that("gg_beta_uvarpro agrees with a live get.beta.entropy() fit", {
   exp <- colMeans(b, na.rm = TRUE)
   expect_equal(got[names(exp)], exp[names(exp)])
 })
+
+## ---- labels= on the variable axis (issue #239) -----------------------------
+
+test_that("plot.gg_beta_uvarpro labels the variable axis", {
+  out <- gg_beta_uvarpro(.stub_uvarpro(), beta_fit = .mock_beta_entropy())
+  p <- plot(out, labels = c(a = "Alpha channel"))
+
+  expect_true("Alpha channel" %in% .varpro_axis_labels(p))
+})
+
+test_that("plot.gg_beta_uvarpro falls back to the raw name per variable", {
+  out <- gg_beta_uvarpro(.stub_uvarpro(), beta_fit = .mock_beta_entropy())
+  axis <- .varpro_axis_labels(plot(out, labels = c(a = "Alpha channel")))
+
+  expect_false("a" %in% axis)
+  expect_true("b" %in% axis)
+})
+
+test_that("plot.gg_beta_uvarpro accepts a labelled data frame", {
+  out <- gg_beta_uvarpro(.stub_uvarpro(), beta_fit = .mock_beta_entropy())
+  d <- data.frame(a = 1:2, b = 3:4)
+  attr(d$a, "label") <- "Alpha channel"
+  attr(d$b, "label") <- "Beta channel"
+
+  expect_true(all(c("Alpha channel", "Beta channel") %in%
+                    .varpro_axis_labels(plot(out, labels = d))))
+})
+
+test_that("plot.gg_beta_uvarpro with labels = NULL keeps the raw names", {
+  out <- gg_beta_uvarpro(.stub_uvarpro(), beta_fit = .mock_beta_entropy())
+
+  expect_true("a" %in% .varpro_axis_labels(plot(out)))
+})
+
+test_that("plot.gg_beta_uvarpro warns once when no label resolves", {
+  out <- gg_beta_uvarpro(.stub_uvarpro(), beta_fit = .mock_beta_entropy())
+
+  expect_warning(plot(out, labels = c(a = "")), "No variable labels")
+})
+
+test_that("plot.gg_beta_uvarpro keeps raw names and order in the returned data", {
+  out <- gg_beta_uvarpro(.stub_uvarpro(), beta_fit = .mock_beta_entropy())
+  p <- plot(out, labels = c(a = "Alpha channel"))
+
+  expect_true("a" %in% as.character(p$data$variable))
+  expect_equal(levels(p$data$variable), levels(out$variable))
+})
+
+test_that("autoplot.gg_beta_uvarpro forwards labels", {
+  out <- gg_beta_uvarpro(.stub_uvarpro(), beta_fit = .mock_beta_entropy())
+  p <- ggplot2::autoplot(out, labels = c(a = "Alpha channel"))
+
+  expect_true("Alpha channel" %in% .varpro_axis_labels(p))
+})

--- a/tests/testthat/test_gg_beta_varpro.R
+++ b/tests/testthat/test_gg_beta_varpro.R
@@ -462,3 +462,70 @@ test_that("empty classification fast-path returns named cutoff vector", {
   expect_true(all(is.na(prov$cutoff)))
   expect_equal(prov$class_levels, levels(iris$Species))
 })
+
+## ---- labels= on the variable axis (issue #239) -----------------------------
+
+test_that("plot.gg_beta_varpro labels the variable axis", {
+  out <- gg_beta_varpro(.varpro_mtcars(), beta_fit = .beta_fit_mtcars())
+  p <- plot(out, labels = c(wt = "Weight (1000 lbs)"))
+
+  expect_true("Weight (1000 lbs)" %in% .varpro_axis_labels(p))
+})
+
+test_that("plot.gg_beta_varpro falls back to the raw name per variable", {
+  out <- gg_beta_varpro(.varpro_mtcars(), beta_fit = .beta_fit_mtcars())
+  axis <- .varpro_axis_labels(plot(out, labels = c(wt = "Weight (1000 lbs)")))
+
+  expect_false("wt" %in% axis)
+  expect_true("hp" %in% axis)
+})
+
+test_that("plot.gg_beta_varpro accepts a key/label data frame", {
+  out <- gg_beta_varpro(.varpro_mtcars(), beta_fit = .beta_fit_mtcars())
+  m <- data.frame(key = "wt", label = "Weight (1000 lbs)",
+                  stringsAsFactors = FALSE)
+
+  expect_true("Weight (1000 lbs)" %in% .varpro_axis_labels(plot(out, labels = m)))
+})
+
+test_that("plot.gg_beta_varpro labels every panel when faceted by class", {
+  # Facets are per class, not per variable, so the variable axis must be
+  # relabelled in each panel while the strips keep their class names.
+  v <- .varpro_iris_multiclass()
+  out <- gg_beta_varpro(v, beta_fit = .beta_fit_iris_multiclass())
+  p <- plot(out, labels = c(Petal.Width = "Petal width"))
+  built <- ggplot2::ggplot_build(p)
+
+  per_panel <- vapply(built$layout$panel_params,
+                      function(pp) "Petal width" %in% as.character(pp$y$get_labels()),
+                      logical(1))
+  expect_gt(length(per_panel), 1L)
+  expect_true(all(per_panel))
+})
+
+test_that("plot.gg_beta_varpro with labels = NULL keeps the raw names", {
+  out <- gg_beta_varpro(.varpro_mtcars(), beta_fit = .beta_fit_mtcars())
+
+  expect_true("wt" %in% .varpro_axis_labels(plot(out)))
+})
+
+test_that("plot.gg_beta_varpro warns once when no label resolves", {
+  out <- gg_beta_varpro(.varpro_mtcars(), beta_fit = .beta_fit_mtcars())
+
+  expect_warning(plot(out, labels = c(wt = "")), "No variable labels")
+})
+
+test_that("plot.gg_beta_varpro keeps raw names and order in the returned data", {
+  out <- gg_beta_varpro(.varpro_mtcars(), beta_fit = .beta_fit_mtcars())
+  p <- plot(out, labels = c(wt = "Weight (1000 lbs)"))
+
+  expect_true("wt" %in% as.character(p$data$variable))
+  expect_equal(levels(p$data$variable), levels(out$variable))
+})
+
+test_that("autoplot.gg_beta_varpro forwards labels", {
+  out <- gg_beta_varpro(.varpro_mtcars(), beta_fit = .beta_fit_mtcars())
+  p <- ggplot2::autoplot(out, labels = c(wt = "Weight (1000 lbs)"))
+
+  expect_true("Weight (1000 lbs)" %in% .varpro_axis_labels(p))
+})

--- a/tests/testthat/test_gg_ivarpro.R
+++ b/tests/testthat/test_gg_ivarpro.R
@@ -316,3 +316,68 @@ test_that("gg_ivarpro cached and uncached paths agree (slow)", {
   expect_false(attr(uncached, "provenance")$precomputed)
   expect_true(attr(cached,   "provenance")$precomputed)
 })
+
+## ---- labels= on the variable axis (issue #239) -----------------------------
+
+test_that("plot.gg_ivarpro labels the variable axis on the jitter path", {
+  out <- gg_ivarpro(.varpro_boston(), ivarpro_fit = .ivarpro_boston())
+  p <- plot(out, labels = c(rm = "Rooms per dwelling"))
+
+  expect_true("Rooms per dwelling" %in% .varpro_axis_labels(p))
+})
+
+test_that("plot.gg_ivarpro labels the variable axis on the which_obs bar path", {
+  # The two branches build different geoms, so both need covering.
+  out <- gg_ivarpro(.varpro_boston(), ivarpro_fit = .ivarpro_boston(),
+                    which_obs = 1L)
+  p <- plot(out, labels = c(rm = "Rooms per dwelling"))
+
+  expect_true("Rooms per dwelling" %in% .varpro_axis_labels(p))
+})
+
+test_that("plot.gg_ivarpro falls back to the raw name per variable", {
+  out <- gg_ivarpro(.varpro_boston(), ivarpro_fit = .ivarpro_boston())
+  axis <- .varpro_axis_labels(plot(out, labels = c(rm = "Rooms per dwelling")))
+
+  expect_false("rm" %in% axis)
+  expect_true("crim" %in% axis)
+})
+
+test_that("plot.gg_ivarpro labels every panel when faceted by class", {
+  out <- gg_ivarpro(.varpro_iris_multiclass_for_ivarpro(),
+                    ivarpro_fit = .ivarpro_iris_multiclass())
+  built <- ggplot2::ggplot_build(plot(out, labels = c(Petal.Width = "Petal width")))
+
+  per_panel <- vapply(built$layout$panel_params,
+                      function(pp) "Petal width" %in% as.character(pp$y$get_labels()),
+                      logical(1))
+  expect_gt(length(per_panel), 1L)
+  expect_true(all(per_panel))
+})
+
+test_that("plot.gg_ivarpro with labels = NULL keeps the raw names", {
+  out <- gg_ivarpro(.varpro_boston(), ivarpro_fit = .ivarpro_boston())
+
+  expect_true("rm" %in% .varpro_axis_labels(plot(out)))
+})
+
+test_that("plot.gg_ivarpro warns once when no label resolves", {
+  out <- gg_ivarpro(.varpro_boston(), ivarpro_fit = .ivarpro_boston())
+
+  expect_warning(plot(out, labels = c(rm = "")), "No variable labels")
+})
+
+test_that("plot.gg_ivarpro keeps raw names and order in the returned data", {
+  out <- gg_ivarpro(.varpro_boston(), ivarpro_fit = .ivarpro_boston())
+  p <- plot(out, labels = c(rm = "Rooms per dwelling"))
+
+  expect_true("rm" %in% as.character(p$data$variable))
+  expect_equal(levels(p$data$variable), levels(out$variable))
+})
+
+test_that("autoplot.gg_ivarpro forwards labels", {
+  out <- gg_ivarpro(.varpro_boston(), ivarpro_fit = .ivarpro_boston())
+  p <- ggplot2::autoplot(out, labels = c(rm = "Rooms per dwelling"))
+
+  expect_true("Rooms per dwelling" %in% .varpro_axis_labels(p))
+})


### PR DESCRIPTION
Closes #239.

`plot.gg_beta_varpro()`, `plot.gg_ivarpro()` and `plot.gg_beta_uvarpro()` were the last varPro importance plots without `labels=`, and they were the worst of the set.

## The failure was silent

Each declares `#' @param ... Not currently used.` and genuinely does not use `...`, so `labels=` was absorbed with **no warning, no error**, and an unlabelled plot as the only symptom:

```r
plot(gg_varpro(v),                    labels = c(wt = "Weight"))  # labelled
plot(gg_beta_varpro(v, beta_fit = b), labels = c(wt = "Weight"))  # silently unlabelled
```

This is worse than the `plot.gg_rhf_importance()` case fixed in #238, where the argument at least reached `geom_point()` and tripped ggplot2's `Ignoring unknown parameters` warning. The red test run for this branch reported `WARN 0`, confirming nothing was emitted.

## What changed

All three reuse `.forest_labels()` / `.apply_forest_labels()` from `R/utils.R`, so the three input shapes and the per-variable raw-name fallback are unchanged. All three `coord_flip()`, so the labelled scale is `scale_x_discrete()`, exactly as in `plot.gg_vimp()`. No new label-resolution logic.

Since `...` is documented and verified unused, `labels = NULL` sits directly after `x`, matching `plot.gg_varpro()` rather than the trailing placement `plot.gg_rhf_importance()` needed.

## One correction to the issue

#239 said the faceted methods "likely want `.forest_strip_labeller()` on the strips too." **That would have been a bug.** They `facet_wrap(~ class)`, so the strips carry outcome-class names (`setosa`, `versicolor`), not variable names. Applying a variable-label lookup to them would relabel the wrong thing. Only the variable axis is relabelled; the class strips are left alone. A test asserts the axis is relabelled in *every* panel while faceted.

## Tests

31 new assertions across the three existing `test_gg_*.R` files, all data-carrying against built scale labels:

- the three `labels=` shapes resolve onto the axis
- per-variable fallback to the raw name
- **both `plot.gg_ivarpro()` geom branches** (jitter distribution, and the `which_obs` bar path) — they build different geoms
- per-panel labelling under class facets, asserting `length(panels) > 1` so the test cannot pass vacuously
- `labels = NULL` reproduces raw names
- warn-once when nothing resolves
- raw names **and factor level order** survive relabelling

A shared `.varpro_axis_labels()` accessor was added to `helper-varpro-fixtures.R` rather than triplicated. Tests reuse the existing memoised fixtures; `gg_beta_uvarpro` uses the stub path and needs no varPro fit.

## Definition of done

| Gate | Result |
|---|---|
| `devtools::document()` | 3 `.Rd` regenerated |
| `lintr::lint_package()` | 0 lints |
| `NOT_CRAN=true VDIFFR_RUN_TESTS=true devtools::test()` | 0 failures, **1898 pass** (was 1867), 6 skips |
| vdiffr baselines | 54 before, 54 after; tree byte-identical, no pruning |
| `R CMD check --as-cran` (with manual, clean `git archive` export) | **1 NOTE**, 0 WARNING, 0 ERROR |

The NOTE is `checking CRAN incoming feasibility` — the maintainer-cadence note. Wall time 3:57. Tarball gate: only `ggRandomForests/.Rinstignore` matches `/\.[^/]+`, `cran-comments` count 0.

No version bump: `4.0.0` is an unreleased development line and the NEWS entry goes under its open section.

## Not in this PR

`plot.gg_shap(type = "importance")` is also an importance plot and still has no `labels`. It was outside #239's scope and has a different shape (beeswarm and dependence modes alongside importance), so it wants its own decision rather than being folded in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)