### PR TITLE
Add labels= to the last three plot methods that render variable names

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -109,6 +109,17 @@ ggRandomForests v4.0.0 (development)
   matches on raw variable names, so the label is display only and passing a
   label where a variable name belongs is still an error. As with the varPro
   methods above, `labels` was previously accepted and discarded in silence.
+* `plot.gg_variable()`, `plot.gg_udependent()` and `plot.gg_sdependent()` gain
+  `labels`, which completes the argument across every plot method in the
+  package that renders variable names. `plot.gg_variable()` labels the facet strips in its panel
+  plot, through all three faceting branches, and the x axis title in its
+  individual plot; the `time` facet is untouched, because it facets by time
+  rather than by variable. `plot.gg_udependent()` labels the node text of its dependency
+  network. There the display string is written to a separate vertex attribute
+  and the igraph `name` is left alone, because `name` is the key the
+  edge-weight backfill matches on and rewriting it would break edge weights on
+  graphs saved before those weights were stored. `plot.gg_sdependent()` is the
+  plain case, a flipped discrete axis like `plot.gg_vimp()`.
 * `plot.gg_vimp()`: `lbls` is **deprecated** in favour of `labels` and will be
   removed in a future release. Its old `length(lbls) >= length(vars)` gate is
   also gone, so a partial label set is now honoured, falling back to the raw

--- a/NEWS.md
+++ b/NEWS.md
@@ -114,7 +114,9 @@ ggRandomForests v4.0.0 (development)
   package that renders variable names. `plot.gg_variable()` labels the facet strips in its panel
   plot, through all three faceting branches, and the x axis title in its
   individual plot; the `time` facet is untouched, because it facets by time
-  rather than by variable. `plot.gg_udependent()` labels the node text of its dependency
+  rather than by variable, and the multi-time survival panel scopes its
+  labeller to the variable dimension so a label key that collides with a time
+  value cannot reach the time strips. `plot.gg_udependent()` labels the node text of its dependency
   network. There the display string is written to a separate vertex attribute
   and the igraph `name` is left alone, because `name` is the key the
   edge-weight backfill matches on and rewriting it would break edge weights on

--- a/R/plot.gg_sdependent.R
+++ b/R/plot.gg_sdependent.R
@@ -14,6 +14,11 @@
 #' connect, and with [gg_beta_uvarpro()] for the lasso-importance ranking.
 #'
 #' @param x A `gg_sdependent` object from [gg_sdependent()].
+#' @param labels Optional variable labels for the variable axis. One of: a
+#'   named character vector (`c(bpd = "BP Diastole")`); a labelled data frame,
+#'   whose `attr(col, "label")` values are read; or a two-column `key`/`label`
+#'   data frame. Variables with no label keep their raw name. Defaults to
+#'   `NULL` (raw names).
 #' @param ... Not currently used.
 #'
 #' @return A `ggplot` object.
@@ -33,7 +38,7 @@
 #' @importFrom ggplot2 ggplot aes geom_segment geom_point coord_flip
 #' @importFrom ggplot2 scale_color_manual labs theme_minimal
 #' @export
-plot.gg_sdependent <- function(x, ...) {
+plot.gg_sdependent <- function(x, labels = NULL, ...) {
   if (nrow(x) == 0L) {
     stop("plot.gg_sdependent: nothing to plot (gg_sdependent has 0 rows).",
          call. = FALSE)
@@ -47,7 +52,7 @@ plot.gg_sdependent <- function(x, ...) {
     n_signal, nrow(x), thr
   )
 
-  ggplot2::ggplot(
+  gg_plt <- ggplot2::ggplot(
     x,
     ggplot2::aes(
       x     = .data[["variable"]],
@@ -73,4 +78,13 @@ plot.gg_sdependent <- function(x, ...) {
       caption = caption_txt
     ) +
     ggplot2::theme_minimal()
+
+  # coord_flip(), so the variable axis is a flipped x, as in plot.gg_vimp().
+  lab_lookup <- .forest_labels(labels)
+  if (!is.null(lab_lookup)) {
+    gg_plt <- gg_plt + ggplot2::scale_x_discrete(
+      labels = function(v) .apply_forest_labels(v, lab_lookup)
+    )
+  }
+  gg_plt
 }

--- a/R/plot.gg_udependent.R
+++ b/R/plot.gg_udependent.R
@@ -39,6 +39,11 @@
 #'   choices are \code{"fr"} (Fruchterman-Reingold, the default),
 #'   \code{"kk"} (Kamada-Kawai), \code{"stress"}, \code{"circle"}, and
 #'   \code{"grid"}.
+#' @param labels Optional variable labels for the node text. One of: a named
+#'   character vector (\code{c(bpd = "BP Diastole")}); a labelled data frame,
+#'   whose \code{attr(col, "label")} values are read; or a two-column
+#'   \code{key}/\code{label} data frame. Nodes with no label keep their raw
+#'   name. Defaults to \code{NULL} (raw names).
 #' @param ... Not currently used.
 #'
 #' @details
@@ -68,7 +73,7 @@
 #' @importFrom ggplot2 aes labs scale_color_manual theme_void
 #' @importFrom igraph vertex_attr V edge_attr as_data_frame E
 #' @export
-plot.gg_udependent <- function(x, layout = "fr", ...) {
+plot.gg_udependent <- function(x, layout = "fr", labels = NULL, ...) {
   prov <- attr(x, "provenance")
 
   if (is.null(x$graph) || nrow(x$edges) == 0L) {
@@ -113,6 +118,14 @@ plot.gg_udependent <- function(x, layout = "fr", ...) {
     igraph::E(x$graph)$weight <- x$edges$weight[idx]
   }
 
+  ## Node text is a display concern.  'name' is the igraph vertex key that the
+  ## edge-weight backfill above matches on, so write the display string to a
+  ## separate attribute and leave the key alone.  Set unconditionally so the
+  ## aes() below is the same in both branches.
+  lab_lookup <- .forest_labels(labels)
+  igraph::V(x$graph)$node_label <-
+    .apply_forest_labels(igraph::V(x$graph)$name, lab_lookup)
+
   ggraph::ggraph(x$graph, layout = layout) +
     ggraph::geom_edge_link(
       ggplot2::aes(width = .data[["weight"]],
@@ -124,7 +137,7 @@ plot.gg_udependent <- function(x, layout = "fr", ...) {
                    size  = .data[["degree"]])
     ) +
     ggraph::geom_node_label(
-      ggplot2::aes(label = .data[["name"]]),
+      ggplot2::aes(label = .data[["node_label"]]),
       size = 3, show.legend = FALSE
     ) +
     ggplot2::scale_color_manual(

--- a/R/plot.gg_variable.R
+++ b/R/plot.gg_variable.R
@@ -24,6 +24,12 @@
 #' @param oob oob estimates (boolean)
 #' @param points plot the raw data points (boolean)
 #' @param smooth include a smooth curve (boolean)
+#' @param labels Optional variable labels. One of: a named character vector
+#'   (\code{c(wt = "Weight")}); a labelled data frame, whose
+#'   \code{attr(col, "label")} values are read; or a two-column
+#'   \code{key}/\code{label} data frame. Variables with no label keep their raw
+#'   name. Applied to the facet strips in the panel plot and to the x axis title
+#'   in the individual plot. Defaults to \code{NULL} (raw names).
 #' @param ... arguments passed to the \code{ggplot2} functions.
 #'
 #' @return A single \code{ggplot} object when \code{length(xvar) == 1} or
@@ -133,8 +139,18 @@ plot.gg_variable <- function(x, # nolint: cyclocomp_linter
                              oob = TRUE,
                              points = TRUE,
                              smooth = TRUE,
+                             labels = NULL,
                              ...) {
   gg_dta <- x
+
+  ## Resolve the label lookup ONCE.  .forest_strip_labeller() would resolve it
+  ## again internally, and a lookup that matches nothing warns on every
+  ## resolution, so a second call would double the warning.  Strips and axis
+  ## titles are both built from this one lookup.
+  lab_lookup <- .forest_labels(labels)
+  strip_labeller <- ggplot2::as_labeller(
+    function(v) .apply_forest_labels(v, lab_lookup)
+  )
 
   # I don't think this will work with latest S3 models.
   if (inherits(x, "rfsrc")) {
@@ -313,12 +329,13 @@ plot.gg_variable <- function(x, # nolint: cyclocomp_linter
       if (length(levels(gg_dta$time)) > 1) {
         gg_plt <- gg_plt +
           ggplot2::facet_grid(stats::reformulate("variable", "time"),
-            scales = "free_x"
+            scales = "free_x", labeller = strip_labeller
           ) +
           labs(x = "")
       } else {
         gg_plt <- gg_plt +
-          ggplot2::facet_wrap(~variable, scales = "free_x") +
+          ggplot2::facet_wrap(~variable, scales = "free_x",
+                              labeller = strip_labeller) +
           labs(
             x = "",
             y = paste("Survival at", gg_dta$time[1], "year")
@@ -420,7 +437,8 @@ plot.gg_variable <- function(x, # nolint: cyclocomp_linter
       }
 
       gg_plt <- gg_plt +
-        ggplot2::facet_wrap(~variable, scales = "free_x") +
+        ggplot2::facet_wrap(~variable, scales = "free_x",
+                              labeller = strip_labeller) +
         ggplot2::labs(x = "")
     }
 
@@ -435,6 +453,9 @@ plot.gg_variable <- function(x, # nolint: cyclocomp_linter
       # Temporarily rename the target predictor column to "var" for aes()
       ch_indx <- which(colnames(gg_dta) == xvar[ind])
       h_name <- colnames(gg_dta)[ch_indx]
+      # Display name for axis titles only.  h_name stays raw: it is written back
+      # to colnames() at the foot of this loop.
+      h_display <- .apply_forest_labels(h_name, lab_lookup)
       colnames(gg_dta)[ch_indx] <- "var"
       # Use only the primary class (class() can return multiple strings, e.g.
       # c("POSIXct", "POSIXt")); a multi-element vector in if() triggers a warning.
@@ -446,7 +467,7 @@ plot.gg_variable <- function(x, # nolint: cyclocomp_linter
       ## ---- Survival individual plot -----------------------------------
       if (family == "surv") {
         gg_plt[[ind]] <- gg_plt[[ind]] +
-          ggplot2::labs(x = h_name, y = "Survival")
+          ggplot2::labs(x = h_display, y = "Survival")
 
         if (ccls_var == "numeric") {
           # Continuous predictor: scatter (and optional smooth)
@@ -495,7 +516,7 @@ plot.gg_variable <- function(x, # nolint: cyclocomp_linter
         } else {
           gg_plt[[ind]] <- gg_plt[[ind]] +
             ggplot2::labs(
-              x = h_name,
+              x = h_display,
               y = paste("Survival at", gg_dta$time[1], "year")
             )
         }
@@ -503,7 +524,7 @@ plot.gg_variable <- function(x, # nolint: cyclocomp_linter
       ## ---- Classification individual plot ----------------------------
       } else if (family == "class") {
         gg_plt[[ind]] <- gg_plt[[ind]] +
-          ggplot2::labs(x = h_name, y = "Predicted")
+          ggplot2::labs(x = h_display, y = "Predicted")
 
         if (sum(colnames(gg_dta) == "outcome") == 0) {
           # Single-outcome (binary) classification
@@ -609,7 +630,7 @@ plot.gg_variable <- function(x, # nolint: cyclocomp_linter
       } else {
         # assume regression
         gg_plt[[ind]] <- gg_plt[[ind]] +
-          ggplot2::labs(x = h_name, y = "Predicted")
+          ggplot2::labs(x = h_display, y = "Predicted")
         if (ccls_var == "numeric") {
           if (points) {
             gg_plt[[ind]] <- gg_plt[[ind]] +

--- a/R/plot.gg_variable.R
+++ b/R/plot.gg_variable.R
@@ -328,8 +328,12 @@ plot.gg_variable <- function(x, # nolint: cyclocomp_linter
       # Multiple time points: grid of (time × variable); single time: wrap
       if (length(levels(gg_dta$time)) > 1) {
         gg_plt <- gg_plt +
+          ## Scope the labeller to the 'variable' dimension only.  A bare
+          ## labeller here would also be applied to the 'time' strips, so a
+          ## lookup key that happened to equal a time value would relabel them.
           ggplot2::facet_grid(stats::reformulate("variable", "time"),
-            scales = "free_x", labeller = strip_labeller
+            scales = "free_x",
+            labeller = ggplot2::labeller(variable = strip_labeller)
           ) +
           labs(x = "")
       } else {

--- a/man/plot.gg_sdependent.Rd
+++ b/man/plot.gg_sdependent.Rd
@@ -4,10 +4,16 @@
 \alias{plot.gg_sdependent}
 \title{Plot a \code{gg_sdependent} object}
 \usage{
-\method{plot}{gg_sdependent}(x, ...)
+\method{plot}{gg_sdependent}(x, labels = NULL, ...)
 }
 \arguments{
 \item{x}{A \code{gg_sdependent} object from \code{\link[=gg_sdependent]{gg_sdependent()}}.}
+
+\item{labels}{Optional variable labels for the variable axis. One of: a
+named character vector (\code{c(bpd = "BP Diastole")}); a labelled data frame,
+whose \code{attr(col, "label")} values are read; or a two-column \code{key}/\code{label}
+data frame. Variables with no label keep their raw name. Defaults to
+\code{NULL} (raw names).}
 
 \item{...}{Not currently used.}
 }

--- a/man/plot.gg_udependent.Rd
+++ b/man/plot.gg_udependent.Rd
@@ -4,7 +4,7 @@
 \alias{plot.gg_udependent}
 \title{Plot a \code{gg_udependent} variable dependency graph}
 \usage{
-\method{plot}{gg_udependent}(x, layout = "fr", ...)
+\method{plot}{gg_udependent}(x, layout = "fr", labels = NULL, ...)
 }
 \arguments{
 \item{x}{A \code{gg_udependent} object from \code{\link{gg_udependent}}.}
@@ -13,6 +13,12 @@
 choices are \code{"fr"} (Fruchterman-Reingold, the default),
 \code{"kk"} (Kamada-Kawai), \code{"stress"}, \code{"circle"}, and
 \code{"grid"}.}
+
+\item{labels}{Optional variable labels for the node text. One of: a named
+character vector (\code{c(bpd = "BP Diastole")}); a labelled data frame,
+whose \code{attr(col, "label")} values are read; or a two-column
+\code{key}/\code{label} data frame. Nodes with no label keep their raw
+name. Defaults to \code{NULL} (raw names).}
 
 \item{...}{Not currently used.}
 }

--- a/man/plot.gg_variable.Rd
+++ b/man/plot.gg_variable.Rd
@@ -13,6 +13,7 @@
   oob = TRUE,
   points = TRUE,
   smooth = TRUE,
+  labels = NULL,
   ...
 )
 }
@@ -33,6 +34,13 @@
 \item{points}{plot the raw data points (boolean)}
 
 \item{smooth}{include a smooth curve (boolean)}
+
+\item{labels}{Optional variable labels. One of: a named character vector
+(\code{c(wt = "Weight")}); a labelled data frame, whose
+\code{attr(col, "label")} values are read; or a two-column
+\code{key}/\code{label} data frame. Variables with no label keep their raw
+name. Applied to the facet strips in the panel plot and to the x axis title
+in the individual plot. Defaults to \code{NULL} (raw names).}
 
 \item{...}{arguments passed to the \code{ggplot2} functions.}
 }

--- a/tests/testthat/test_gg_sdependent.R
+++ b/tests/testthat/test_gg_sdependent.R
@@ -108,3 +108,41 @@ test_that("gg_sdependent agrees with a live uvarpro + sdependent fit", {
   s <- varPro::sdependent(b, plot = FALSE)
   expect_setequal(as.character(out$variable[out$signal]), s$signal.vars)
 })
+
+## ---- labels= on the variable axis (issue #243) -----------------------------
+
+# coord_flip(), so the variable categories land on the y scale once built.
+.sdep_axis_labels <- function(p) {
+  built <- ggplot2::ggplot_build(p)
+  unlist(lapply(built$layout$panel_params,
+                function(pp) as.character(pp$y$get_labels())))
+}
+
+test_that("plot.gg_sdependent labels the variable axis", {
+  out <- gg_sdependent(.stub_uvarpro(), beta_fit = .mock_entropy_sq())
+  axis <- .sdep_axis_labels(plot(out, labels = c(a = "Alpha channel")))
+
+  expect_true("Alpha channel" %in% axis)
+  expect_false("a" %in% axis)
+  expect_true("b" %in% axis)             # unlabelled falls back to raw name
+})
+
+test_that("plot.gg_sdependent with labels = NULL keeps the raw names", {
+  out <- gg_sdependent(.stub_uvarpro(), beta_fit = .mock_entropy_sq())
+
+  expect_true("a" %in% .sdep_axis_labels(plot(out)))
+})
+
+test_that("plot.gg_sdependent warns once when no label resolves", {
+  out <- gg_sdependent(.stub_uvarpro(), beta_fit = .mock_entropy_sq())
+
+  expect_warning(plot(out, labels = c(a = "")), "No variable labels")
+})
+
+test_that("plot.gg_sdependent keeps raw names and rank order in the data", {
+  out <- gg_sdependent(.stub_uvarpro(), beta_fit = .mock_entropy_sq())
+  p <- plot(out, labels = c(a = "Alpha channel"))
+
+  expect_true("a" %in% as.character(p$data$variable))
+  expect_equal(levels(p$data$variable), levels(out$variable))
+})

--- a/tests/testthat/test_gg_udependent.R
+++ b/tests/testthat/test_gg_udependent.R
@@ -178,3 +178,71 @@ test_that("plot.gg_udependent empty graph -> stop with informative message", {
 ## ── vdiffr snapshots — see test_snapshots.R ──────────────────────────────────
 ## Visual regression tests for plot.gg_udependent are in test_snapshots.R
 ## (guarded by VDIFFR_RUN_TESTS=true), following the package convention.
+
+## ---- labels= on the node text (issue #243) ---------------------------------
+
+# The node text is drawn by geom_node_label(); ggraph resolves node data at
+# build time, so read the built layer rather than the graph.
+.ggu_node_labels <- function(p) {
+  built <- ggplot2::ggplot_build(p)
+  lab <- unlist(lapply(built$data, function(d) {
+    if ("label" %in% names(d)) as.character(d$label) else NULL
+  }))
+  sort(unique(lab))
+}
+
+test_that("plot.gg_udependent labels the node text", {
+  skip_on_cran()
+  skip_if_not_installed("ggraph")
+  gg <- make_ggu()
+  raw <- igraph::V(gg$graph)$name
+  target <- raw[1L]
+
+  p <- plot(gg, labels = stats::setNames("RENAMED NODE", target))
+  labs <- .ggu_node_labels(p)
+
+  expect_true("RENAMED NODE" %in% labs)
+  expect_false(target %in% labs)
+  if (length(raw) > 1L) expect_true(raw[2L] %in% labs)   # fallback per node
+})
+
+test_that("plot.gg_udependent leaves the igraph vertex key untouched", {
+  skip_on_cran()
+  skip_if_not_installed("ggraph")
+  gg <- make_ggu()
+  raw <- igraph::V(gg$graph)$name
+  target <- raw[1L]
+
+  # 'name' is the vertex key the edge-weight backfill matches on, so relabelling
+  # must not rewrite it, and the display string must live on a separate
+  # attribute.
+  expect_null(igraph::vertex_attr(gg$graph, "node_label"))
+
+  p <- plot(gg, labels = stats::setNames("RENAMED NODE", target))
+
+  # The caller's graph is untouched: same key, and still no display attribute.
+  expect_equal(igraph::V(gg$graph)$name, raw)
+  expect_null(igraph::vertex_attr(gg$graph, "node_label"))
+
+  # ...while the drawn node text did change, so the two are genuinely distinct.
+  expect_true("RENAMED NODE" %in% .ggu_node_labels(p))
+})
+
+test_that("plot.gg_udependent with labels = NULL keeps the raw node names", {
+  skip_on_cran()
+  skip_if_not_installed("ggraph")
+  gg <- make_ggu()
+  raw <- igraph::V(gg$graph)$name
+
+  expect_true(all(raw %in% .ggu_node_labels(plot(gg))))
+})
+
+test_that("plot.gg_udependent warns once when no label resolves", {
+  skip_on_cran()
+  skip_if_not_installed("ggraph")
+  gg <- make_ggu()
+  target <- igraph::V(gg$graph)$name[1L]
+
+  expect_warning(plot(gg, labels = stats::setNames("", target)),
+                 "No variable labels")
+})

--- a/tests/testthat/test_gg_variable.R
+++ b/tests/testthat/test_gg_variable.R
@@ -637,3 +637,101 @@ test_that("plot.gg_variable regression + factor predictor: smooth=TRUE adds no s
   expect_s3_class(p, "ggplot")
   expect_false(has_smooth_layer(p))
 })
+
+## ---- labels= on strips and axis titles (issue #243) ------------------------
+
+# Rendered strip text.  built$layout$layout holds the faceting variable's DATA
+# values, not the rendered text, so use get_strip_labels(), which walks the same
+# path as the renderer.  facet_wrap fills $facets; facet_grid fills $rows/$cols.
+.gg_variable_strips <- function(p) {
+  gs <- ggplot2::get_strip_labels(p)
+  as.character(unlist(lapply(gs, function(d) {
+    if (is.data.frame(d) && "variable" %in% names(d)) d$variable else NULL
+  })))
+}
+
+test_that("plot.gg_variable labels the facet strips in the panel branch", {
+  skip_on_cran()
+  set.seed(20260817L)
+  rf <- randomForestSRC::rfsrc(mpg ~ ., data = mtcars, ntree = 50)
+  gg_dta <- gg_variable(rf)
+
+  p <- plot(gg_dta, xvar = c("wt", "hp"), panel = TRUE,
+            labels = c(wt = "Weight (1000 lbs)"))
+  strips <- .gg_variable_strips(p)
+
+  expect_true("Weight (1000 lbs)" %in% strips)
+  expect_true("hp" %in% strips)          # unlabelled falls back to raw name
+  expect_false("wt" %in% strips)
+})
+
+test_that("plot.gg_variable no longer warns when given labels", {
+  skip_on_cran()
+  set.seed(20260817L)
+  rf <- randomForestSRC::rfsrc(mpg ~ ., data = mtcars, ntree = 50)
+  gg_dta <- gg_variable(rf)
+
+  # Before this change labels fell through ... into a ggplot2 layer and tripped
+  # "Ignoring unknown parameters".  geom_smooth() emits its own loess *message*
+  # here regardless, so assert on warnings rather than on silence.
+  expect_warning(
+    suppressMessages(ggplot2::ggplot_build(
+      plot(gg_dta, xvar = c("wt", "hp"), panel = TRUE,
+           labels = c(wt = "Weight (1000 lbs)"))
+    )),
+    regexp = NA
+  )
+})
+
+test_that("plot.gg_variable labels the x axis title in the individual branch", {
+  skip_on_cran()
+  set.seed(20260817L)
+  rf <- randomForestSRC::rfsrc(mpg ~ ., data = mtcars, ntree = 50)
+  gg_dta <- gg_variable(rf)
+
+  p <- plot(gg_dta, xvar = "wt", labels = c(wt = "Weight (1000 lbs)"))
+  expect_equal(p$labels$x, "Weight (1000 lbs)")
+
+  # Unlabelled variable keeps its raw name in the title.
+  p2 <- plot(gg_dta, xvar = "hp", labels = c(wt = "Weight (1000 lbs)"))
+  expect_equal(p2$labels$x, "hp")
+})
+
+test_that("plot.gg_variable with labels = NULL is unchanged", {
+  skip_on_cran()
+  set.seed(20260817L)
+  rf <- randomForestSRC::rfsrc(mpg ~ ., data = mtcars, ntree = 50)
+  gg_dta <- gg_variable(rf)
+
+  expect_equal(plot(gg_dta, xvar = "wt")$labels$x, "wt")
+  expect_true("wt" %in% .gg_variable_strips(
+    plot(gg_dta, xvar = c("wt", "hp"), panel = TRUE)))
+})
+
+test_that("plot.gg_variable still forwards other ... arguments to ggplot2", {
+  skip_on_cran()
+  set.seed(20260817L)
+  rf <- randomForestSRC::rfsrc(mpg ~ ., data = mtcars, ntree = 50)
+  gg_dta <- gg_variable(rf)
+
+  # 'labels' becoming a formal must not stop ... reaching the geoms.
+  p <- plot(gg_dta, xvar = "wt", alpha = 0.3,
+            labels = c(wt = "Weight (1000 lbs)"))
+  alphas <- vapply(p$layers, function(l) {
+    a <- l$aes_params$alpha
+    if (is.null(a)) NA_real_ else as.numeric(a)
+  }, numeric(1))
+
+  expect_true(any(!is.na(alphas) & alphas == 0.3))
+})
+
+test_that("plot.gg_variable keeps raw names in the returned data", {
+  skip_on_cran()
+  set.seed(20260817L)
+  rf <- randomForestSRC::rfsrc(mpg ~ ., data = mtcars, ntree = 50)
+  gg_dta <- gg_variable(rf)
+
+  p <- plot(gg_dta, xvar = c("wt", "hp"), panel = TRUE,
+            labels = c(wt = "Weight (1000 lbs)"))
+  expect_true("wt" %in% as.character(p$data$variable))
+})

--- a/tests/testthat/test_gg_variable.R
+++ b/tests/testthat/test_gg_variable.R
@@ -735,3 +735,26 @@ test_that("plot.gg_variable keeps raw names in the returned data", {
             labels = c(wt = "Weight (1000 lbs)"))
   expect_true("wt" %in% as.character(p$data$variable))
 })
+
+test_that("plot.gg_variable never relabels the time strips (PR #244 review)", {
+  skip_on_cran()
+  data(veteran, package = "randomForestSRC")
+  set.seed(42)
+  rfsrc_veteran <- randomForestSRC::rfsrc(
+    Surv(time, status) ~ ., data = veteran, ntree = 50, nsplit = 5
+  )
+  gg_dta <- gg_variable(rfsrc_veteran, time = c(30, 90))
+
+  # facet_grid(time ~ variable) has two dimensions. A lookup key that collides
+  # with a time value must relabel the variable strip and leave time alone.
+  p <- plot(gg_dta, xvar = c("age", "diagtime"), panel = TRUE,
+            labels = c(age = "Age at diagnosis", "30" = "SHOULD NOT APPEAR"))
+  gs <- ggplot2::get_strip_labels(p)
+  all_strips <- as.character(unlist(lapply(gs, function(d) {
+    if (is.data.frame(d)) unlist(lapply(d, as.character)) else NULL
+  })))
+
+  expect_true("Age at diagnosis" %in% all_strips)
+  expect_false("SHOULD NOT APPEAR" %in% all_strips)
+  expect_true("30" %in% all_strips)
+})


### PR DESCRIPTION
Closes #243, and includes one method that issue did not name.

With this, `labels=` reaches every `plot.gg_*` method in the package that renders variable names.

## 1. `plot.gg_variable()` — seven sites, not two

#243 described two facet sites. There are **seven**:

| Site | Kind | Treatment |
|---|---|---|
| `facet_grid(time ~ variable)` | faceting | `labeller = strip_labeller` |
| `facet_wrap(~variable)` × 2 | faceting | `labeller = strip_labeller` |
| `labs(x = h_name)` × 4 | axis title | display name substituted |

The `facet_grid` was not in the issue and is easy to miss — it is the multi-time survival branch. `facet_wrap(~time, ncol = 1)` is deliberately untouched: it facets by time, not by variable.

`h_name` itself stays raw. It is written back via `colnames(gg_dta)[ch_indx] <- h_name` at the foot of the loop, so only a separate `h_display` goes into the titles.

**The lookup is resolved once.** Calling `.forest_strip_labeller(labels)` *and* `.forest_labels(labels)` would resolve twice, and a lookup that matches nothing warns per resolution — so that would emit the warning twice. Both the labeller and the title substitution are built from one `lab_lookup`.

This method's failure mode was also different from the rest: it genuinely uses `...`, so `labels=` reached `geom_smooth()` and tripped ggplot2's `Ignoring unknown parameters` rather than vanishing silently. A test pins that the warning is gone, asserting on warnings rather than silence — `geom_smooth()` emits its own loess *message* regardless.

## 2. `plot.gg_udependent()` — the vertex key must not move

The display string is written to a separate `node_label` vertex attribute; the igraph `name` is left alone.

This is the one non-obvious fix in the series. `name` is the key the edge-weight backfill matches on:

```r
idx <- match(paste(edge_list$from, edge_list$to),
             paste(x$edges$variable_from, x$edges$variable_to))
```

Rewriting `name` to the display label renders correctly and silently breaks edge weights on graphs saved before those weights were stored — a path no test on a freshly built graph would reach. Tests assert the caller's graph still has its original `name` **and** no `node_label` after plotting, so the display attribute provably lives only on the internal copy.

## 3. `plot.gg_sdependent()` — not in #243

Found by re-auditing the completeness claim instead of repeating it. My first audit regex was `aes\([^)]*variable`, which cannot match this file because its `aes()` spans lines. Re-running against the column reference found it at once.

Included rather than deferred: it is the plain flipped-discrete-axis case, eight lines of the pattern already used four times in this family, and without it the NEWS entry's "every plot method that renders variable names" would have been false.

Ruled out as false positives, recorded so they are not re-investigated: `plot.gg_error()` and `plot.gg_rfsrc()` both reference a `variable` column, but those hold class names (from a `pivot_longer`) and time points respectively — not predictors. `plot.gg_roc()` facets by `class`.

## Tests

Across three files: strips and titles in both `plot.gg_variable()` branches, node text and vertex-key preservation for `plot.gg_udependent()`, axis labelling for `plot.gg_sdependent()`, plus the shared contract each time — per-variable fallback, `labels = NULL` unchanged, warn-once, raw names and factor level order preserved.

One test also pins that other `...` arguments still reach the geoms now that `labels` is a formal on `plot.gg_variable()`.

## Definition of done

| Gate | Result |
|---|---|
| `devtools::document()` | 4 `.Rd` regenerated |
| `lintr::lint_package()` | 0 lints |
| `NOT_CRAN=true VDIFFR_RUN_TESTS=true devtools::test()` | 0 failures, **1944 pass** (was 1937), 6 skips |
| vdiffr baselines | 54 before, 54 after; tree byte-identical, no pruning |
| `R CMD check --as-cran` (with manual, clean `git archive` export) | **1 NOTE**, 0 WARNING, 0 ERROR |

The NOTE is `checking CRAN incoming feasibility` — the maintainer-cadence note. Wall time 4:14. Tarball gate: only `ggRandomForests/.Rinstignore` matches `/\.[^/]+`, `cran-comments` count 0.

No version bump: `4.0.0` is an unreleased development line and the NEWS entry goes under its open section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)