### PR TITLE
Install the UBSAN runtime, and prove it links before building

### DIFF
--- a/.github/workflows/upstream-ubsan.yaml
+++ b/.github/workflows/upstream-ubsan.yaml
@@ -34,6 +34,33 @@ jobs:
           R --version
           cat "$R_MAKEVARS_USER"
 
+      - name: Provide and prove the UBSAN runtime
+        shell: bash
+        run: |
+          # The gcc16 image is referenced as :latest and has shipped without the
+          # UBSAN runtime: every -fsanitize link then fails with
+          #   ld.bfd: cannot find /usr/lib64/libubsan.so.1.0.0
+          # which surfaces as "compilation failed for package rlang" and then as
+          # ~70 cascading "not available" errors, none of which name the cause.
+          # See run 33266002924.
+          if ! ls /usr/lib64/libubsan.so* >/dev/null 2>&1; then
+            dnf -y install libubsan || true
+          fi
+
+          echo "--- what the toolchain resolves ---"
+          gcc -print-file-name=libubsan.so || true
+          ls -l /usr/lib64/libubsan* 2>&1 || true
+
+          # Fail HERE, with a linkable/not-linkable answer, rather than 78
+          # packages later behind an unrelated-looking error.
+          printf 'int main(void){return 0;}\n' > /tmp/ubsan-probe.c
+          if gcc -fsanitize=undefined,bounds-strict -o /tmp/ubsan-probe /tmp/ubsan-probe.c; then
+            echo "UBSAN runtime links OK"
+          else
+            echo "::error::The UBSAN runtime is not linkable in this image. The sanitizer build cannot proceed; pin the container to a tag that ships libubsan, or install it explicitly."
+            exit 1
+          fi
+
       - name: Install dependencies and upstream engines from source
         shell: bash
         run: |


### PR DESCRIPTION
Third blocker on this gate, and the second one that only appears when you actually run it.

## What the last run showed

[Run 33266002924](https://github.com/ehrlinger/ggRandomForests/actions/runs/33266002924) confirmed #246 worked: 78 packages downloaded cleanly from `cloud.r-project.org`, the r-hub 404s are gone. The failure moved from *download* to *link*:

```
ld.bfd: cannot find /usr/lib64/libubsan.so.1.0.0: No such file or directory
collect2: error: ld returned 1 exit status
ERROR: compilation failed for package ‘rlang’
```

`tools/Makevars.ubsan` puts `-fsanitize=undefined,bounds-strict` in `LDFLAGS`, so **every** package with compiled code must link `libubsan`. The `gcc16` image currently ships GCC 16.2.1 without that runtime. `rlang`, `glue`, `cli`, `farver`, `S7`, `utf8`, `magrittr` and `stringi` all failed to link, and roughly 70 more cascaded into `not available`. **None of those ~70 errors names the cause** — you have to read past all of them to find one `ld.bfd` line.

## The change

**1. Install the runtime.** `dnf -y install libubsan` when absent.

**2. Prove it links, and fail here if it doesn't.**

```bash
printf 'int main(void){return 0;}\n' > /tmp/ubsan-probe.c
if gcc -fsanitize=undefined,bounds-strict -o /tmp/ubsan-probe /tmp/ubsan-probe.c; then
  echo "UBSAN runtime links OK"
else
  echo "::error::The UBSAN runtime is not linkable in this image..."
  exit 1
fi
```

Part 2 is the half that lasts. Whether or not `dnf install libubsan` is the right incantation, the job now answers *linkable / not linkable* in one step with a named cause, instead of burying it under a package-dependency cascade. It also prints `gcc -print-file-name=libubsan.so` and `ls /usr/lib64/libubsan*`, so a failing run still tells us what the image actually contains.

## ⚠️ Not verified locally, and it cannot be

There is no container runtime on the maintainer's machine (no docker/podman/colima), and the target is **x86_64 Fedora** while the host is **arm64 Darwin**, where `libubsan.so` has no equivalent. CI is the only place this executes. That is precisely why the change is built to produce a diagnosis on failure rather than another cascade.

## Root cause worth addressing separately

The workflow pins no image digest, so it follows `ghcr.io/r-hub/containers/gcc16:latest`. **Two independent regressions have now arrived through that one unpinned reference:** the fedora-44/R-4.7 binary repo whose tarballs 404 (fixed in #246), and now a GCC 16 image without its own sanitizer runtime. Pinning to a dated tag or digest addresses the class rather than the instance, and is worth doing once this run is green.

CI cannot test this PR: the workflow is `workflow_dispatch` only, so green checks here say nothing about it. Verification is a manual dispatch after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)