### PR TITLE
Add labels= to plot.gg_shap() and the three shap_* mode functions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -99,6 +99,16 @@ ggRandomForests v4.0.0 (development)
   error, and an unlabelled plot as the only symptom. Their facets are per class
   rather than per variable, so the class strips are left alone and only the
   variable axis is relabelled; in a faceted plot every panel is relabelled.
+* `plot.gg_shap()` and the three exported mode functions it dispatches to,
+  `shap_importance()`, `shap_beeswarm()` and `shap_dependence()`, gain
+  `labels`. Each of the three puts variable names somewhere different, so each
+  honours the argument differently: `shap_importance()` labels a flipped
+  discrete `x` scale, `shap_beeswarm()` labels `y` directly because it does not
+  flip, and `shap_dependence()` has no variable scale at all and substitutes
+  the label into both axis titles instead. In that last mode `xvar` still
+  matches on raw variable names, so the label is display only and passing a
+  label where a variable name belongs is still an error. As with the varPro
+  methods above, `labels` was previously accepted and discarded in silence.
 * `plot.gg_vimp()`: `lbls` is **deprecated** in favour of `labels` and will be
   removed in a future release. Its old `length(lbls) >= length(vars)` gate is
   also gone, so a partial label set is now honoured, falling back to the raw

--- a/R/plot.gg_shap.R
+++ b/R/plot.gg_shap.R
@@ -10,6 +10,12 @@
 #'   \code{"dependence"}.
 #' @param xvar For \code{type = "dependence"}, the variable to plot. When
 #'   \code{NULL}, the top-ranked variable is used.
+#' @param labels Optional variable labels, forwarded to the mode function. One
+#'   of: a named character vector (`c(Temp = "Temperature")`); a labelled data
+#'   frame, whose \code{attr(col, "label")} values are read; or a two-column
+#'   \code{key}/\code{label} data frame. Variables with no label keep their raw
+#'   name. In \code{"dependence"} mode the label is substituted into the axis
+#'   titles; \code{xvar} still matches on raw names.
 #' @param ... Passed to the underlying builder.
 #'
 #' @return A \code{ggplot} object.
@@ -28,12 +34,12 @@
 #'
 #' @export
 plot.gg_shap <- function(x, type = c("beeswarm", "importance", "dependence"),
-                         xvar = NULL, ...) {
+                         xvar = NULL, labels = NULL, ...) {
   type <- match.arg(type)
   switch(type,
-         beeswarm   = shap_beeswarm(x, ...),
-         importance = shap_importance(x, ...),
-         dependence = shap_dependence(x, xvar = xvar, ...))
+         beeswarm   = shap_beeswarm(x, labels = labels, ...),
+         importance = shap_importance(x, labels = labels, ...),
+         dependence = shap_dependence(x, xvar = xvar, labels = labels, ...))
 }
 
 #' SHAP global importance bar chart
@@ -42,20 +48,34 @@ plot.gg_shap <- function(x, type = c("beeswarm", "importance", "dependence"),
 #' \code{\link{plot.gg_vimp}}.
 #'
 #' @param x A \code{\link{gg_shap}} object.
+#' @param labels Optional variable labels. One of: a named character vector
+#'   (`c(Temp = "Temperature")`); a labelled data frame, whose
+#'   \code{attr(col, "label")} values are read; or a two-column
+#'   \code{key}/\code{label} data frame. Variables with no label keep their raw
+#'   name. Defaults to \code{NULL} (raw names).
 #' @param ... Unused.
 #'
 #' @return A \code{ggplot} object.
 #' @seealso \code{\link{gg_shap}} \code{\link{plot.gg_shap}}
 #' @export
-shap_importance <- function(x, ...) {
+shap_importance <- function(x, labels = NULL, ...) {
   imp <- dplyr::summarise(dplyr::group_by(x, .data$vars),
                           mean_abs = mean(abs(.data$shap)), .groups = "drop")
-  ggplot2::ggplot(imp) +
+  gg_plt <- ggplot2::ggplot(imp) +
     ggplot2::geom_bar(
       ggplot2::aes(x = .data$vars, y = .data$mean_abs),
       stat = "identity", width = 0.5) +
     ggplot2::coord_flip() +
     ggplot2::labs(x = "", y = "mean(|SHAP|)")
+
+  # coord_flip(), so the variable axis is a flipped x, as in plot.gg_vimp().
+  lab_lookup <- .forest_labels(labels)
+  if (!is.null(lab_lookup)) {
+    gg_plt <- gg_plt + ggplot2::scale_x_discrete(
+      labels = function(v) .apply_forest_labels(v, lab_lookup)
+    )
+  }
+  gg_plt
 }
 
 #' SHAP beeswarm summary plot
@@ -67,12 +87,17 @@ shap_importance <- function(x, ...) {
 #' render as a neutral gray (no numeric value to scale).
 #'
 #' @param x A \code{\link{gg_shap}} object.
+#' @param labels Optional variable labels. One of: a named character vector
+#'   (`c(Temp = "Temperature")`); a labelled data frame, whose
+#'   \code{attr(col, "label")} values are read; or a two-column
+#'   \code{key}/\code{label} data frame. Variables with no label keep their raw
+#'   name. Defaults to \code{NULL} (raw names).
 #' @param ... Unused.
 #'
 #' @return A \code{ggplot} object.
 #' @seealso \code{\link{gg_shap}} \code{\link{plot.gg_shap}}
 #' @export
-shap_beeswarm <- function(x, ...) {
+shap_beeswarm <- function(x, labels = NULL, ...) {
   x <- dplyr::mutate(dplyr::group_by(x, .data$vars),
                      value_scaled = {
                        finite_vals <- .data$value[is.finite(.data$value)]
@@ -90,7 +115,7 @@ shap_beeswarm <- function(x, ...) {
                      })
   x <- dplyr::ungroup(x)
 
-  ggplot2::ggplot(x, ggplot2::aes(x = .data$shap, y = .data$vars)) +
+  gg_plt <- ggplot2::ggplot(x, ggplot2::aes(x = .data$shap, y = .data$vars)) +
     ggplot2::geom_vline(xintercept = 0, linetype = 2, color = "gray60") +
     ggplot2::geom_jitter(ggplot2::aes(color = .data$value_scaled),
                          height = 0.2, width = 0, alpha = 0.6) +
@@ -98,6 +123,16 @@ shap_beeswarm <- function(x, ...) {
                                     breaks = c(0, 1),
                                     labels = c("Low", "High")) +
     ggplot2::labs(x = "SHAP value (impact on prediction)", y = "")
+
+  # No coord_flip() here: vars are mapped to y directly, so the labelled scale
+  # is scale_y_discrete().
+  lab_lookup <- .forest_labels(labels)
+  if (!is.null(lab_lookup)) {
+    gg_plt <- gg_plt + ggplot2::scale_y_discrete(
+      labels = function(v) .apply_forest_labels(v, lab_lookup)
+    )
+  }
+  gg_plt
 }
 
 #' SHAP dependence plot
@@ -109,12 +144,17 @@ shap_beeswarm <- function(x, ...) {
 #' @param x A \code{\link{gg_shap}} object.
 #' @param xvar The variable to plot. When \code{NULL}, the top-ranked variable
 #'   (largest mean absolute SHAP) is used.
+#' @param labels Optional variable labels. One of: a named character vector
+#'   (`c(Temp = "Temperature")`); a labelled data frame, whose
+#'   \code{attr(col, "label")} values are read; or a two-column
+#'   \code{key}/\code{label} data frame. Variables with no label keep their raw
+#'   name. Defaults to \code{NULL} (raw names).
 #' @param ... Unused.
 #'
 #' @return A \code{ggplot} object.
 #' @seealso \code{\link{gg_shap}} \code{\link{plot.gg_shap}}
 #' @export
-shap_dependence <- function(x, xvar = NULL, ...) {
+shap_dependence <- function(x, xvar = NULL, labels = NULL, ...) {
   # vars levels are reversed (most important last); top variable is the last
   # level.
   if (is.null(xvar)) {
@@ -128,9 +168,15 @@ shap_dependence <- function(x, xvar = NULL, ...) {
   sub <- x[as.character(x$vars) == xvar, , drop = FALSE]
   is_numeric_feature <- any(!is.na(sub$value))
 
+  # There is no discrete variable scale in this mode: the variable name appears
+  # in the axis titles.  Resolve xvar against the raw names first (above), then
+  # substitute the display label, so 'labels' stays display-only.
+  xvar_display <- .apply_forest_labels(xvar, .forest_labels(labels))
+
   gg_plt <- ggplot2::ggplot(sub) +
     ggplot2::geom_hline(yintercept = 0, linetype = 2, color = "gray60") +
-    ggplot2::labs(x = xvar, y = paste("SHAP value for", xvar))
+    ggplot2::labs(x = xvar_display,
+                  y = paste("SHAP value for", xvar_display))
 
   if (is_numeric_feature) {
     gg_plt + ggplot2::geom_point(

--- a/man/plot.gg_shap.Rd
+++ b/man/plot.gg_shap.Rd
@@ -4,7 +4,13 @@
 \alias{plot.gg_shap}
 \title{Plot a \code{\link{gg_shap}} object}
 \usage{
-\method{plot}{gg_shap}(x, type = c("beeswarm", "importance", "dependence"), xvar = NULL, ...)
+\method{plot}{gg_shap}(
+  x,
+  type = c("beeswarm", "importance", "dependence"),
+  xvar = NULL,
+  labels = NULL,
+  ...
+)
 }
 \arguments{
 \item{x}{A \code{\link{gg_shap}} object.}
@@ -14,6 +20,13 @@
 
 \item{xvar}{For \code{type = "dependence"}, the variable to plot. When
 \code{NULL}, the top-ranked variable is used.}
+
+\item{labels}{Optional variable labels, forwarded to the mode function. One
+of: a named character vector (\code{c(Temp = "Temperature")}); a labelled data
+frame, whose \code{attr(col, "label")} values are read; or a two-column
+\code{key}/\code{label} data frame. Variables with no label keep their raw
+name. In \code{"dependence"} mode the label is substituted into the axis
+titles; \code{xvar} still matches on raw names.}
 
 \item{...}{Passed to the underlying builder.}
 }

--- a/man/shap_beeswarm.Rd
+++ b/man/shap_beeswarm.Rd
@@ -4,10 +4,16 @@
 \alias{shap_beeswarm}
 \title{SHAP beeswarm summary plot}
 \usage{
-shap_beeswarm(x, ...)
+shap_beeswarm(x, labels = NULL, ...)
 }
 \arguments{
 \item{x}{A \code{\link{gg_shap}} object.}
+
+\item{labels}{Optional variable labels. One of: a named character vector
+(\code{c(Temp = "Temperature")}); a labelled data frame, whose
+\code{attr(col, "label")} values are read; or a two-column
+\code{key}/\code{label} data frame. Variables with no label keep their raw
+name. Defaults to \code{NULL} (raw names).}
 
 \item{...}{Unused.}
 }

--- a/man/shap_dependence.Rd
+++ b/man/shap_dependence.Rd
@@ -4,13 +4,19 @@
 \alias{shap_dependence}
 \title{SHAP dependence plot}
 \usage{
-shap_dependence(x, xvar = NULL, ...)
+shap_dependence(x, xvar = NULL, labels = NULL, ...)
 }
 \arguments{
 \item{x}{A \code{\link{gg_shap}} object.}
 
 \item{xvar}{The variable to plot. When \code{NULL}, the top-ranked variable
 (largest mean absolute SHAP) is used.}
+
+\item{labels}{Optional variable labels. One of: a named character vector
+(\code{c(Temp = "Temperature")}); a labelled data frame, whose
+\code{attr(col, "label")} values are read; or a two-column
+\code{key}/\code{label} data frame. Variables with no label keep their raw
+name. Defaults to \code{NULL} (raw names).}
 
 \item{...}{Unused.}
 }

--- a/man/shap_importance.Rd
+++ b/man/shap_importance.Rd
@@ -4,10 +4,16 @@
 \alias{shap_importance}
 \title{SHAP global importance bar chart}
 \usage{
-shap_importance(x, ...)
+shap_importance(x, labels = NULL, ...)
 }
 \arguments{
 \item{x}{A \code{\link{gg_shap}} object.}
+
+\item{labels}{Optional variable labels. One of: a named character vector
+(\code{c(Temp = "Temperature")}); a labelled data frame, whose
+\code{attr(col, "label")} values are read; or a two-column
+\code{key}/\code{label} data frame. Variables with no label keep their raw
+name. Defaults to \code{NULL} (raw names).}
 
 \item{...}{Unused.}
 }

--- a/tests/testthat/test_gg_shap.R
+++ b/tests/testthat/test_gg_shap.R
@@ -265,3 +265,127 @@ test_that("gg_shap rejects which.class that is not a whole, finite number", {
   expect_error(gg_shap(rf_rf, bg_n = 20, which.class = 2.9), "single integer")
   expect_error(gg_shap(rf_rf, bg_n = 20, which.class = 99), "out of range")
 })
+
+## ---- labels= across the three modes (issue #241) ---------------------------
+
+# Session-memoised so the eight blocks below share one forest fit and one
+# kernelshap run.  The file's older blocks each build their own; this is the
+# pattern helper-varpro-fixtures.R uses, and it keeps the added cost near zero.
+.shap_cache <- new.env(parent = emptyenv())
+
+.gg_shap_airq <- function() {
+  if (is.null(.shap_cache$g)) {
+    set.seed(20260817L)
+    rf <- randomForestSRC::rfsrc(Ozone ~ ., data = na.omit(airquality),
+                                 ntree = 50)
+    set.seed(42)
+    .shap_cache$g <- gg_shap(rf, bg_n = 20)
+  }
+  .shap_cache$g
+}
+
+# vars sit on a flipped x scale for importance and on y for beeswarm, so
+# collect both and let the caller assert membership.
+.shap_axis_labels <- function(p) {
+  built <- ggplot2::ggplot_build(p)
+  unlist(lapply(built$layout$panel_params, function(pp) {
+    c(as.character(pp$x$get_labels()), as.character(pp$y$get_labels()))
+  }))
+}
+
+test_that("shap_importance labels the variable axis", {
+  skip_if_not_installed("kernelshap")
+  skip_on_cran()
+  g <- .gg_shap_airq()
+  axis <- .shap_axis_labels(shap_importance(g, labels = c(Temp = "Temperature")))
+
+  expect_true("Temperature" %in% axis)
+  expect_false("Temp" %in% axis)
+  expect_true("Wind" %in% axis)          # unlabelled falls back to raw name
+})
+
+test_that("shap_beeswarm labels the variable axis", {
+  skip_if_not_installed("kernelshap")
+  skip_on_cran()
+  set.seed(42)                            # beeswarm jitters at build time
+  g <- .gg_shap_airq()
+  axis <- .shap_axis_labels(shap_beeswarm(g, labels = c(Temp = "Temperature")))
+
+  expect_true("Temperature" %in% axis)
+  expect_true("Wind" %in% axis)
+})
+
+test_that("shap_dependence substitutes the label into both axis titles", {
+  skip_if_not_installed("kernelshap")
+  skip_on_cran()
+  g <- .gg_shap_airq()
+  p <- shap_dependence(g, xvar = "Temp", labels = c(Temp = "Temperature"))
+
+  expect_equal(p$labels$x, "Temperature")
+  expect_equal(p$labels$y, "SHAP value for Temperature")
+})
+
+test_that("shap_dependence still resolves xvar against raw names", {
+  skip_if_not_installed("kernelshap")
+  skip_on_cran()
+  g <- .gg_shap_airq()
+
+  # The label is display only: passing the *label* as xvar must still error.
+  expect_error(
+    shap_dependence(g, xvar = "Temperature", labels = c(Temp = "Temperature")),
+    "Temperature"
+  )
+  expect_s3_class(
+    shap_dependence(g, xvar = "Temp", labels = c(Temp = "Temperature")),
+    "ggplot"
+  )
+})
+
+test_that("shap_dependence falls back to the raw name in its titles", {
+  skip_if_not_installed("kernelshap")
+  skip_on_cran()
+  g <- .gg_shap_airq()
+  p <- shap_dependence(g, xvar = "Wind", labels = c(Temp = "Temperature"))
+
+  expect_equal(p$labels$x, "Wind")
+  expect_equal(p$labels$y, "SHAP value for Wind")
+})
+
+test_that("plot.gg_shap forwards labels to every mode", {
+  skip_if_not_installed("kernelshap")
+  skip_on_cran()
+  set.seed(42)
+  g <- .gg_shap_airq()
+  lb <- c(Temp = "Temperature")
+
+  expect_true("Temperature" %in%
+                .shap_axis_labels(plot(g, type = "importance", labels = lb)))
+  expect_true("Temperature" %in%
+                .shap_axis_labels(plot(g, type = "beeswarm", labels = lb)))
+  expect_equal(plot(g, type = "dependence", xvar = "Temp", labels = lb)$labels$x,
+               "Temperature")
+})
+
+test_that("labels = NULL leaves every mode unchanged", {
+  skip_if_not_installed("kernelshap")
+  skip_on_cran()
+  set.seed(42)
+  g <- .gg_shap_airq()
+
+  expect_true("Temp" %in% .shap_axis_labels(shap_importance(g)))
+  expect_true("Temp" %in% .shap_axis_labels(shap_beeswarm(g)))
+  expect_equal(shap_dependence(g, xvar = "Temp")$labels$x, "Temp")
+})
+
+test_that("gg_shap labels warn once when nothing resolves, and never touch the data", {
+  skip_if_not_installed("kernelshap")
+  skip_on_cran()
+  g <- .gg_shap_airq()
+
+  expect_warning(shap_importance(g, labels = c(Temp = "")), "No variable labels")
+
+  # Ordering is meaningful here: vars levels are reversed, top variable last.
+  p <- shap_importance(g, labels = c(Temp = "Temperature"))
+  expect_true("Temp" %in% as.character(p$data$vars))
+  expect_equal(levels(p$data$vars), levels(g$vars))
+})


### PR DESCRIPTION
Closes #241. This is the last importance surface without `labels=`.

## The silent drop

`plot.gg_shap()` forwards `...` to its mode functions, each of which declared `#' @param ... Unused.`, so `labels=` was absorbed with no warning and no error. Verified on `4.0.0` at `fefe0763` before the fix, and the red test run reported `WARN 0`.

## Not a copy of #240

`gg_shap` is three plots behind one generic, and each puts variable names somewhere structurally different. That is why this needed its own design rather than the varPro patch applied three more times.

| Mode | Where variable names appear | Lever |
|---|---|---|
| `shap_importance()` | `aes(x = vars)` + `coord_flip()` | `scale_x_discrete()`, as in `plot.gg_vimp()` |
| `shap_beeswarm()` | `aes(y = vars)`, **no** `coord_flip()` | `scale_y_discrete()`, as in `plot.gg_rhf_importance()` |
| `shap_dependence()` | the **axis titles** — there is no variable scale | substitution into `labs()` |

### Ordering matters in dependence mode

`xvar` is validated against `levels(x$vars)`. The resolution order is therefore: resolve and validate `xvar` on **raw** names first, *then* compute the display label. Reversed, `labels` would stop being display-only and passing `"Temperature"` as `xvar` would silently start working, making the label part of the lookup key. A test asserts that still errors.

## Maintainer decision applied

Per the [decision recorded on the issue](https://github.com/ehrlinger/ggRandomForests/issues/241#issuecomment-5462223701), `labels` goes on **all four** entry points, not the dispatcher alone. `shap_importance()`, `shap_beeswarm()` and `shap_dependence()` are each exported (`NAMESPACE` 166-168), so a direct call now honours the argument too. `plot.gg_shap()` forwards it explicitly rather than through `...`.

## Tests

20 new assertions in `test_gg_shap.R`:

- each mode labels its own surface, via the correct scale or title
- `xvar` still resolves against raw names, and passing a label errors
- unlabelled variables fall back to their raw name, in scales and in titles
- `plot.gg_shap()` forwards to all three modes
- `labels = NULL` leaves every mode unchanged
- warn-once when nothing resolves
- raw names and the `vars` factor level order (reversed, top variable last) survive relabelling

They share a **session-memoised `gg_shap` fixture**, so the eight blocks cost one forest fit and one kernelshap run between them. The file's older blocks each build their own; those are left alone.

## Definition of done

| Gate | Result |
|---|---|
| `devtools::document()` | 4 `.Rd` regenerated |
| `lintr::lint_package()` | 0 lints |
| `NOT_CRAN=true VDIFFR_RUN_TESTS=true devtools::test()` | 0 failures, **1918 pass** (was 1898), 6 skips |
| vdiffr baselines | 54 before, 54 after; tree byte-identical, no pruning |
| `R CMD check --as-cran` (with manual, clean `git archive` export) | **1 NOTE**, 0 WARNING, 0 ERROR |

The NOTE is `checking CRAN incoming feasibility` — the maintainer-cadence note. Tarball gate: only `ggRandomForests/.Rinstignore` matches `/\.[^/]+`, `cran-comments` count 0.

No version bump: `4.0.0` is an unreleased development line and the NEWS entry goes under its open section.

## Result, and a correction

`labels=` is now on twelve entry points: the five from #236, `plot.gg_rhf_importance()` from #238, the three varPro methods from #240, and these four. That completes every **importance** plot in the package.

It does **not** complete every plot that renders variable names, which I initially claimed here. Auditing the remaining methods turned up two more:

- **`plot.gg_variable()`** — `facet_wrap(~variable)`, so the facet strips carry predictor names. This is the case `.forest_strip_labeller()` was actually built for, and it is the only remaining site where that helper is the right tool.
- **`plot.gg_udependent()`** — a `ggraph` network whose nodes *are* variables, drawn with `geom_node_label(aes(label = name))`. Not a scale and not a strip, so it needs its own approach.

(`plot.gg_rfsrc()` also maps `aes(x = variable)`, but there `variable` is class-probability column names, not predictors, so variable labels do not apply.)

Both are out of scope here and neither is tracked yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
