### PR TITLE
Pin the UBSAN workflow's dependency install to CRAN

### DIFF
--- a/.github/workflows/upstream-ubsan.yaml
+++ b/.github/workflows/upstream-ubsan.yaml
@@ -2,6 +2,11 @@
 # This is intentionally manual: randomForestSRC has a known UBSAN defect in
 # unsupervised growth, so the workflow first confirms that calibration signal
 # and then requires the supported ggRandomForests paths to remain clean.
+#
+# Every install here pins repos= to CRAN. The gcc16 container defaults to an
+# r-hub binary repo whose PACKAGES index resolves but whose tarballs 404
+# (fedora-44/4.7, observed 2026-08-29), so an unpinned install fails on every
+# dependency before any sanitizer runs. See run 33264064851.
 on:
   workflow_dispatch:
 
@@ -34,7 +39,7 @@ jobs:
         run: |
           mkdir -p "$R_LIBS_USER"
           Rscript -e 'install.packages("remotes", repos = "https://cloud.r-project.org", type = "source")'
-          Rscript -e 'remotes::install_deps(dependencies = c("Depends", "Imports", "LinkingTo"), upgrade = "never")'
+          Rscript -e 'remotes::install_deps(dependencies = c("Depends", "Imports", "LinkingTo"), upgrade = "never", repos = "https://cloud.r-project.org")'
           Rscript -e 'install.packages(c("randomForestSRC", "randomForestRHF", "varPro"), repos = "https://cloud.r-project.org", type = "source")'
           R CMD INSTALL .
 


### PR DESCRIPTION
The `Upstream GCC UBSAN` gate has never produced a result. This is why.

## What happened

[Run 33264064851](https://github.com/ehrlinger/ggRandomForests/actions/runs/33264064851), dispatched against `main` @ `57b4aa0f`, **failed in 5m44s at the install step**, before either sanitizer probe ran:

| Step | Result |
|---|---|
| Record sanitizer toolchain | success |
| **Install dependencies and upstream engines from source** | **failure** |
| Confirm the known randomForestSRC sanitizer signal | skipped |
| Run supported rfsrc, varpro, and RHF workflows | skipped |

**This is not a UBSAN finding.** Nothing was sanitized. The two probe steps never executed.

## Cause

`remotes::install_deps()` was the only install call in the workflow **without an explicit `repos=`**, so it inherited the `ghcr.io/r-hub/containers/gcc16` container's default: an r-hub *binary* repo for `fedora-44` / R 4.7.

That repo is broken. Its index resolves but the files it advertises do not:

```
PACKAGES                                    -> 200
rlang_1.3.0_b3_R4.7_...-fedora-44.tar.gz    -> 404
```

So every dependency failed with `download of package ‘rlang’ failed`, `‘cli’ failed`, `‘glue’ failed, and so on for ~30 packages.

Its two neighbouring calls already pinned `https://cloud.r-project.org`; this one did not, which is the whole bug.

## The change

One argument, plus a header comment recording the cause so the next reader does not re-diagnose it.

```r
remotes::install_deps(dependencies = c("Depends", "Imports", "LinkingTo"),
                      upgrade = "never", repos = "https://cloud.r-project.org")
```

## Worth knowing

- The only prior run of this workflow was against tag `v4.0.0-rc1` and was **cancelled after 64h07m**. Combined with this failure, the gate has no recorded verdict for the v4 line at all, which is consistent with it sitting `pending` in `release-checklist-v4.0.0.md`.
- ⚠️ **This fix unblocks the install; it does not prove the run completes.** CRAN serves no Linux binaries, so dependencies compile from source, and that may be what made the rc1 run long. If the next run is slow rather than failing, a prebuilt Linux binary repo for the deps (keeping `type = "source"` for the three forest engines, which are the actual sanitizer target) is the next lever. Flagging rather than pre-optimising.
- The workflow is `workflow_dispatch` only, so nothing here runs on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)