### PR TITLE
Install libuv headers so 'fs' can configure

### DIFF
--- a/.github/workflows/upstream-ubsan.yaml
+++ b/.github/workflows/upstream-ubsan.yaml
@@ -34,7 +34,7 @@ jobs:
           R --version
           cat "$R_MAKEVARS_USER"
 
-      - name: Provide and prove the UBSAN runtime
+      - name: Provide and prove the build prerequisites
         shell: bash
         run: |
           # The gcc16 image is referenced as :latest and has shipped without the
@@ -47,9 +47,25 @@ jobs:
             dnf -y install libubsan || true
           fi
 
+          # 'fs' needs libuv headers and the image ships none, so it fails
+          # configure with "fatal error: uv.h: No such file or directory".
+          # It is the single primary failure that cascades through
+          # sass -> bslib -> rmarkdown -> htmlwidgets -> visNetwork ->
+          # DiagrammeR -> randomForestSRC, i.e. it blocks the sanitizer target
+          # itself. See run 33267620518.
+          if [ ! -f /usr/include/uv.h ]; then
+            dnf -y install libuv-devel || true
+          fi
+
           echo "--- what the toolchain resolves ---"
           gcc -print-file-name=libubsan.so || true
           ls -l /usr/lib64/libubsan* 2>&1 || true
+          ls -l /usr/include/uv.h 2>&1 || true
+
+          if [ ! -f /usr/include/uv.h ]; then
+            echo "::error::libuv headers (uv.h) are still missing; package 'fs' will fail to configure and take randomForestSRC down with it."
+            exit 1
+          fi
 
           # Fail HERE, with a linkable/not-linkable answer, rather than 78
           # packages later behind an unrelated-looking error.


### PR DESCRIPTION
Fourth blocker on this gate. Each one has only been discoverable by running it, because the workflow is `workflow_dispatch` only and has never completed.

## #247 worked

[Run 33267620518](https://github.com/ehrlinger/ggRandomForests/actions/runs/33267620518), the probe step:

```
Installing libubsan-0:16.2.1-2.fc ... Complete!
--- what the toolchain resolves ---
/usr/lib/gcc/x86_64-redhat-linux/16/libubsan.so
/usr/lib64/libubsan.so.1.0.0
UBSAN runtime links OK
```

The build then ran **~23 minutes** (18:13 to 18:36) compiling packages successfully, against dying at the first link in the previous run.

## The remaining blocker is a single header

```
fatal error: uv.h: No such file or directory
ERROR: configuration failed for package ‘fs’
```

`ERROR: configuration failed for package ‘fs’` is the **only** primary failure in the entire log. Everything else cascades from it:

```
fs -> sass -> bslib -> rmarkdown -> htmlwidgets -> visNetwork -> DiagrammeR
   -> randomForestSRC -> varPro / randomForestRHF / ggRandomForests
```

`DiagrammeR` is a hard dependency of `randomForestSRC`, so this one missing header takes down the sanitizer target itself.

## The change

Install `libuv-devel`, then **check for `uv.h` explicitly** and fail the step with a named cause if it is still absent:

```bash
if [ ! -f /usr/include/uv.h ]; then
  echo "::error::libuv headers (uv.h) are still missing; package 'fs' will fail to configure and take randomForestSRC down with it."
  exit 1
fi
```

Same reasoning as the `libubsan` probe from #247, and it is why this round took one look at the log instead of reading ~70 cascading errors backwards. The step is renamed from *Provide and prove the UBSAN runtime* to *Provide and prove the build prerequisites* now that it covers both.

## ⚠️ Still not verifiable locally

No container runtime on the maintainer's machine, and the target is x86_64 Fedora against an arm64 Darwin host. CI remains the only place this executes, which is why each fix carries its own explicit check rather than relying on the next failure to be legible.

## Standing observation

This is the fourth regression to arrive through one unpinned `ghcr.io/r-hub/containers/gcc16:latest` reference: the fedora-44 repo 404s (#246), the missing UBSAN runtime (#247), and now missing libuv headers. Pinning to a digest addresses the class rather than the instance, and is worth doing once a run goes green so there is a known-good image to pin *to*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)