### PR TITLE
Retire dev_rhf from the v4.0.0 release checklist

### DIFF
--- a/release-checklist-v4.0.0.md
+++ b/release-checklist-v4.0.0.md
@@ -1,7 +1,7 @@
 # Release Checklist: ggRandomForests v4.0.0
 
 **Audit date:** 2026-08-25
-**Integration branch:** `dev_rhf`
+**Integration branch:** `main`
 **Release status:** HOLD
 
 This checklist records the v3/v4 consistency sweep and later RHF release
@@ -99,6 +99,11 @@ unsupervised variable priority where that method is discussed.
 - After v4 integration, `main` is the internal release-candidate channel.
   `hvtiR::install()` therefore installs the v4 candidate from GitHub even while
   CRAN remains on v3.
+- `dev_rhf` is **retired** (2026-08-29). It was the pre-integration branch; once
+  the v4 work reached `main` it held no commits `main` did not, so the local
+  branch, the remote branch, and the `protect dev_rhf` ruleset were removed.
+  `main` had already taken over as the candidate channel, per the point above.
+  Anything that still points at `dev_rhf` is stale.
 - **hvtiR follow-up:** make `hvtiR::status()` and `hvtiR::update()` commit-aware.
   Their current version comparison cannot distinguish two candidate commits
   that both declare `Version: 4.0.0`. Until that work lands, internal testers


### PR DESCRIPTION
`dev_rhf` was removed on 2026-08-29: local branch, remote branch, and the `protect dev_rhf` ruleset, after verifying it held zero commits `main` did not. The checklist was the last live pointer at it.

## Changes

- **`**Integration branch:** `dev_rhf`` → `main`.** The topology section already said `main` becomes the internal release-candidate channel after v4 integration, so the header was contradicting the body.
- **Added a bullet under *Internal release-candidate topology*** recording the retirement and why, so a future reader sees the change explained rather than silently applied.

## Deliberately unchanged

**`Release status:` stays `HOLD`.** Retiring a stale branch pointer is not a release decision, and the checklist's own preamble says it does not authorize a release, submission, tag, version change, or merge to `main` without maintainer approval.

Five gates remain pending, two of them substantive prerequisites for cutting a release candidate:

| Gate | Status |
|---|---|
| Upstream Linux GCC UBSAN execution (run on the release candidate) | pending |
| Full release verification | pending |
| Explicit maintainer authorization | pending |
| Submission | pending |
| CRAN acceptance | pending |

## Scope

Markdown only. `release-checklist-v4.0.0.md` is matched by `^release-checklist.*\.md$` in `.Rbuildignore`, so it does not ship in the tarball and no package code, docs, or tests are affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)