### PR TITLE
Fix the UBSAN calibration probe, which never reached rfsrc

### DIFF
--- a/tools/check-upstream-ubsan.R
+++ b/tools/check-upstream-ubsan.R
@@ -28,8 +28,18 @@ assert_known_rfsrc_ubsan <- function(path) {
 }
 
 run_known_rfsrc_probe <- function() {
+  ## The LHS must be written BARE as `Unsupervised()`, never
+  ## `randomForestSRC::Unsupervised()`.  rfsrc's parseFormula() matches the
+  ## response symbol textually and never evaluates it, so the `::`-qualified
+  ## call does not match and the call dies with "formula is incorrectly
+  ## specified" before it reaches any native code.  The probe then reports
+  ## "Did not observe the known randomForestSRC UBSAN diagnostic", which reads
+  ## like the upstream defect was fixed rather than like a broken probe.
+  ## `Unsupervised` is not exported, but that does not matter here precisely
+  ## because the LHS is never evaluated.  Verified against randomForestSRC
+  ## 3.6.2: bare form OK, qualified form errors.  See run 33278882599.
   randomForestSRC::rfsrc(
-    randomForestSRC::Unsupervised() ~ .,
+    Unsupervised() ~ .,
     data = mtcars,
     ntree = 1L
   )


### PR DESCRIPTION
## First, the good news

[Run 33278882599](https://github.com/ehrlinger/ggRandomForests/actions/runs/33278882599) got further than any previous attempt:

| Step | Result |
|---|---|
| Provide and prove the build prerequisites | **success** |
| **Install dependencies and upstream engines from source** | **success** (first time ever, ~19 min) |
| Confirm the known randomForestSRC sanitizer signal | **failure** |
| Run supported rfsrc, varpro, and RHF workflows | skipped |

#246, #247 and #248 all did their jobs. The whole dependency tree now builds under the sanitizer.

## The calibration probe has never worked

```
Error in parseFormula(formula, data, ytry) : formula is incorrectly specified.
Calls: run_known_rfsrc_probe -> <Anonymous> -> parseFormula
Error: Did not observe the known randomForestSRC UBSAN diagnostic.
```

The probe wrote its response as `randomForestSRC::Unsupervised() ~ .`. `rfsrc`'s `parseFormula()` matches the response symbol **textually** and never evaluates it, so the `::`-qualified call does not match, and the call errors out before reaching any native code. The probe never triggered the defect it exists to confirm.

**Verified locally** against randomForestSRC 3.6.2 — this part is portable R and needs no container:

| Form | Result |
|---|---|
| `randomForestSRC::Unsupervised() ~ .` | `formula is incorrectly specified` |
| `Unsupervised() ~ .` | OK, returns an `rfsrc` object |

`Unsupervised` is not exported, and that is exactly why the bare form is correct: the LHS is never evaluated, so it does not need to resolve.

## Why this is worse than an ordinary bug

The failure presents as **"Did not observe the known randomForestSRC UBSAN diagnostic"** — which reads like upstream fixed the defect and the calibration is now stale. It is the opposite. The probe is broken and **can never go red**.

That inverts the whole point of the step. The workflow runs the probe first and requires it to fail, precisely so that a clean result from the *supported* paths means something. A calibration that cannot go red cannot certify anything the later clean check reports. Had the probe's `stop("...unexpectedly returned")` path fired instead, the job would have said so honestly; instead it failed in a way that invites the wrong conclusion.

This is the same shape as the v3.5.0 lesson recorded in `AGENTS.md`: `Status: OK` in `00check.log` coexisting with a live `entry.c:184`, because the signal being read was not the signal that mattered.

## The change

One line, plus a comment at the call site explaining why the namespace qualifier must not come back. Re-qualifying it is exactly the tidy-up a future reader would apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)