### PR TITLE
Add vdiffr cover for all four plot.gg_variable() survival paths

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -155,6 +155,13 @@ ggRandomForests v4.0.0 (development)
   `ggRandomForests-survival.qmd`) are moved off the now-deprecated `lbls`
   argument onto `labels`, so the shipped examples model the current API
   rather than the one being phased out.
+* `plot.gg_variable()`'s survival branch has visual regression cover for the
+  first time. The branch forks on `panel` and on whether the object carries one
+  time or several, and the four resulting paths differ in both faceting and
+  y-axis title; each now has a `vdiffr` baseline. The two single-time paths are
+  the ones that render a time unit into the axis title, so a change to that
+  title now surfaces as an SVG diff rather than resting on an `expect_equal()`
+  of `p$labels$y`, which cannot see the rest of the panel. Tests only.
 
 ggRandomForests v3.5.2
 ======================

--- a/tests/testthat/_snaps/snapshots/gg-variable-survival-multi-time.svg
+++ b/tests/testthat/_snaps/snapshots/gg-variable-survival-multi-time.svg
@@ -1,0 +1,736 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpMzUuMjR8NjUyLjkyfDM5LjQzfDI4MS4yMQ=='>
+    <rect x='35.24' y='39.43' width='617.68' height='241.77' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMzUuMjR8NjUyLjkyfDM5LjQzfDI4MS4yMQ==)'>
+<rect x='35.24' y='39.43' width='617.68' height='241.77' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<polygon points='351.17,164.09 353.81,168.65 348.54,168.65 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='79.53' cy='58.38' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='85.61,60.27 88.25,64.83 82.98,64.83 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='93.72,98.57 96.35,103.13 91.09,103.13 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='126.16' cy='61.98' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='73.45,56.67 76.08,61.23 70.82,61.23 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='77.50' cy='54.12' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='63.31,49.21 65.95,53.77 60.68,53.77 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='122.10,65.83 124.74,70.39 119.47,70.39 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='312.66,145.32 315.29,149.88 310.02,149.88 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='85.61,53.18 88.25,57.74 82.98,57.74 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='130.21,69.13 132.84,73.69 127.58,73.69 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='71.42' cy='52.48' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='73.45,104.69 76.08,109.25 70.82,109.25 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='73.45,55.85 76.08,60.41 70.82,60.41 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='71.42' cy='54.77' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='111.97,75.69 114.60,80.25 109.33,80.25 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='288.33,144.25 290.96,148.81 285.70,148.81 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='71.42' cy='52.31' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='160.62,83.89 163.25,88.45 157.99,88.45 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='69.40' cy='57.93' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='126.16,78.77 128.79,83.33 123.52,83.33 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='409.96,137.16 412.59,141.72 407.33,141.72 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='99.80,55.35 102.44,59.91 97.17,59.91 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='71.42' cy='53.15' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='162.65,69.08 165.28,73.64 160.01,73.64 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='495.10,122.85 497.74,127.41 492.47,127.41 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='405.91,131.14 408.54,135.70 403.27,135.70 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='71.42' cy='58.08' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='130.21,102.42 132.84,106.98 127.58,106.98 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='152.51,71.22 155.14,75.78 149.88,75.78 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='93.72' cy='57.32' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='73.45,57.09 76.08,61.65 70.82,61.65 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='73.45' cy='52.71' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='81.56,56.79 84.19,61.35 78.93,61.35 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='63.31' cy='53.07' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='201.16,102.65 203.80,107.21 198.53,107.21 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='124.13,56.11 126.76,60.67 121.50,60.67 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='71.42,60.51 74.06,65.07 68.79,65.07 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='83.59' cy='53.00' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='195.08,85.32 197.71,89.88 192.45,89.88 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='99.80' cy='54.61' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='79.53' cy='54.64' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='124.13,58.79 126.76,63.35 121.50,63.35 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='69.40' cy='52.49' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='172.78,79.51 175.41,84.07 170.15,84.07 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='67.37' cy='51.95' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='95.75' cy='57.98' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='73.45,49.96 76.08,54.52 70.82,54.52 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='79.53,50.90 82.16,55.46 76.90,55.46 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='73.45,48.91 76.08,53.47 70.82,53.47 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='178.86,74.72 181.50,79.28 176.23,79.28 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='109.94,96.99 112.57,101.55 107.31,101.55 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='83.59,51.16 86.22,55.72 80.95,55.72 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='93.72,55.67 96.35,60.23 91.09,60.23 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='79.53,52.48 82.16,57.04 76.90,57.04 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='103.86,79.66 106.49,84.22 101.23,84.22 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='71.42' cy='52.73' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='73.45,49.51 76.08,54.07 70.82,54.07 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='75.48' cy='57.61' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='69.40' cy='52.88' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='83.59,87.06 86.22,91.62 80.95,91.62 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='513.35,159.71 515.98,164.27 510.71,164.27 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='99.80,60.39 102.44,64.95 97.17,64.95 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='81.56' cy='53.48' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='85.61,50.53 88.25,55.09 82.98,55.09 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='79.53,52.25 82.16,56.81 76.90,56.81 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='71.42' cy='55.07' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='462.67,130.18 465.30,134.74 460.04,134.74 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='69.40' cy='76.62' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='81.56' cy='53.43' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='67.37' cy='52.50' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='71.42' cy='53.25' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='227.52,93.49 230.15,98.05 224.88,98.05 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='403.88,151.60 406.51,156.16 401.25,156.16 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='304.55,132.60 307.18,137.15 301.92,137.15 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='191.03,78.41 193.66,82.97 188.39,82.97 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='184.95,89.22 187.58,93.78 182.31,93.78 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='73.45' cy='67.86' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='203.19,93.57 205.82,98.13 200.56,98.13 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='349.15,129.77 351.78,134.33 346.51,134.33 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='148.46,92.10 151.09,96.66 145.82,96.66 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='83.59' cy='55.18' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='65.34' cy='52.28' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='99.80,53.92 102.44,58.48 97.17,58.48 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='158.59,82.23 161.22,86.79 155.96,86.79 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='79.53,49.33 82.16,53.89 76.90,53.89 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='69.40' cy='52.59' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='97.78,55.32 100.41,59.88 95.14,59.88 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='89.67,59.12 92.30,63.68 87.04,63.68 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='158.59,68.47 161.22,73.03 155.96,73.03 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='85.61,63.01 88.25,67.57 82.98,67.57 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='83.59' cy='58.99' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='122.10,87.43 124.74,91.99 119.47,91.99 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='409.96,143.53 412.59,148.09 407.33,148.09 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='77.50' cy='52.97' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='97.78,66.06 100.41,70.62 95.14,70.62 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='77.50' cy='54.98' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='93.72' cy='54.94' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='103.86,67.65 106.49,72.21 101.23,72.21 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='75.48' cy='52.52' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='75.48' cy='54.39' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='107.91,55.99 110.55,60.55 105.28,60.55 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='79.53,50.86 82.16,55.42 76.90,55.42 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='79.53' cy='66.24' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='99.80,64.84 102.44,69.40 97.17,69.40 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='69.40' cy='55.79' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='65.34,49.92 67.97,54.48 62.71,54.48 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='67.37' cy='51.95' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='95.75,50.40 98.38,54.96 93.12,54.96 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='168.73' cy='60.94' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='97.78,57.01 100.41,61.57 95.14,61.57 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='193.05,77.87 195.69,82.43 190.42,82.43 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='122.10,71.02 124.74,75.58 119.47,75.58 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='71.42' cy='56.67' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='118.05' cy='92.14' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='189.00,99.28 191.63,103.84 186.37,103.84 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='128.18,80.33 130.82,84.89 125.55,84.89 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='69.40,49.18 72.03,53.74 66.76,53.74 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='128.18' cy='62.45' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='83.59,62.68 86.22,67.24 80.95,67.24 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='69.40' cy='53.48' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='160.62,72.99 163.25,77.55 157.99,77.55 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='69.40' cy='52.17' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='83.59' cy='53.52' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='81.56,59.61 84.19,64.17 78.93,64.17 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='67.37' cy='53.74' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='385.64,147.49 388.27,152.05 383.00,152.05 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='75.48' cy='59.50' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='409.96,119.40 412.59,123.96 407.33,123.96 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='113.99,77.14 116.63,81.70 111.36,81.70 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='95.75' cy='53.67' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='87.64,56.22 90.27,60.78 85.01,60.78 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='71.42' cy='51.95' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='65.34' cy='52.64' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='73.45' cy='52.98' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='79.53' cy='56.71' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='205.22,91.76 207.85,96.32 202.58,96.32 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='79.53' cy='57.00' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='79.53' cy='54.69' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='75.48' cy='52.25' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='77.50,49.90 80.14,54.46 74.87,54.46 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='116.02,63.95 118.65,68.51 113.39,68.51 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='624.84,137.24 627.47,141.80 622.21,141.80 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='71.42' cy='53.30' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='81.56' cy='58.51' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='81.56' cy='57.89' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='203.19,105.39 205.82,109.95 200.56,109.95 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='118.05,81.55 120.68,86.11 115.42,86.11 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='77.50' cy='52.98' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='75.48' cy='62.13' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='103.86,106.05 106.49,110.61 101.23,110.61 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='67.37' cy='52.56' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='105.89,119.63 108.52,124.18 103.25,124.18 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='69.40' cy='52.27' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='574.16,124.45 576.80,129.01 571.53,129.01 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='69.40' cy='52.62' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='126.16' cy='63.81' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='107.91,66.21 110.55,70.77 105.28,70.77 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='69.40' cy='52.88' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='103.86' cy='58.30' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='122.10,75.35 124.74,79.91 119.47,79.91 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='63.31,49.63 65.95,54.19 60.68,54.19 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='229.54,85.99 232.18,90.55 226.91,90.55 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='138.32,72.42 140.95,76.98 135.69,76.98 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='172.78' cy='85.96' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='75.48,52.13 78.11,56.69 72.85,56.69 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='65.34' cy='51.95' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='83.59,57.01 86.22,61.57 80.95,61.57 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='81.56' cy='53.65' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='67.37' cy='73.14' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='83.59' cy='53.37' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='118.05' cy='59.23' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='67.37' cy='52.26' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='73.45' cy='52.23' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='122.10,60.78 124.74,65.34 119.47,65.34 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='75.48' cy='55.15' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='69.40' cy='57.86' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='93.72' cy='55.31' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='152.51' cy='65.53' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='85.61' cy='52.19' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='69.40' cy='51.95' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='67.37' cy='52.88' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='280.22,103.88 282.86,108.44 277.59,108.44 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='73.45' cy='52.39' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='97.78,61.14 100.41,65.70 95.14,65.70 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='341.04,113.06 343.67,117.62 338.40,117.62 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='71.42' cy='56.74' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='83.59' cy='54.32' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='103.86' cy='72.68' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='553.89,105.83 556.52,110.39 551.26,110.39 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='75.48' cy='52.94' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='276.17,126.63 278.80,131.19 273.54,131.19 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='87.64' cy='78.62' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='132.24' cy='63.01' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='85.61' cy='54.06' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='69.40' cy='52.26' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='71.42' cy='62.92' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='99.80' cy='57.46' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='152.51' cy='61.60' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='69.40' cy='58.34' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='67.37' cy='55.01' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='67.37' cy='56.08' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='71.42,51.82 74.06,56.38 68.79,56.38 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='107.91,61.90 110.55,66.46 105.28,66.46 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='69.40' cy='53.60' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='69.40' cy='62.30' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='136.29,109.09 138.93,113.65 133.66,113.65 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='71.42' cy='53.08' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='75.48' cy='52.59' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='83.59' cy='53.23' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='81.56' cy='54.29' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='67.37' cy='52.59' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='75.48,53.70 78.11,58.26 72.85,58.26 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='176.84,64.99 179.47,69.55 174.20,69.55 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='67.37' cy='52.86' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='288.33,112.26 290.96,116.82 285.70,116.82 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='67.37' cy='54.03' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='89.67' cy='56.51' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='134.27,105.24 136.90,109.80 131.63,109.80 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='75.48' cy='51.95' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='148.46,65.94 151.09,70.50 145.82,70.50 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='343.06,166.81 345.70,171.37 340.43,171.37 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='77.50' cy='56.11' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='71.42' cy='54.19' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='67.37' cy='53.46' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='103.86,62.72 106.49,67.28 101.23,67.28 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='71.42' cy='52.74' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='148.46,90.39 151.09,94.95 145.82,94.95 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='124.13' cy='60.90' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='126.16,167.48 128.79,172.04 123.52,172.04 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='65.34' cy='61.36' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='75.48' cy='63.21' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='75.48' cy='52.62' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='320.77' cy='114.67' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='87.64' cy='54.82' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='89.67' cy='81.15' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='69.40' cy='60.17' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='73.45,61.14 76.08,65.70 70.82,65.70 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='65.34' cy='52.39' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='146.43' cy='65.06' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='95.75' cy='85.11' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='219.41,134.57 222.04,139.13 216.77,139.13 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='136.29,72.84 138.93,77.40 133.66,77.40 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='69.40' cy='52.25' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='99.80' cy='56.44' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='180.89' cy='101.42' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='73.45' cy='52.93' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='83.59' cy='61.58' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='69.40' cy='52.89' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='67.37' cy='52.52' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='79.53' cy='60.68' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='201.16' cy='151.54' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='120.08' cy='62.17' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='71.42' cy='53.40' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='79.53' cy='55.44' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='67.37' cy='57.55' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='79.53' cy='53.79' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='120.08' cy='95.33' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='170.75' cy='90.45' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='122.10' cy='85.55' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='113.99' cy='76.85' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='79.53' cy='55.17' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='126.16' cy='86.30' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='128.18' cy='81.45' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='67.37' cy='55.87' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='191.03,149.25 193.66,153.81 188.39,153.81 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='186.97,124.56 189.60,129.12 184.34,129.12 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='130.21' cy='81.62' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='77.50' cy='54.13' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='77.50' cy='53.45' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='67.37' cy='65.09' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='101.83' cy='65.16' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='89.67' cy='61.61' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='101.83' cy='58.13' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='77.50' cy='55.21' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='77.50' cy='53.38' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='170.75' cy='64.68' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='67.37' cy='52.22' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='89.67' cy='53.09' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='420.10,169.01 422.73,173.57 417.46,173.57 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='83.59' cy='57.26' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='79.53' cy='59.82' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='83.59' cy='54.15' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='73.45' cy='53.75' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='97.78' cy='55.15' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='186.97' cy='104.41' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='233.60' cy='114.81' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='138.32,73.76 140.95,78.32 135.69,78.32 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='85.61' cy='64.08' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='122.10' cy='67.82' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='231.57' cy='114.52' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='229.54' cy='141.63' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='191.03' cy='124.82' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='105.89' cy='63.16' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='73.45' cy='57.34' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='81.56' cy='53.98' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='79.53' cy='54.98' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='105.89' cy='66.61' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='162.65,133.67 165.28,138.23 160.01,138.23 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='77.50' cy='52.51' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='71.42' cy='56.52' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='77.50' cy='62.04' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='67.37' cy='55.73' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='116.02' cy='66.81' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='69.40' cy='52.69' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='73.45' cy='52.79' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='65.34' cy='52.26' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='65.34' cy='71.46' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='91.70' cy='63.03' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='97.78' cy='63.66' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='186.97' cy='73.29' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='63.31,50.42 70.42,53.05 77.53,54.25 84.64,55.76 91.75,59.00 98.85,62.52 105.96,66.28 113.07,70.37 120.18,73.67 127.29,75.87 134.39,77.69 141.50,79.56 148.61,81.49 155.72,83.45 162.83,85.44 169.93,87.49 177.04,89.64 184.15,91.96 191.26,94.50 198.37,96.97 205.47,99.32 212.58,101.55 219.69,103.69 226.80,105.75 233.91,107.73 241.01,109.65 248.12,111.51 255.23,113.31 262.34,115.05 269.44,116.73 276.55,118.36 283.66,119.93 290.77,121.44 297.88,122.90 304.98,124.30 312.09,125.65 319.20,126.93 326.31,128.16 333.42,129.33 340.52,130.43 347.63,131.48 354.74,132.46 361.85,133.37 368.96,134.22 376.06,134.99 383.17,135.70 390.28,136.33 397.39,136.89 404.50,137.37 411.60,137.77 418.71,138.08 425.82,138.31 432.93,138.45 440.04,138.50 447.14,138.45 454.25,138.30 461.36,138.06 468.47,137.71 475.58,137.26 482.68,136.70 489.79,136.03 496.90,135.26 504.01,134.38 511.12,133.39 518.22,132.29 525.33,131.09 532.44,129.78 539.55,128.37 546.65,126.85 553.76,125.23 560.87,123.50 567.98,121.67 575.09,119.74 582.19,117.70 589.30,115.56 596.41,113.32 603.52,110.98 610.63,108.54 617.73,105.99 624.84,103.34 624.84,139.37 617.73,140.32 610.63,141.24 603.52,142.13 596.41,142.98 589.30,143.79 582.19,144.57 575.09,145.32 567.98,146.02 560.87,146.69 553.76,147.33 546.65,147.92 539.55,148.48 532.44,149.00 525.33,149.49 518.22,149.94 511.12,150.36 504.01,150.74 496.90,151.08 489.79,151.39 482.68,151.66 475.58,151.89 468.47,152.09 461.36,152.24 454.25,152.35 447.14,152.41 440.04,152.43 432.93,152.39 425.82,152.30 418.71,152.15 411.60,151.94 404.50,151.66 397.39,151.32 390.28,150.90 383.17,150.41 376.06,149.84 368.96,149.19 361.85,148.46 354.74,147.65 347.63,146.75 340.52,145.76 333.42,144.68 326.31,143.51 319.20,142.25 312.09,140.89 304.98,139.44 297.88,137.88 290.77,136.23 283.66,134.49 276.55,132.64 269.44,130.69 262.34,128.64 255.23,126.48 248.12,124.23 241.01,121.88 233.91,119.44 226.80,116.90 219.69,114.28 212.58,111.58 205.47,108.81 198.37,105.99 191.26,103.14 184.15,100.33 177.04,97.69 169.93,95.24 162.83,92.97 155.72,90.90 148.61,88.97 141.50,87.13 134.39,85.30 127.29,83.42 120.18,80.87 113.07,77.27 105.96,73.61 98.85,69.78 91.75,65.13 84.64,61.48 77.53,58.86 70.42,57.94 63.31,60.45 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #999999; fill-opacity: 0.40;' />
+<polyline points='63.31,50.42 70.42,53.05 77.53,54.25 84.64,55.76 91.75,59.00 98.85,62.52 105.96,66.28 113.07,70.37 120.18,73.67 127.29,75.87 134.39,77.69 141.50,79.56 148.61,81.49 155.72,83.45 162.83,85.44 169.93,87.49 177.04,89.64 184.15,91.96 191.26,94.50 198.37,96.97 205.47,99.32 212.58,101.55 219.69,103.69 226.80,105.75 233.91,107.73 241.01,109.65 248.12,111.51 255.23,113.31 262.34,115.05 269.44,116.73 276.55,118.36 283.66,119.93 290.77,121.44 297.88,122.90 304.98,124.30 312.09,125.65 319.20,126.93 326.31,128.16 333.42,129.33 340.52,130.43 347.63,131.48 354.74,132.46 361.85,133.37 368.96,134.22 376.06,134.99 383.17,135.70 390.28,136.33 397.39,136.89 404.50,137.37 411.60,137.77 418.71,138.08 425.82,138.31 432.93,138.45 440.04,138.50 447.14,138.45 454.25,138.30 461.36,138.06 468.47,137.71 475.58,137.26 482.68,136.70 489.79,136.03 496.90,135.26 504.01,134.38 511.12,133.39 518.22,132.29 525.33,131.09 532.44,129.78 539.55,128.37 546.65,126.85 553.76,125.23 560.87,123.50 567.98,121.67 575.09,119.74 582.19,117.70 589.30,115.56 596.41,113.32 603.52,110.98 610.63,108.54 617.73,105.99 624.84,103.34 ' style='stroke-width: 2.13; stroke: none; stroke-linecap: butt;' />
+<polyline points='624.84,139.37 617.73,140.32 610.63,141.24 603.52,142.13 596.41,142.98 589.30,143.79 582.19,144.57 575.09,145.32 567.98,146.02 560.87,146.69 553.76,147.33 546.65,147.92 539.55,148.48 532.44,149.00 525.33,149.49 518.22,149.94 511.12,150.36 504.01,150.74 496.90,151.08 489.79,151.39 482.68,151.66 475.58,151.89 468.47,152.09 461.36,152.24 454.25,152.35 447.14,152.41 440.04,152.43 432.93,152.39 425.82,152.30 418.71,152.15 411.60,151.94 404.50,151.66 397.39,151.32 390.28,150.90 383.17,150.41 376.06,149.84 368.96,149.19 361.85,148.46 354.74,147.65 347.63,146.75 340.52,145.76 333.42,144.68 326.31,143.51 319.20,142.25 312.09,140.89 304.98,139.44 297.88,137.88 290.77,136.23 283.66,134.49 276.55,132.64 269.44,130.69 262.34,128.64 255.23,126.48 248.12,124.23 241.01,121.88 233.91,119.44 226.80,116.90 219.69,114.28 212.58,111.58 205.47,108.81 198.37,105.99 191.26,103.14 184.15,100.33 177.04,97.69 169.93,95.24 162.83,92.97 155.72,90.90 148.61,88.97 141.50,87.13 134.39,85.30 127.29,83.42 120.18,80.87 113.07,77.27 105.96,73.61 98.85,69.78 91.75,65.13 84.64,61.48 77.53,58.86 70.42,57.94 63.31,60.45 ' style='stroke-width: 2.13; stroke: none; stroke-linecap: butt;' />
+<polyline points='63.31,55.44 70.42,55.50 77.53,56.55 84.64,58.62 91.75,62.07 98.85,66.15 105.96,69.95 113.07,73.82 120.18,77.27 127.29,79.65 134.39,81.49 141.50,83.35 148.61,85.23 155.72,87.17 162.83,89.21 169.93,91.36 177.04,93.67 184.15,96.15 191.26,98.82 198.37,101.48 205.47,104.06 212.58,106.56 219.69,108.98 226.80,111.33 233.91,113.59 241.01,115.77 248.12,117.87 255.23,119.90 262.34,121.84 269.44,123.71 276.55,125.50 283.66,127.21 290.77,128.84 297.88,130.39 304.98,131.87 312.09,133.27 319.20,134.59 326.31,135.84 333.42,137.01 340.52,138.10 347.63,139.11 354.74,140.05 361.85,140.92 368.96,141.70 376.06,142.42 383.17,143.05 390.28,143.62 397.39,144.10 404.50,144.51 411.60,144.85 418.71,145.12 425.82,145.31 432.93,145.42 440.04,145.46 447.14,145.43 454.25,145.33 461.36,145.15 468.47,144.90 475.58,144.57 482.68,144.18 489.79,143.71 496.90,143.17 504.01,142.56 511.12,141.87 518.22,141.12 525.33,140.29 532.44,139.39 539.55,138.42 546.65,137.39 553.76,136.28 560.87,135.10 567.98,133.85 575.09,132.53 582.19,131.14 589.30,129.68 596.41,128.15 603.52,126.55 610.63,124.89 617.73,123.16 624.84,121.35 ' style='stroke-width: 2.13; stroke: #3366FF; stroke-linecap: butt;' />
+<rect x='35.24' y='39.43' width='617.68' height='241.77' style='stroke-width: 1.07; stroke: #333333;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMzUuMjR8NjUyLjkyfDMwMy4zNHw1NDUuMTE='>
+    <rect x='35.24' y='303.34' width='617.68' height='241.77' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMzUuMjR8NjUyLjkyfDMwMy4zNHw1NDUuMTE=)'>
+<rect x='35.24' y='303.34' width='617.68' height='241.77' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<polygon points='351.17,499.02 353.81,503.58 348.54,503.58 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='79.53' cy='329.26' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='85.61,345.07 88.25,349.63 82.98,349.63 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='93.72,407.67 96.35,412.23 91.09,412.23 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='126.16' cy='369.33' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='73.45,345.19 76.08,349.75 70.82,349.75 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='77.50' cy='326.96' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='63.31,323.07 65.95,327.63 60.68,327.63 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='122.10,372.37 124.74,376.93 119.47,376.93 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='312.66,503.53 315.29,508.09 310.02,508.09 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='85.61,330.59 88.25,335.15 82.98,335.15 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='130.21,412.56 132.84,417.12 127.58,417.12 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='71.42' cy='319.64' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='73.45,402.40 76.08,406.96 70.82,406.96 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='73.45,347.51 76.08,352.07 70.82,352.07 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='71.42' cy='318.67' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='111.97,391.27 114.60,395.83 109.33,395.83 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='288.33,516.68 290.96,521.24 285.70,521.24 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='71.42' cy='318.04' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='160.62,417.02 163.25,421.58 157.99,421.58 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='69.40' cy='340.61' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='126.16,390.43 128.79,394.99 123.52,394.99 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='409.96,513.18 412.59,517.74 407.33,517.74 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='99.80,335.54 102.44,340.10 97.17,340.10 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='71.42' cy='317.37' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='162.65,416.76 165.28,421.32 160.01,421.32 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='495.10,502.57 497.74,507.13 492.47,507.13 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='405.91,491.41 408.54,495.97 403.27,495.97 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='71.42' cy='342.10' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='130.21,413.06 132.84,417.62 127.58,417.62 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='152.51,393.33 155.14,397.89 149.88,397.89 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='93.72' cy='343.89' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='73.45,350.62 76.08,355.18 70.82,355.18 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='73.45' cy='324.89' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='81.56,349.70 84.19,354.26 78.93,354.26 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='63.31' cy='322.85' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='201.16,452.36 203.80,456.92 198.53,456.92 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='124.13,352.83 126.76,357.39 121.50,357.39 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='71.42,355.61 74.06,360.17 68.79,360.17 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='83.59' cy='323.65' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='195.08,419.80 197.71,424.36 192.45,424.36 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='99.80' cy='332.39' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='79.53' cy='320.97' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='124.13,352.55 126.76,357.11 121.50,357.11 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='69.40' cy='317.58' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='172.78,413.01 175.41,417.57 170.15,417.57 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='67.37' cy='316.85' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='95.75' cy='336.54' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='73.45,323.10 76.08,327.66 70.82,327.66 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='79.53,328.71 82.16,333.27 76.90,333.27 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='73.45,317.18 76.08,321.74 70.82,321.74 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='178.86,418.11 181.50,422.67 176.23,422.67 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='109.94,428.64 112.57,433.20 107.31,433.20 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='83.59,320.37 86.22,324.93 80.95,324.93 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='93.72,348.48 96.35,353.04 91.09,353.04 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='79.53,316.86 82.16,321.42 76.90,321.42 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='103.86,415.82 106.49,420.38 101.23,420.38 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='71.42' cy='317.90' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='73.45,319.79 76.08,324.35 70.82,324.35 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='75.48' cy='339.28' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='69.40' cy='318.89' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='83.59,392.37 86.22,396.93 80.95,396.93 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='513.35,522.25 515.98,526.81 510.71,526.81 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='99.80,378.91 102.44,383.47 97.17,383.47 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='81.56' cy='318.92' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='85.61,320.56 88.25,325.12 82.98,325.12 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='79.53,324.75 82.16,329.31 76.90,329.31 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='71.42' cy='319.57' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='462.67,512.93 465.30,517.49 460.04,517.49 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='69.40' cy='346.50' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='81.56' cy='321.21' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='67.37' cy='317.86' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='71.42' cy='318.05' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='227.52,452.03 230.15,456.59 224.88,456.59 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='403.88,517.69 406.51,522.25 401.25,522.25 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='304.55,501.71 307.18,506.27 301.92,506.27 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='191.03,423.69 193.66,428.25 188.39,428.25 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='184.95,431.06 187.58,435.62 182.31,435.62 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='73.45' cy='333.60' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='203.19,439.82 205.82,444.38 200.56,444.38 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='349.15,511.17 351.78,515.73 346.51,515.73 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='148.46,436.57 151.09,441.13 145.82,441.13 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='83.59' cy='332.15' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='65.34' cy='321.71' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='99.80,341.62 102.44,346.18 97.17,346.18 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='158.59,435.98 161.22,440.54 155.96,440.54 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='79.53,315.91 82.16,320.47 76.90,320.47 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='69.40' cy='317.64' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='97.78,345.73 100.41,350.29 95.14,350.29 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='89.67,323.95 92.30,328.51 87.04,328.51 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='158.59,390.84 161.22,395.40 155.96,395.40 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='85.61,378.05 88.25,382.61 82.98,382.61 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='83.59' cy='324.68' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='122.10,412.43 124.74,416.99 119.47,416.99 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='409.96,513.94 412.59,518.50 407.33,518.50 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='77.50' cy='320.28' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='97.78,383.83 100.41,388.39 95.14,388.39 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='77.50' cy='321.12' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='93.72' cy='329.44' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='103.86,382.57 106.49,387.13 101.23,387.13 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='75.48' cy='318.55' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='75.48' cy='327.02' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='107.91,364.44 110.55,369.00 105.28,369.00 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='79.53,315.89 82.16,320.45 76.90,320.45 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='79.53' cy='332.43' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='99.80,372.05 102.44,376.61 97.17,376.61 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='69.40' cy='340.06' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='65.34,319.78 67.97,324.34 62.71,324.34 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='67.37' cy='316.18' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='95.75,321.65 98.38,326.21 93.12,326.21 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='168.73' cy='377.77' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='97.78,350.32 100.41,354.88 95.14,354.88 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='193.05,414.66 195.69,419.22 190.42,419.22 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='122.10,388.52 124.74,393.08 119.47,393.08 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='71.42' cy='320.79' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='118.05' cy='435.98' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='189.00,434.13 191.63,438.69 186.37,438.69 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='128.18,413.32 130.82,417.88 125.55,417.88 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='69.40,313.60 72.03,318.16 66.76,318.16 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='128.18' cy='356.07' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='83.59,379.09 86.22,383.65 80.95,383.65 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='69.40' cy='324.33' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='160.62,393.03 163.25,397.59 157.99,397.59 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='69.40' cy='327.36' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='83.59' cy='319.65' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='81.56,350.77 84.19,355.33 78.93,355.33 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='67.37' cy='318.66' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='385.64,492.40 388.27,496.96 383.00,496.96 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='75.48' cy='349.02' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='409.96,496.03 412.59,500.59 407.33,500.59 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='113.99,401.15 116.63,405.71 111.36,405.71 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='95.75' cy='323.83' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='87.64,351.84 90.27,356.40 85.01,356.40 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='71.42' cy='316.18' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='65.34' cy='319.56' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='73.45' cy='328.87' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='79.53' cy='343.71' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='205.22,442.53 207.85,447.09 202.58,447.09 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='79.53' cy='334.51' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='79.53' cy='332.04' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='75.48' cy='317.85' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='77.50,321.16 80.14,325.72 74.87,325.72 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='116.02,365.18 118.65,369.74 113.39,369.74 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='624.84,506.64 627.47,511.20 622.21,511.20 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='71.42' cy='325.36' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='81.56' cy='324.16' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='81.56' cy='366.90' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='203.19,462.13 205.82,466.69 200.56,466.69 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='118.05,402.27 120.68,406.83 115.42,406.83 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='77.50' cy='317.15' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='75.48' cy='361.15' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='103.86,442.27 106.49,446.83 101.23,446.83 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='67.37' cy='322.06' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='105.89,454.66 108.52,459.22 103.25,459.22 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='69.40' cy='320.69' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='574.16,483.00 576.80,487.56 571.53,487.56 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='69.40' cy='321.91' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='126.16' cy='372.87' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='107.91,384.56 110.55,389.12 105.28,389.12 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='69.40' cy='325.50' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='103.86' cy='349.77' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='122.10,420.83 124.74,425.39 119.47,425.39 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='63.31,320.45 65.95,325.01 60.68,325.01 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='229.54,437.37 232.18,441.93 226.91,441.93 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='138.32,402.05 140.95,406.61 135.69,406.61 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='172.78' cy='415.12' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='75.48,335.03 78.11,339.59 72.85,339.59 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='65.34' cy='317.67' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='83.59,322.97 86.22,327.53 80.95,327.53 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='81.56' cy='318.34' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='67.37' cy='343.35' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='83.59' cy='323.65' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='118.05' cy='354.07' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='67.37' cy='327.15' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='73.45' cy='325.62' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='122.10,362.31 124.74,366.87 119.47,366.87 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='75.48' cy='327.31' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='69.40' cy='344.49' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='93.72' cy='325.77' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='152.51' cy='369.30' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='85.61' cy='320.07' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='69.40' cy='324.59' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='67.37' cy='317.43' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='280.22,457.57 282.86,462.13 277.59,462.13 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='73.45' cy='319.59' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='97.78,390.33 100.41,394.89 95.14,394.89 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='341.04,473.76 343.67,478.32 338.40,478.32 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='71.42' cy='346.27' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='83.59' cy='323.91' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='103.86' cy='390.20' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='553.89,491.32 556.52,495.88 551.26,495.88 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='75.48' cy='328.95' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='276.17,482.59 278.80,487.15 273.54,487.15 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='87.64' cy='346.14' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='132.24' cy='368.71' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='85.61' cy='334.85' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='69.40' cy='318.86' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='71.42' cy='360.09' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='99.80' cy='343.88' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='152.51' cy='366.39' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='69.40' cy='347.62' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='67.37' cy='337.04' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='67.37' cy='320.35' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='71.42,331.70 74.06,336.26 68.79,336.26 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='107.91,379.00 110.55,383.56 105.28,383.56 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='69.40' cy='335.20' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='69.40' cy='356.47' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='136.29,447.26 138.93,451.82 133.66,451.82 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='71.42' cy='324.76' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='75.48' cy='322.77' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='83.59' cy='326.07' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='81.56' cy='321.45' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='67.37' cy='322.76' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='75.48,347.59 78.11,352.15 72.85,352.15 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='176.84,374.53 179.47,379.09 174.20,379.09 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='67.37' cy='328.33' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='288.33,469.94 290.96,474.50 285.70,474.50 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='67.37' cy='319.33' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='89.67' cy='323.90' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='134.27,465.20 136.90,469.76 131.63,469.76 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='75.48' cy='325.11' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='148.46,381.64 151.09,386.20 145.82,386.20 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='343.06,512.33 345.70,516.89 340.43,516.89 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='77.50' cy='321.62' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='71.42' cy='318.97' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='67.37' cy='323.33' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='103.86,365.17 106.49,369.73 101.23,369.73 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='71.42' cy='319.45' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='148.46,438.89 151.09,443.45 145.82,443.45 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='124.13' cy='354.82' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='126.16,483.49 128.79,488.05 123.52,488.05 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='65.34' cy='365.54' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='75.48' cy='368.76' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='75.48' cy='318.79' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='320.77' cy='495.65' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='87.64' cy='322.69' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='89.67' cy='389.63' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='69.40' cy='353.98' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='73.45,349.99 76.08,354.55 70.82,354.55 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='65.34' cy='322.54' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='146.43' cy='373.87' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='95.75' cy='401.14' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='219.41,468.57 222.04,473.13 216.77,473.13 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='136.29,406.55 138.93,411.11 133.66,411.11 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='69.40' cy='318.05' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='99.80' cy='330.21' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='180.89' cy='413.84' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='73.45' cy='327.59' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='83.59' cy='356.44' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='69.40' cy='321.78' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='67.37' cy='322.97' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='79.53' cy='364.03' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='201.16' cy='521.04' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='120.08' cy='359.11' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='71.42' cy='319.01' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='79.53' cy='319.59' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='67.37' cy='330.87' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='79.53' cy='325.38' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='120.08' cy='428.62' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='170.75' cy='447.13' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='122.10' cy='418.55' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='113.99' cy='394.17' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='79.53' cy='320.06' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='126.16' cy='420.06' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='128.18' cy='408.53' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='67.37' cy='331.43' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='191.03,478.08 193.66,482.64 188.39,482.64 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='186.97,456.34 189.60,460.90 184.34,460.90 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='130.21' cy='403.57' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='77.50' cy='319.22' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='77.50' cy='324.52' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='67.37' cy='365.87' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='101.83' cy='370.87' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='89.67' cy='361.05' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='101.83' cy='339.97' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='77.50' cy='324.60' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='77.50' cy='318.78' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='170.75' cy='379.90' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='67.37' cy='322.44' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='89.67' cy='321.16' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='420.10,511.57 422.73,516.13 417.46,516.13 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='83.59' cy='325.49' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='79.53' cy='348.39' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='83.59' cy='322.00' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='73.45' cy='325.77' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='97.78' cy='332.90' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='186.97' cy='460.57' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='233.60' cy='478.78' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='138.32,408.24 140.95,412.80 135.69,412.80 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='85.61' cy='369.17' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='122.10' cy='373.58' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='231.57' cy='475.67' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='229.54' cy='506.88' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='191.03' cy='475.47' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='105.89' cy='350.60' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='73.45' cy='341.48' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='81.56' cy='330.47' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='79.53' cy='327.04' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='105.89' cy='361.86' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='162.65,457.96 165.28,462.52 160.01,462.52 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='77.50' cy='320.83' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='71.42' cy='323.54' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='77.50' cy='363.50' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='67.37' cy='322.83' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='116.02' cy='373.22' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='69.40' cy='320.93' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='73.45' cy='317.96' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='65.34' cy='326.60' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='65.34' cy='363.88' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='91.70' cy='365.55' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='97.78' cy='361.08' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='186.97' cy='394.78' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='63.31,321.31 70.42,324.93 77.53,328.03 84.64,333.53 91.75,344.48 98.85,356.69 105.96,367.66 113.07,378.48 120.18,387.47 127.29,394.07 134.39,399.39 141.50,404.22 148.61,408.66 155.72,412.79 162.83,416.70 169.93,420.54 177.04,424.49 184.15,428.79 191.26,433.57 198.37,438.27 205.47,442.70 212.58,446.91 219.69,450.92 226.80,454.75 233.91,458.42 241.01,461.95 248.12,465.33 255.23,468.59 262.34,471.71 269.44,474.71 276.55,477.59 283.66,480.35 290.77,482.99 297.88,485.51 304.98,487.92 312.09,490.21 319.20,492.38 326.31,494.44 333.42,496.38 340.52,498.20 347.63,499.91 354.74,501.49 361.85,502.96 368.96,504.31 376.06,505.53 383.17,506.64 390.28,507.61 397.39,508.46 404.50,509.18 411.60,509.76 418.71,510.21 425.82,510.52 432.93,510.68 440.04,510.70 447.14,510.57 454.25,510.28 461.36,509.84 468.47,509.24 475.58,508.49 482.68,507.57 489.79,506.49 496.90,505.25 504.01,503.86 511.12,502.30 518.22,500.59 525.33,498.73 532.44,496.72 539.55,494.57 546.65,492.27 553.76,489.83 560.87,487.24 567.98,484.53 575.09,481.67 582.19,478.69 589.30,475.57 596.41,472.33 603.52,468.96 610.63,465.46 617.73,461.83 624.84,458.08 624.84,518.66 617.73,519.55 610.63,520.44 603.52,521.31 596.41,522.18 589.30,523.03 582.19,523.86 575.09,524.68 567.98,525.47 560.87,526.23 553.76,526.98 546.65,527.69 539.55,528.38 532.44,529.04 525.33,529.67 518.22,530.26 511.12,530.82 504.01,531.35 496.90,531.85 489.79,532.30 482.68,532.72 475.58,533.09 468.47,533.41 461.36,533.68 454.25,533.89 447.14,534.04 440.04,534.12 432.93,534.12 425.82,534.04 418.71,533.86 411.60,533.59 404.50,533.21 397.39,532.72 390.28,532.10 383.17,531.36 376.06,530.49 368.96,529.49 361.85,528.33 354.74,527.03 347.63,525.58 340.52,523.96 333.42,522.19 326.31,520.24 319.20,518.12 312.09,515.83 304.98,513.36 297.88,510.70 290.77,507.86 283.66,504.83 276.55,501.60 269.44,498.18 262.34,494.56 255.23,490.74 248.12,486.72 241.01,482.51 233.91,478.10 226.80,473.50 219.69,468.72 212.58,463.76 205.47,458.66 198.37,453.43 191.26,448.10 184.15,442.85 177.04,438.03 169.93,433.56 162.83,429.35 155.72,425.30 148.61,421.23 141.50,416.93 134.39,412.17 127.29,406.75 120.18,399.57 113.07,390.09 105.96,379.97 98.85,368.89 91.75,354.79 84.64,343.16 77.53,335.78 70.42,333.16 63.31,338.17 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #999999; fill-opacity: 0.40;' />
+<polyline points='63.31,321.31 70.42,324.93 77.53,328.03 84.64,333.53 91.75,344.48 98.85,356.69 105.96,367.66 113.07,378.48 120.18,387.47 127.29,394.07 134.39,399.39 141.50,404.22 148.61,408.66 155.72,412.79 162.83,416.70 169.93,420.54 177.04,424.49 184.15,428.79 191.26,433.57 198.37,438.27 205.47,442.70 212.58,446.91 219.69,450.92 226.80,454.75 233.91,458.42 241.01,461.95 248.12,465.33 255.23,468.59 262.34,471.71 269.44,474.71 276.55,477.59 283.66,480.35 290.77,482.99 297.88,485.51 304.98,487.92 312.09,490.21 319.20,492.38 326.31,494.44 333.42,496.38 340.52,498.20 347.63,499.91 354.74,501.49 361.85,502.96 368.96,504.31 376.06,505.53 383.17,506.64 390.28,507.61 397.39,508.46 404.50,509.18 411.60,509.76 418.71,510.21 425.82,510.52 432.93,510.68 440.04,510.70 447.14,510.57 454.25,510.28 461.36,509.84 468.47,509.24 475.58,508.49 482.68,507.57 489.79,506.49 496.90,505.25 504.01,503.86 511.12,502.30 518.22,500.59 525.33,498.73 532.44,496.72 539.55,494.57 546.65,492.27 553.76,489.83 560.87,487.24 567.98,484.53 575.09,481.67 582.19,478.69 589.30,475.57 596.41,472.33 603.52,468.96 610.63,465.46 617.73,461.83 624.84,458.08 ' style='stroke-width: 2.13; stroke: none; stroke-linecap: butt;' />
+<polyline points='624.84,518.66 617.73,519.55 610.63,520.44 603.52,521.31 596.41,522.18 589.30,523.03 582.19,523.86 575.09,524.68 567.98,525.47 560.87,526.23 553.76,526.98 546.65,527.69 539.55,528.38 532.44,529.04 525.33,529.67 518.22,530.26 511.12,530.82 504.01,531.35 496.90,531.85 489.79,532.30 482.68,532.72 475.58,533.09 468.47,533.41 461.36,533.68 454.25,533.89 447.14,534.04 440.04,534.12 432.93,534.12 425.82,534.04 418.71,533.86 411.60,533.59 404.50,533.21 397.39,532.72 390.28,532.10 383.17,531.36 376.06,530.49 368.96,529.49 361.85,528.33 354.74,527.03 347.63,525.58 340.52,523.96 333.42,522.19 326.31,520.24 319.20,518.12 312.09,515.83 304.98,513.36 297.88,510.70 290.77,507.86 283.66,504.83 276.55,501.60 269.44,498.18 262.34,494.56 255.23,490.74 248.12,486.72 241.01,482.51 233.91,478.10 226.80,473.50 219.69,468.72 212.58,463.76 205.47,458.66 198.37,453.43 191.26,448.10 184.15,442.85 177.04,438.03 169.93,433.56 162.83,429.35 155.72,425.30 148.61,421.23 141.50,416.93 134.39,412.17 127.29,406.75 120.18,399.57 113.07,390.09 105.96,379.97 98.85,368.89 91.75,354.79 84.64,343.16 77.53,335.78 70.42,333.16 63.31,338.17 ' style='stroke-width: 2.13; stroke: none; stroke-linecap: butt;' />
+<polyline points='63.31,329.74 70.42,329.04 77.53,331.91 84.64,338.35 91.75,349.63 98.85,362.79 105.96,373.82 113.07,384.28 120.18,393.52 127.29,400.41 134.39,405.78 141.50,410.58 148.61,414.94 155.72,419.04 162.83,423.03 169.93,427.05 177.04,431.26 184.15,435.82 191.26,440.84 198.37,445.85 205.47,450.68 212.58,455.34 219.69,459.82 226.80,464.12 233.91,468.26 241.01,472.23 248.12,476.03 255.23,479.66 262.34,483.14 269.44,486.45 276.55,489.60 283.66,492.59 290.77,495.42 297.88,498.11 304.98,500.64 312.09,503.02 319.20,505.25 326.31,507.34 333.42,509.28 340.52,511.08 347.63,512.74 354.74,514.26 361.85,515.65 368.96,516.90 376.06,518.01 383.17,519.00 390.28,519.86 397.39,520.59 404.50,521.19 411.60,521.68 418.71,522.04 425.82,522.28 432.93,522.40 440.04,522.41 447.14,522.30 454.25,522.09 461.36,521.76 468.47,521.33 475.58,520.79 482.68,520.14 489.79,519.40 496.90,518.55 504.01,517.60 511.12,516.56 518.22,515.43 525.33,514.20 532.44,512.88 539.55,511.47 546.65,509.98 553.76,508.40 560.87,506.74 567.98,505.00 575.09,503.18 582.19,501.28 589.30,499.30 596.41,497.25 603.52,495.14 610.63,492.95 617.73,490.69 624.84,488.37 ' style='stroke-width: 2.13; stroke: #3366FF; stroke-linecap: butt;' />
+<rect x='35.24' y='303.34' width='617.68' height='241.77' style='stroke-width: 1.07; stroke: #333333;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMzUuMjR8NjUyLjkyfDI4Ni42OXwzMDMuMzQ='>
+    <rect x='35.24' y='286.69' width='617.68' height='16.65' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMzUuMjR8NjUyLjkyfDI4Ni42OXwzMDMuMzQ=)'>
+<rect x='35.24' y='286.69' width='617.68' height='16.65' style='stroke-width: 1.07; stroke: #333333; fill: #D9D9D9;' />
+<text x='344.08' y='298.04' text-anchor='middle' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>3</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMzUuMjR8NjUyLjkyfDIyLjc4fDM5LjQz'>
+    <rect x='35.24' y='22.78' width='617.68' height='16.65' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMzUuMjR8NjUyLjkyfDIyLjc4fDM5LjQz)'>
+<rect x='35.24' y='22.78' width='617.68' height='16.65' style='stroke-width: 1.07; stroke: #333333; fill: #D9D9D9;' />
+<text x='344.08' y='34.14' text-anchor='middle' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>1</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<polyline points='57.23,547.85 57.23,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='259.95,547.85 259.95,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='462.67,547.85 462.67,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='57.23' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='259.95' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>10</text>
+<text x='462.67' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>20</text>
+<text x='30.31' y='281.84' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.2</text>
+<text x='30.31' y='225.12' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.4</text>
+<text x='30.31' y='168.41' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.6</text>
+<text x='30.31' y='111.69' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.8</text>
+<text x='30.31' y='54.98' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<polyline points='32.50,278.81 35.24,278.81 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='32.50,222.09 35.24,222.09 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='32.50,165.38 35.24,165.38 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='32.50,108.66 35.24,108.66 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='32.50,51.95 35.24,51.95 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='30.31' y='545.74' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.2</text>
+<text x='30.31' y='489.03' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.4</text>
+<text x='30.31' y='432.31' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.6</text>
+<text x='30.31' y='375.60' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.8</text>
+<text x='30.31' y='318.88' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<polyline points='32.50,542.71 35.24,542.71 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='32.50,486.00 35.24,486.00 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='32.50,429.28 35.24,429.28 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='32.50,372.57 35.24,372.57 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='32.50,315.85 35.24,315.85 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='344.08' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='13.44px' lengthAdjust='spacingAndGlyphs'>bili</text>
+<text transform='translate(13.05,292.27) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='39.13px' lengthAdjust='spacingAndGlyphs'>Survival</text>
+<rect x='663.88' y='267.33' width='50.64' height='49.89' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<text x='663.88' y='276.04' style='font-size: 11.00px; font-family: sans;' textLength='26.91px' lengthAdjust='spacingAndGlyphs'>event</text>
+<rect x='663.88' y='282.66' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<circle cx='672.52' cy='291.30' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<rect x='663.88' y='299.94' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<polygon points='672.52,305.54 675.15,310.10 669.88,310.10 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<text x='686.64' y='294.33' style='font-size: 8.80px; font-family: sans;' textLength='27.88px' lengthAdjust='spacingAndGlyphs'>FALSE</text>
+<text x='686.64' y='311.61' style='font-size: 8.80px; font-family: sans;' textLength='23.96px' lengthAdjust='spacingAndGlyphs'>TRUE</text>
+<text x='35.24' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='176.82px' lengthAdjust='spacingAndGlyphs'>gg_variable survival multi time</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/snapshots/gg-variable-survival-panel-multi-time.svg
+++ b/tests/testthat/_snaps/snapshots/gg-variable-survival-panel-multi-time.svg
@@ -1,0 +1,1429 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpMzUuMjR8MzMzLjAxfDM5LjQzfDI4OS41Mw=='>
+    <rect x='35.24' y='39.43' width='297.78' height='250.10' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMzUuMjR8MzMzLjAxfDM5LjQzfDI4OS41Mw==)'>
+<rect x='35.24' y='39.43' width='297.78' height='250.10' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<polygon points='187.55,174.05 190.18,178.61 184.91,178.61 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='56.59' cy='85.92' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='59.52,87.02 62.16,91.58 56.89,91.58 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='63.43,119.13 66.07,123.69 60.80,123.69 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='79.07' cy='88.95' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='53.66,84.01 56.29,88.56 51.03,88.56 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='55.61' cy='82.35' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='48.77,77.75 51.41,82.31 46.14,82.31 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='77.11,91.68 79.75,96.24 74.48,96.24 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='168.98,158.33 171.61,162.89 166.35,162.89 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='59.52,81.08 62.16,85.64 56.89,85.64 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='81.02,94.45 83.66,99.01 78.39,99.01 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='52.68' cy='80.98' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='53.66,124.26 56.29,128.82 51.03,128.82 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='53.66,83.31 56.29,87.87 51.03,87.87 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='52.68' cy='82.90' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='72.23,99.94 74.86,104.50 69.60,104.50 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='157.25,157.42 159.88,161.98 154.62,161.98 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='52.68' cy='80.84' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='95.68,106.82 98.32,111.38 93.05,111.38 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='51.71' cy='85.55' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='79.07,102.53 81.70,107.09 76.44,107.09 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='215.89,151.48 218.52,156.04 213.25,156.04 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='66.36,82.90 69.00,87.46 63.73,87.46 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='52.68' cy='81.55' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='96.66,94.40 99.29,98.96 94.03,98.96 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='256.93,139.48 259.57,144.04 254.30,144.04 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='213.93,146.43 216.57,150.99 211.30,150.99 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='52.68' cy='85.67' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='81.02,122.36 83.66,126.92 78.39,126.92 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='91.77,96.20 94.41,100.76 89.14,100.76 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='63.43' cy='85.04' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='53.66,84.36 56.29,88.92 51.03,88.92 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='53.66' cy='81.17' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='57.57,84.10 60.20,88.66 54.94,88.66 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='48.77' cy='81.48' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='115.23,122.55 117.86,127.11 112.60,127.11 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='78.09,83.54 80.72,88.10 75.46,88.10 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='52.68,87.22 55.32,91.78 50.05,91.78 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='58.55' cy='81.42' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='112.30,108.02 114.93,112.58 109.66,112.58 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='66.36' cy='82.77' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='56.59' cy='82.79' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='78.09,85.78 80.72,90.34 75.46,90.34 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='51.71' cy='80.99' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='101.55,103.15 104.18,107.71 98.91,107.71 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='50.73' cy='80.54' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='64.41' cy='85.60' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='53.66,78.37 56.29,82.93 51.03,82.93 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='56.59,79.16 59.22,83.72 53.96,83.72 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='53.66,77.50 56.29,82.06 51.03,82.06 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='104.48,99.14 107.11,103.70 101.85,103.70 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='71.25,117.80 73.88,122.36 68.62,122.36 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='58.55,79.39 61.18,83.95 55.91,83.95 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='63.43,83.17 66.07,87.73 60.80,87.73 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='56.59,80.49 59.22,85.05 53.96,85.05 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='68.32,103.28 70.95,107.84 65.69,107.84 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='52.68' cy='81.19' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='53.66,78.00 56.29,82.56 51.03,82.56 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='54.64' cy='85.28' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='51.71' cy='81.32' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='58.55,109.48 61.18,114.04 55.91,114.04 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='265.73,170.38 268.36,174.94 263.10,174.94 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='66.36,87.12 69.00,91.68 63.73,91.68 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='57.57' cy='81.82' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='59.52,78.85 62.16,83.41 56.89,83.41 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='56.59,80.30 59.22,84.86 53.96,84.86 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='52.68' cy='83.16' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='241.30,145.63 243.93,150.19 238.66,150.19 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='51.71' cy='101.22' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='57.57' cy='81.78' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='50.73' cy='80.99' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='52.68' cy='81.63' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='127.93,114.87 130.57,119.43 125.30,119.43 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='212.96,163.59 215.59,168.15 210.32,168.15 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='165.07,147.65 167.70,152.21 162.44,152.21 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='110.34,102.23 112.97,106.79 107.71,106.79 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='107.41,111.29 110.04,115.85 104.78,115.85 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='53.66' cy='93.87' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='116.21,114.94 118.84,119.50 113.57,119.50 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='186.57,145.29 189.20,149.85 183.94,149.85 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='89.82,113.70 92.45,118.26 87.19,118.26 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='58.55' cy='83.25' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='49.75' cy='80.81' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='66.36,81.70 69.00,86.26 63.73,86.26 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='94.71,105.43 97.34,109.99 92.07,109.99 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='56.59,77.85 59.22,82.41 53.96,82.41 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='51.71' cy='81.07' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='65.39,82.87 68.02,87.43 62.75,87.43 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='61.48,86.05 64.11,90.61 58.85,90.61 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='94.71,93.89 97.34,98.45 92.07,98.45 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='59.52,89.32 62.16,93.88 56.89,93.88 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='58.55' cy='86.44' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='77.11,109.79 79.75,114.35 74.48,114.35 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='215.89,156.82 218.52,161.38 213.25,161.38 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='55.61' cy='81.40' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='65.39,91.88 68.02,96.44 62.75,96.44 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='55.61' cy='83.08' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='63.43' cy='83.05' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='68.32,93.21 70.95,97.77 65.69,97.77 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='54.64' cy='81.02' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='54.64' cy='82.58' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='70.27,83.43 72.91,87.99 67.64,87.99 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='56.59,79.13 59.22,83.69 53.96,83.69 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='56.59' cy='92.52' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='66.36,90.85 69.00,95.41 63.73,95.41 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='51.71' cy='83.76' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='49.75,78.35 52.38,82.91 47.12,82.91 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='50.73' cy='80.54' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='64.41,78.75 67.04,83.31 61.78,83.31 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='99.59' cy='88.08' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='65.39,84.29 68.02,88.85 62.75,88.85 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='111.32,101.78 113.95,106.34 108.69,106.34 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='77.11,96.03 79.75,100.59 74.48,100.59 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='52.68' cy='84.50' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='75.16' cy='114.23' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='109.36,119.73 112.00,124.29 106.73,124.29 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='80.05,103.84 82.68,108.40 77.41,108.40 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='51.71,77.72 54.34,82.28 49.07,82.28 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='80.05' cy='89.34' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='58.55,89.04 61.18,93.60 55.91,93.60 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='51.71' cy='81.82' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='95.68,97.68 98.32,102.24 93.05,102.24 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='51.71' cy='80.72' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='58.55' cy='81.85' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='57.57,86.46 60.20,91.02 54.94,91.02 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='50.73' cy='82.04' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='204.16,160.14 206.79,164.70 201.53,164.70 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='54.64' cy='86.87' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='215.89,136.59 218.52,141.15 213.25,141.15 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='73.21,101.16 75.84,105.72 70.57,105.72 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='64.41' cy='81.98' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='60.50,83.63 63.13,88.19 57.87,88.19 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='52.68' cy='80.54' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='49.75' cy='81.12' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='53.66' cy='81.41' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='56.59' cy='84.53' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='117.18,113.42 119.82,117.98 114.55,117.98 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='56.59' cy='84.77' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='56.59' cy='82.83' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='54.64' cy='80.79' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='55.61,78.33 58.25,82.89 52.98,82.89 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='74.18,90.11 76.82,94.67 71.55,94.67 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='319.48,151.55 322.11,156.11 316.85,156.11 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='52.68' cy='81.67' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='57.57' cy='86.03' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='57.57' cy='85.51' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='116.21,124.85 118.84,129.41 113.57,129.41 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='75.16,104.86 77.79,109.42 72.53,109.42 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='55.61' cy='81.40' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='54.64' cy='89.07' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='68.32,125.40 70.95,129.96 65.69,129.96 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='50.73' cy='81.05' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='69.30,136.78 71.93,141.34 66.66,141.34 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='51.71' cy='80.81' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='295.05,140.82 297.68,145.38 292.41,145.38 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='51.71' cy='81.10' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='79.07' cy='90.48' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='70.27,92.00 72.91,96.56 67.64,96.56 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='51.71' cy='81.32' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='68.32' cy='85.86' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='77.11,99.66 79.75,104.22 74.48,104.22 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='48.77,78.10 51.41,82.66 46.14,82.66 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='128.91,108.59 131.54,113.15 126.28,113.15 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='84.93,97.21 87.57,101.77 82.30,101.77 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='101.55' cy='109.05' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='54.64,80.20 57.27,84.76 52.00,84.76 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='49.75' cy='80.54' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='58.55,84.29 61.18,88.85 55.91,88.85 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='57.57' cy='81.96' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='50.73' cy='98.30' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='58.55' cy='81.73' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='75.16' cy='86.64' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='50.73' cy='80.80' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='53.66' cy='80.77' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='77.11,87.45 79.75,92.01 74.48,92.01 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='54.64' cy='83.22' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='51.71' cy='85.50' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='63.43' cy='83.36' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='91.77' cy='91.92' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='59.52' cy='80.74' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='51.71' cy='80.54' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='50.73' cy='81.32' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='153.34,123.58 155.97,128.14 150.71,128.14 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='53.66' cy='80.90' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='65.39,87.75 68.02,92.31 62.75,92.31 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='182.66,131.28 185.29,135.84 180.03,135.84 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='52.68' cy='84.55' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='58.55' cy='82.53' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='68.32' cy='97.92' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='285.27,125.21 287.91,129.77 282.64,129.77 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='54.64' cy='81.36' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='151.39,142.66 154.02,147.22 148.75,147.22 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='60.50' cy='102.89' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='82.00' cy='89.81' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='59.52' cy='82.31' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='51.71' cy='80.80' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='52.68' cy='89.73' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='66.36' cy='85.15' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='91.77' cy='88.63' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='51.71' cy='85.90' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='50.73' cy='83.10' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='50.73' cy='84.00' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='52.68,79.93 55.32,84.49 50.05,84.49 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='70.27,88.39 72.91,92.95 67.64,92.95 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='51.71' cy='81.93' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='51.71' cy='89.22' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='83.96,127.95 86.59,132.51 81.32,132.51 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='52.68' cy='81.48' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='54.64' cy='81.08' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='58.55' cy='81.61' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='57.57' cy='82.50' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='50.73' cy='81.08' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='54.64,81.51 57.27,86.07 52.00,86.07 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='103.50,90.98 106.13,95.54 100.87,95.54 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='50.73' cy='81.30' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='157.25,130.61 159.88,135.17 154.62,135.17 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='50.73' cy='82.28' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='61.48' cy='84.36' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='82.98,124.72 85.61,129.28 80.35,129.28 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='54.64' cy='80.54' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='89.82,91.77 92.45,96.33 87.19,96.33 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='183.64,176.34 186.27,180.90 181.00,180.90 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='55.61' cy='84.03' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='52.68' cy='82.41' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='50.73' cy='81.80' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='68.32,89.08 70.95,93.64 65.69,93.64 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='52.68' cy='81.20' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='89.82,112.27 92.45,116.83 87.19,116.83 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='78.09' cy='88.04' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='79.07,176.90 81.70,181.46 76.44,181.46 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='49.75' cy='88.42' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='54.64' cy='89.98' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='54.64' cy='81.10' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='172.89' cy='133.12' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='60.50' cy='82.95' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='61.48' cy='105.02' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='51.71' cy='87.43' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='53.66,87.75 56.29,92.31 51.03,92.31 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='49.75' cy='80.90' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='88.84' cy='91.53' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='64.41' cy='108.34' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='124.02,149.31 126.66,153.87 121.39,153.87 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='83.96,97.56 86.59,102.12 81.32,102.12 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='51.71' cy='80.79' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='66.36' cy='84.30' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='105.46' cy='122.01' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='53.66' cy='81.36' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='58.55' cy='88.61' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='51.71' cy='81.32' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='50.73' cy='81.01' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='56.59' cy='87.85' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='115.23' cy='164.03' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='76.14' cy='89.11' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='52.68' cy='81.76' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='56.59' cy='83.46' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='50.73' cy='85.23' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='56.59' cy='82.08' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='76.14' cy='116.90' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='100.57' cy='112.81' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='77.11' cy='108.70' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='73.21' cy='101.41' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='56.59' cy='83.23' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='79.07' cy='109.33' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='80.05' cy='105.27' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='50.73' cy='83.82' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='110.34,161.61 112.97,166.17 107.71,166.17 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='108.39,140.92 111.02,145.48 105.75,145.48 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='81.02' cy='105.41' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='55.61' cy='82.36' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='55.61' cy='81.79' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='50.73' cy='91.55' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='67.34' cy='91.61' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='61.48' cy='88.64' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='67.34' cy='85.72' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='55.61' cy='83.27' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='55.61' cy='81.73' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='100.57' cy='91.21' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='50.73' cy='80.76' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='61.48' cy='81.50' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='220.77,178.18 223.41,182.74 218.14,182.74 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='58.55' cy='84.99' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='56.59' cy='87.13' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='58.55' cy='82.38' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='53.66' cy='82.05' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='65.39' cy='83.22' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='108.39' cy='124.51' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='130.86' cy='133.24' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='84.93,98.33 87.57,102.89 82.30,102.89 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='59.52' cy='90.71' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='77.11' cy='93.84' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='129.89' cy='133.00' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='128.91' cy='155.72' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='110.34' cy='141.63' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='69.30' cy='89.94' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='53.66' cy='85.06' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='57.57' cy='82.24' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='56.59' cy='83.08' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='69.30' cy='92.83' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='96.66,148.55 99.29,153.11 94.03,153.11 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='55.61' cy='81.01' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='52.68' cy='84.37' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='55.61' cy='89.00' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='50.73' cy='83.71' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='74.18' cy='92.99' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='51.71' cy='81.16' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='53.66' cy='81.24' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='49.75' cy='80.79' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='49.75' cy='96.89' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='62.46' cy='89.83' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='65.39' cy='90.35' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='108.39' cy='98.43' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='48.77,79.13 50.34,80.99 51.92,81.56 53.49,81.28 55.06,81.20 56.63,81.67 58.20,82.38 59.77,83.17 61.34,83.82 62.91,84.40 64.48,85.14 66.06,86.11 67.63,87.23 69.20,88.43 70.77,89.63 72.34,90.74 73.91,91.71 75.48,92.49 77.05,93.07 78.62,93.46 80.19,93.71 81.77,93.99 83.34,94.31 84.91,94.68 86.48,95.10 88.05,95.57 89.62,96.10 91.19,96.67 92.76,97.30 94.33,97.98 95.91,98.71 97.48,99.48 99.05,100.29 100.62,101.15 102.19,102.04 103.76,102.96 105.33,103.92 106.90,104.91 108.47,105.92 110.04,106.95 111.62,108.00 113.19,109.06 114.76,110.13 116.33,111.21 117.90,112.29 119.47,113.37 121.04,114.44 122.61,115.51 124.18,116.56 125.76,117.59 127.33,118.60 128.90,119.59 130.47,120.54 132.04,121.47 133.61,122.35 135.18,123.20 136.75,124.01 138.32,124.77 139.89,125.48 141.47,126.14 143.04,126.75 144.61,127.30 146.18,127.79 147.75,128.22 149.32,128.59 150.89,128.89 152.46,129.13 154.03,129.29 155.61,129.38 157.18,129.39 158.75,129.33 160.32,129.18 161.89,128.95 163.46,128.63 165.03,128.22 166.60,127.72 168.17,127.13 169.75,126.44 171.32,125.64 172.89,124.74 172.89,153.58 171.32,153.27 169.75,152.90 168.17,152.47 166.60,151.99 165.03,151.45 163.46,150.86 161.89,150.22 160.32,149.54 158.75,148.81 157.18,148.04 155.61,147.23 154.03,146.38 152.46,145.49 150.89,144.58 149.32,143.63 147.75,142.65 146.18,141.65 144.61,140.63 143.04,139.58 141.47,138.52 139.89,137.44 138.32,136.34 136.75,135.24 135.18,134.12 133.61,133.00 132.04,131.88 130.47,130.74 128.90,129.61 127.33,128.48 125.76,127.34 124.18,126.21 122.61,125.08 121.04,123.95 119.47,122.83 117.90,121.71 116.33,120.60 114.76,119.50 113.19,118.40 111.62,117.31 110.04,116.24 108.47,115.17 106.90,114.12 105.33,113.08 103.76,112.06 102.19,111.06 100.62,110.07 99.05,109.11 97.48,108.17 95.91,107.25 94.33,106.37 92.76,105.51 91.19,104.69 89.62,103.90 88.05,103.16 86.48,102.46 84.91,101.81 83.34,101.22 81.77,100.70 80.19,100.24 78.62,99.86 77.05,99.28 75.48,98.47 73.91,97.51 72.34,96.46 70.77,95.38 69.20,94.28 67.63,93.16 66.06,92.01 64.48,90.86 62.91,89.73 61.34,88.67 59.77,87.76 58.20,86.85 56.63,85.77 55.06,85.17 53.49,84.87 51.92,84.81 50.34,86.03 48.77,88.96 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #999999; fill-opacity: 0.40;' />
+<polyline points='48.77,79.13 50.34,80.99 51.92,81.56 53.49,81.28 55.06,81.20 56.63,81.67 58.20,82.38 59.77,83.17 61.34,83.82 62.91,84.40 64.48,85.14 66.06,86.11 67.63,87.23 69.20,88.43 70.77,89.63 72.34,90.74 73.91,91.71 75.48,92.49 77.05,93.07 78.62,93.46 80.19,93.71 81.77,93.99 83.34,94.31 84.91,94.68 86.48,95.10 88.05,95.57 89.62,96.10 91.19,96.67 92.76,97.30 94.33,97.98 95.91,98.71 97.48,99.48 99.05,100.29 100.62,101.15 102.19,102.04 103.76,102.96 105.33,103.92 106.90,104.91 108.47,105.92 110.04,106.95 111.62,108.00 113.19,109.06 114.76,110.13 116.33,111.21 117.90,112.29 119.47,113.37 121.04,114.44 122.61,115.51 124.18,116.56 125.76,117.59 127.33,118.60 128.90,119.59 130.47,120.54 132.04,121.47 133.61,122.35 135.18,123.20 136.75,124.01 138.32,124.77 139.89,125.48 141.47,126.14 143.04,126.75 144.61,127.30 146.18,127.79 147.75,128.22 149.32,128.59 150.89,128.89 152.46,129.13 154.03,129.29 155.61,129.38 157.18,129.39 158.75,129.33 160.32,129.18 161.89,128.95 163.46,128.63 165.03,128.22 166.60,127.72 168.17,127.13 169.75,126.44 171.32,125.64 172.89,124.74 ' style='stroke-width: 2.13; stroke: none; stroke-linecap: butt;' />
+<polyline points='172.89,153.58 171.32,153.27 169.75,152.90 168.17,152.47 166.60,151.99 165.03,151.45 163.46,150.86 161.89,150.22 160.32,149.54 158.75,148.81 157.18,148.04 155.61,147.23 154.03,146.38 152.46,145.49 150.89,144.58 149.32,143.63 147.75,142.65 146.18,141.65 144.61,140.63 143.04,139.58 141.47,138.52 139.89,137.44 138.32,136.34 136.75,135.24 135.18,134.12 133.61,133.00 132.04,131.88 130.47,130.74 128.90,129.61 127.33,128.48 125.76,127.34 124.18,126.21 122.61,125.08 121.04,123.95 119.47,122.83 117.90,121.71 116.33,120.60 114.76,119.50 113.19,118.40 111.62,117.31 110.04,116.24 108.47,115.17 106.90,114.12 105.33,113.08 103.76,112.06 102.19,111.06 100.62,110.07 99.05,109.11 97.48,108.17 95.91,107.25 94.33,106.37 92.76,105.51 91.19,104.69 89.62,103.90 88.05,103.16 86.48,102.46 84.91,101.81 83.34,101.22 81.77,100.70 80.19,100.24 78.62,99.86 77.05,99.28 75.48,98.47 73.91,97.51 72.34,96.46 70.77,95.38 69.20,94.28 67.63,93.16 66.06,92.01 64.48,90.86 62.91,89.73 61.34,88.67 59.77,87.76 58.20,86.85 56.63,85.77 55.06,85.17 53.49,84.87 51.92,84.81 50.34,86.03 48.77,88.96 ' style='stroke-width: 2.13; stroke: none; stroke-linecap: butt;' />
+<polyline points='48.77,84.04 50.34,83.51 51.92,83.19 53.49,83.08 55.06,83.19 56.63,83.72 58.20,84.61 59.77,85.46 61.34,86.25 62.91,87.06 64.48,88.00 66.06,89.06 67.63,90.20 69.20,91.36 70.77,92.51 72.34,93.60 73.91,94.61 75.48,95.48 77.05,96.18 78.62,96.66 80.19,96.98 81.77,97.34 83.34,97.76 84.91,98.25 86.48,98.78 88.05,99.36 89.62,100.00 91.19,100.68 92.76,101.41 94.33,102.17 95.91,102.98 97.48,103.82 99.05,104.70 100.62,105.61 102.19,106.55 103.76,107.51 105.33,108.50 106.90,109.51 108.47,110.54 110.04,111.59 111.62,112.66 113.19,113.73 114.76,114.81 116.33,115.91 117.90,117.00 119.47,118.10 121.04,119.20 122.61,120.29 124.18,121.38 125.76,122.47 127.33,123.54 128.90,124.60 130.47,125.64 132.04,126.67 133.61,127.68 135.18,128.66 136.75,129.62 138.32,130.56 139.89,131.46 141.47,132.33 143.04,133.16 144.61,133.96 146.18,134.72 147.75,135.44 149.32,136.11 150.89,136.74 152.46,137.31 154.03,137.83 155.61,138.30 157.18,138.72 158.75,139.07 160.32,139.36 161.89,139.59 163.46,139.75 165.03,139.84 166.60,139.85 168.17,139.80 169.75,139.67 171.32,139.45 172.89,139.16 ' style='stroke-width: 2.13; stroke: #F8766D; stroke-linecap: butt;' />
+<polygon points='48.77,70.70 52.20,76.99 55.63,82.34 59.05,86.62 62.48,89.96 65.91,92.80 69.33,95.31 72.76,97.96 76.19,100.31 79.61,102.12 83.04,103.34 86.47,104.01 89.89,104.66 93.32,106.00 96.75,107.56 100.17,109.06 103.60,110.37 107.03,111.54 110.45,112.74 113.88,114.11 117.31,115.59 120.73,117.18 124.16,118.89 127.59,120.68 131.01,122.55 134.44,124.48 137.87,126.43 141.29,128.39 144.72,130.33 148.15,132.24 151.57,134.09 155.00,135.87 158.43,137.56 161.85,139.16 165.28,140.66 168.71,142.06 172.13,143.35 175.56,144.54 178.99,145.61 182.41,146.57 185.84,147.42 189.27,148.19 192.69,148.90 196.12,149.54 199.55,150.12 202.97,150.63 206.40,151.08 209.83,151.46 213.25,151.78 216.68,152.02 220.11,152.20 223.53,152.31 226.96,152.35 230.39,152.31 233.81,152.19 237.24,151.99 240.67,151.70 244.09,151.32 247.52,150.86 250.95,150.29 254.37,149.63 257.80,148.87 261.23,148.00 264.65,147.03 268.08,145.96 271.51,144.78 274.93,143.49 278.36,142.10 281.79,140.61 285.21,139.01 288.64,137.31 292.07,135.51 295.49,133.60 298.92,131.60 302.35,129.49 305.77,127.29 309.20,124.99 312.63,122.59 316.05,120.09 319.48,117.50 319.48,159.60 316.05,160.08 312.63,160.54 309.20,160.99 305.77,161.42 302.35,161.84 298.92,162.24 295.49,162.63 292.07,163.00 288.64,163.35 285.21,163.69 281.79,164.02 278.36,164.34 274.93,164.64 271.51,164.93 268.08,165.21 264.65,165.47 261.23,165.72 257.80,165.95 254.37,166.16 250.95,166.36 247.52,166.53 244.09,166.68 240.67,166.80 237.24,166.88 233.81,166.93 230.39,166.94 226.96,166.90 223.53,166.82 220.11,166.69 216.68,166.50 213.25,166.25 209.83,165.95 206.40,165.59 202.97,165.17 199.55,164.68 196.12,164.14 192.69,163.53 189.27,162.86 185.84,162.13 182.41,161.33 178.99,160.36 175.56,159.20 172.13,157.89 168.71,156.43 165.28,154.85 161.85,153.17 158.43,151.42 155.00,149.61 151.57,147.77 148.15,145.90 144.72,144.02 141.29,142.12 137.87,140.22 134.44,138.32 131.01,136.42 127.59,134.52 124.16,132.63 120.73,130.75 117.31,128.89 113.88,127.07 110.45,125.32 107.03,123.61 103.60,122.03 100.17,120.65 96.75,119.45 93.32,118.24 89.89,116.80 86.47,115.27 83.04,113.86 79.61,112.55 76.19,110.75 72.76,107.98 69.33,104.85 65.91,101.64 62.48,98.17 59.05,94.85 55.63,92.13 52.20,90.22 48.77,89.07 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #999999; fill-opacity: 0.40;' />
+<polyline points='48.77,70.70 52.20,76.99 55.63,82.34 59.05,86.62 62.48,89.96 65.91,92.80 69.33,95.31 72.76,97.96 76.19,100.31 79.61,102.12 83.04,103.34 86.47,104.01 89.89,104.66 93.32,106.00 96.75,107.56 100.17,109.06 103.60,110.37 107.03,111.54 110.45,112.74 113.88,114.11 117.31,115.59 120.73,117.18 124.16,118.89 127.59,120.68 131.01,122.55 134.44,124.48 137.87,126.43 141.29,128.39 144.72,130.33 148.15,132.24 151.57,134.09 155.00,135.87 158.43,137.56 161.85,139.16 165.28,140.66 168.71,142.06 172.13,143.35 175.56,144.54 178.99,145.61 182.41,146.57 185.84,147.42 189.27,148.19 192.69,148.90 196.12,149.54 199.55,150.12 202.97,150.63 206.40,151.08 209.83,151.46 213.25,151.78 216.68,152.02 220.11,152.20 223.53,152.31 226.96,152.35 230.39,152.31 233.81,152.19 237.24,151.99 240.67,151.70 244.09,151.32 247.52,150.86 250.95,150.29 254.37,149.63 257.80,148.87 261.23,148.00 264.65,147.03 268.08,145.96 271.51,144.78 274.93,143.49 278.36,142.10 281.79,140.61 285.21,139.01 288.64,137.31 292.07,135.51 295.49,133.60 298.92,131.60 302.35,129.49 305.77,127.29 309.20,124.99 312.63,122.59 316.05,120.09 319.48,117.50 ' style='stroke-width: 2.13; stroke: none; stroke-linecap: butt;' />
+<polyline points='319.48,159.60 316.05,160.08 312.63,160.54 309.20,160.99 305.77,161.42 302.35,161.84 298.92,162.24 295.49,162.63 292.07,163.00 288.64,163.35 285.21,163.69 281.79,164.02 278.36,164.34 274.93,164.64 271.51,164.93 268.08,165.21 264.65,165.47 261.23,165.72 257.80,165.95 254.37,166.16 250.95,166.36 247.52,166.53 244.09,166.68 240.67,166.80 237.24,166.88 233.81,166.93 230.39,166.94 226.96,166.90 223.53,166.82 220.11,166.69 216.68,166.50 213.25,166.25 209.83,165.95 206.40,165.59 202.97,165.17 199.55,164.68 196.12,164.14 192.69,163.53 189.27,162.86 185.84,162.13 182.41,161.33 178.99,160.36 175.56,159.20 172.13,157.89 168.71,156.43 165.28,154.85 161.85,153.17 158.43,151.42 155.00,149.61 151.57,147.77 148.15,145.90 144.72,144.02 141.29,142.12 137.87,140.22 134.44,138.32 131.01,136.42 127.59,134.52 124.16,132.63 120.73,130.75 117.31,128.89 113.88,127.07 110.45,125.32 107.03,123.61 103.60,122.03 100.17,120.65 96.75,119.45 93.32,118.24 89.89,116.80 86.47,115.27 83.04,113.86 79.61,112.55 76.19,110.75 72.76,107.98 69.33,104.85 65.91,101.64 62.48,98.17 59.05,94.85 55.63,92.13 52.20,90.22 48.77,89.07 ' style='stroke-width: 2.13; stroke: none; stroke-linecap: butt;' />
+<polyline points='48.77,79.89 52.20,83.61 55.63,87.24 59.05,90.74 62.48,94.07 65.91,97.22 69.33,100.08 72.76,102.97 76.19,105.53 79.61,107.33 83.04,108.60 86.47,109.64 89.89,110.73 93.32,112.12 96.75,113.51 100.17,114.86 103.60,116.20 107.03,117.58 110.45,119.03 113.88,120.59 117.31,122.24 120.73,123.97 124.16,125.76 127.59,127.60 131.01,129.49 134.44,131.40 137.87,133.33 141.29,135.26 144.72,137.18 148.15,139.07 151.57,140.93 155.00,142.74 158.43,144.49 161.85,146.16 165.28,147.75 168.71,149.24 172.13,150.62 175.56,151.87 178.99,152.99 182.41,153.95 185.84,154.77 189.27,155.53 192.69,156.22 196.12,156.84 199.55,157.40 202.97,157.90 206.40,158.33 209.83,158.71 213.25,159.01 216.68,159.26 220.11,159.44 223.53,159.57 226.96,159.63 230.39,159.62 233.81,159.56 237.24,159.44 240.67,159.25 244.09,159.00 247.52,158.69 250.95,158.33 254.37,157.90 257.80,157.41 261.23,156.86 264.65,156.25 268.08,155.58 271.51,154.85 274.93,154.07 278.36,153.22 281.79,152.32 285.21,151.35 288.64,150.33 292.07,149.25 295.49,148.11 298.92,146.92 302.35,145.67 305.77,144.36 309.20,142.99 312.63,141.57 316.05,140.08 319.48,138.55 ' style='stroke-width: 2.13; stroke: #00BFC4; stroke-linecap: butt;' />
+<rect x='35.24' y='39.43' width='297.78' height='250.10' style='stroke-width: 1.07; stroke: #333333;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMzUuMjR8MzMzLjAxfDI5NS4wMXw1NDUuMTE='>
+    <rect x='35.24' y='295.01' width='297.78' height='250.10' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMzUuMjR8MzMzLjAxfDI5NS4wMXw1NDUuMTE=)'>
+<rect x='35.24' y='295.01' width='297.78' height='250.10' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<polygon points='187.55,489.18 190.18,493.74 184.91,493.74 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='56.59' cy='347.35' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='59.52,360.12 62.16,364.68 56.89,364.68 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='63.43,412.60 66.07,417.16 60.80,417.16 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='79.07' cy='380.95' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='53.66,360.22 56.29,364.78 51.03,364.78 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='55.61' cy='345.43' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='48.77,341.67 51.41,346.23 46.14,346.23 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='77.11,383.01 79.75,387.57 74.48,387.57 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='168.98,492.96 171.61,497.52 166.35,497.52 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='59.52,347.98 62.16,352.54 56.89,352.54 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='81.02,416.69 83.66,421.25 78.39,421.25 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='52.68' cy='339.29' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='53.66,408.18 56.29,412.74 51.03,412.74 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='53.66,362.16 56.29,366.72 51.03,366.72 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='52.68' cy='338.48' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='72.23,398.85 74.86,403.41 69.60,403.41 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='157.25,503.98 159.88,508.54 154.62,508.54 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='52.68' cy='337.95' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='95.68,420.43 98.32,424.99 93.05,424.99 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='51.71' cy='356.87' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='79.07,398.15 81.70,402.71 76.44,402.71 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='215.89,501.05 218.52,505.61 213.25,505.61 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='66.36,352.13 69.00,356.69 63.73,356.69 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='52.68' cy='337.38' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='96.66,420.22 99.29,424.78 94.03,424.78 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='256.93,492.15 259.57,496.71 254.30,496.71 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='213.93,482.80 216.57,487.36 211.30,487.36 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='52.68' cy='358.12' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='81.02,417.12 83.66,421.68 78.39,421.68 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='91.77,400.58 94.41,405.14 89.14,405.14 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='63.43' cy='359.62' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='53.66,364.77 56.29,369.33 51.03,369.33 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='53.66' cy='343.69' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='57.57,364.00 60.20,368.56 54.94,368.56 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='48.77' cy='341.98' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='115.23,450.06 117.86,454.62 112.60,454.62 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='78.09,366.62 80.72,371.18 75.46,371.18 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='52.68,368.95 55.32,373.51 50.05,373.51 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='58.55' cy='342.65' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='112.30,422.77 114.93,427.33 109.66,427.33 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='66.36' cy='349.98' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='56.59' cy='340.40' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='78.09,366.39 80.72,370.95 75.46,370.95 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='51.71' cy='337.57' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='101.55,417.08 104.18,421.64 98.91,421.64 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='50.73' cy='336.95' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='64.41' cy='353.46' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='53.66,341.70 56.29,346.26 51.03,346.26 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='56.59,346.40 59.22,350.96 53.96,350.96 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='53.66,336.74 56.29,341.30 51.03,341.30 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='104.48,421.35 107.11,425.91 101.85,425.91 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='71.25,430.18 73.88,434.74 68.62,434.74 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='58.55,339.42 61.18,343.98 55.91,343.98 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='63.43,362.97 66.07,367.53 60.80,367.53 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='56.59,336.47 59.22,341.03 53.96,341.03 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='68.32,419.43 70.95,423.99 65.69,423.99 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='52.68' cy='337.83' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='53.66,338.92 56.29,343.48 51.03,343.48 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='54.64' cy='355.75' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='51.71' cy='338.66' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='58.55,399.77 61.18,404.33 55.91,404.33 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='265.73,508.65 268.36,513.21 263.10,513.21 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='66.36,388.48 69.00,393.04 63.73,393.04 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='57.57' cy='338.68' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='59.52,339.57 62.16,344.13 56.89,344.13 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='56.59,343.08 59.22,347.64 53.96,347.64 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='52.68' cy='339.23' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='241.30,500.84 243.93,505.40 238.66,505.40 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='51.71' cy='361.81' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='57.57' cy='340.61' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='50.73' cy='337.80' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='52.68' cy='337.96' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='127.93,449.79 130.57,454.35 125.30,454.35 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='212.96,504.83 215.59,509.39 210.32,509.39 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='165.07,491.44 167.70,496.00 162.44,496.00 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='110.34,426.02 112.97,430.58 107.71,430.58 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='107.41,432.20 110.04,436.76 104.78,436.76 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='53.66' cy='350.99' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='116.21,439.55 118.84,444.11 113.57,444.11 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='186.57,499.37 189.20,503.93 183.94,503.93 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='89.82,436.83 92.45,441.39 87.19,441.39 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='58.55' cy='349.78' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='49.75' cy='341.03' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='66.36,357.23 69.00,361.79 63.73,361.79 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='94.71,436.33 97.34,440.89 92.07,440.89 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='56.59,335.67 59.22,340.23 53.96,340.23 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='51.71' cy='337.61' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='65.39,360.67 68.02,365.23 62.75,365.23 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='61.48,342.41 64.11,346.97 58.85,346.97 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='94.71,398.49 97.34,403.05 92.07,403.05 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='59.52,387.76 62.16,392.32 56.89,392.32 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='58.55' cy='343.52' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='77.11,416.59 79.75,421.15 74.48,421.15 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='215.89,501.69 218.52,506.25 213.25,506.25 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='55.61' cy='339.83' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='65.39,392.61 68.02,397.17 62.75,397.17 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='55.61' cy='340.53' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='63.43' cy='347.51' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='68.32,391.56 70.95,396.12 65.69,396.12 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='54.64' cy='338.38' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='54.64' cy='345.47' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='70.27,376.35 72.91,380.91 67.64,380.91 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='56.59,335.65 59.22,340.21 53.96,340.21 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='56.59' cy='350.02' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='66.36,382.74 69.00,387.30 63.73,387.30 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='51.71' cy='356.41' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='49.75,338.92 52.38,343.48 47.12,343.48 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='50.73' cy='336.39' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='64.41,340.48 67.04,345.04 61.78,345.04 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='99.59' cy='388.02' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='65.39,364.52 68.02,369.08 62.75,369.08 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='111.32,418.46 113.95,423.02 108.69,423.02 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='77.11,396.55 79.75,401.11 74.48,401.11 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='52.68' cy='340.26' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='75.16' cy='436.82' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='109.36,434.78 112.00,439.34 106.73,439.34 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='80.05,417.34 82.68,421.90 77.41,421.90 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='51.71,333.74 54.34,338.30 49.07,338.30 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='80.05' cy='369.83' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='58.55,388.64 61.18,393.20 55.91,393.20 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='51.71' cy='343.22' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='95.68,400.32 98.32,404.88 93.05,404.88 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='51.71' cy='345.76' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='58.55' cy='339.29' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='57.57,364.90 60.20,369.45 54.94,369.45 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='50.73' cy='338.47' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='204.16,483.63 206.79,488.19 201.53,488.19 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='54.64' cy='363.92' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='215.89,486.67 218.52,491.23 213.25,491.23 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='73.21,407.14 75.84,411.70 70.57,411.70 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='64.41' cy='342.80' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='60.50,365.79 63.13,370.35 57.87,370.35 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='52.68' cy='336.39' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='49.75' cy='339.22' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='53.66' cy='347.03' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='56.59' cy='359.47' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='117.18,441.83 119.82,446.39 114.55,446.39 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='56.59' cy='351.76' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='56.59' cy='349.69' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='54.64' cy='337.79' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='55.61,340.07 58.25,344.63 52.98,344.63 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='74.18,376.98 76.82,381.54 71.55,381.54 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='319.48,495.57 322.11,500.13 316.85,500.13 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='52.68' cy='344.09' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='57.57' cy='343.08' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='57.57' cy='378.91' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='116.21,458.25 118.84,462.81 113.57,462.81 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='75.16,408.07 77.79,412.63 72.53,412.63 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='55.61' cy='337.20' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='54.64' cy='374.09' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='68.32,441.61 70.95,446.17 65.69,446.17 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='50.73' cy='341.32' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='69.30,451.99 71.93,456.55 66.66,456.55 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='51.71' cy='340.17' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='295.05,475.75 297.68,480.31 292.41,480.31 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='51.71' cy='341.20' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='79.07' cy='383.91' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='70.27,393.22 72.91,397.78 67.64,397.78 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='51.71' cy='344.20' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='68.32' cy='364.55' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='77.11,423.63 79.75,428.19 74.48,428.19 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='48.77,339.48 51.41,344.04 46.14,344.04 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='128.91,437.50 131.54,442.06 126.28,442.06 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='84.93,407.88 87.57,412.44 82.30,412.44 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='101.55' cy='419.33' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='54.64,351.70 57.27,356.26 52.00,356.26 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='49.75' cy='337.64' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='58.55,341.59 61.18,346.15 55.91,346.15 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='57.57' cy='338.20' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='50.73' cy='359.17' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='58.55' cy='342.65' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='75.16' cy='368.16' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='50.73' cy='345.59' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='53.66' cy='344.30' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='77.11,374.57 79.75,379.13 74.48,379.13 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='54.64' cy='345.72' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='51.71' cy='360.13' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='63.43' cy='344.43' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='91.77' cy='380.93' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='59.52' cy='339.65' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='51.71' cy='343.44' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='50.73' cy='337.43' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='153.34,454.43 155.97,458.99 150.71,458.99 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='53.66' cy='339.25' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='65.39,398.06 68.02,402.62 62.75,402.62 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='182.66,468.00 185.29,472.56 180.03,472.56 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='52.68' cy='361.62' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='58.55' cy='342.87' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='68.32' cy='398.45' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='285.27,482.72 287.91,487.28 282.64,487.28 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='54.64' cy='347.09' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='151.39,475.40 154.02,479.96 148.75,479.96 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='60.50' cy='361.51' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='82.00' cy='380.43' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='59.52' cy='352.04' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='51.71' cy='338.64' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='52.68' cy='373.20' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='66.36' cy='359.61' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='91.77' cy='378.48' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='51.71' cy='362.75' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='50.73' cy='353.88' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='50.73' cy='339.89' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='52.68,348.91 55.32,353.47 50.05,353.47 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='70.27,388.57 72.91,393.13 67.64,393.13 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='51.71' cy='352.33' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='51.71' cy='370.17' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='83.96,445.79 86.59,450.35 81.32,450.35 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='52.68' cy='343.58' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='54.64' cy='341.91' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='58.55' cy='344.68' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='57.57' cy='340.81' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='50.73' cy='341.90' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='54.64,362.23 57.27,366.79 52.00,366.79 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='103.50,384.81 106.13,389.37 100.87,389.37 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='50.73' cy='346.58' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='157.25,464.80 159.88,469.36 154.62,469.36 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='50.73' cy='339.03' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='61.48' cy='342.86' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='82.98,460.83 85.61,465.39 80.35,465.39 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='54.64' cy='343.88' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='89.82,390.77 92.45,395.33 87.19,395.33 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='183.64,500.34 186.27,504.90 181.00,504.90 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='55.61' cy='340.95' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='52.68' cy='338.73' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='50.73' cy='342.39' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='68.32,376.97 70.95,381.53 65.69,381.53 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='52.68' cy='339.13' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='89.82,438.77 92.45,443.33 87.19,443.33 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='78.09' cy='368.79' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='79.07,476.16 81.70,480.72 76.44,480.72 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='49.75' cy='377.77' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='54.64' cy='380.47' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='54.64' cy='338.58' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='172.89' cy='486.85' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='60.50' cy='341.85' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='61.48' cy='397.97' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='51.71' cy='368.08' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='53.66,364.24 56.29,368.80 51.03,368.80 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='49.75' cy='341.72' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='88.84' cy='384.76' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='64.41' cy='407.62' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='124.02,463.65 126.66,468.21 121.39,468.21 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='83.96,411.66 86.59,416.22 81.32,416.22 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='51.71' cy='337.96' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='66.36' cy='348.15' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='105.46' cy='418.26' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='53.66' cy='345.96' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='58.55' cy='370.15' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='51.71' cy='341.08' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='50.73' cy='342.08' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='56.59' cy='376.50' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='115.23' cy='508.13' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='76.14' cy='372.38' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='52.68' cy='338.76' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='56.59' cy='339.25' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='50.73' cy='348.71' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='56.59' cy='344.11' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='76.14' cy='430.65' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='100.57' cy='446.17' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='77.11' cy='422.21' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='73.21' cy='401.77' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='56.59' cy='339.64' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='79.07' cy='423.48' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='80.05' cy='413.81' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='50.73' cy='349.18' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='110.34,471.63 112.97,476.19 107.71,476.19 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='108.39,453.40 111.02,457.96 105.75,457.96 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='81.02' cy='409.65' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='55.61' cy='338.94' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='55.61' cy='343.38' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='50.73' cy='378.05' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='67.34' cy='382.24' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='61.48' cy='374.01' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='67.34' cy='356.33' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='55.61' cy='343.45' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='55.61' cy='338.57' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='100.57' cy='389.81' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='50.73' cy='341.64' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='61.48' cy='340.56' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='220.77,499.70 223.41,504.26 218.14,504.26 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='58.55' cy='344.19' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='56.59' cy='363.39' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='58.55' cy='341.27' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='53.66' cy='344.43' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='65.39' cy='350.40' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='108.39' cy='457.44' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='130.86' cy='472.71' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='84.93,413.08 87.57,417.64 82.30,417.64 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='59.52' cy='380.81' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='77.11' cy='384.51' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='129.89' cy='470.10' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='128.91' cy='496.26' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='110.34' cy='469.93' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='69.30' cy='365.24' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='53.66' cy='357.60' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='57.57' cy='348.37' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='56.59' cy='345.50' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='69.30' cy='374.69' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='96.66,454.76 99.29,459.32 94.03,459.32 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='55.61' cy='340.29' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='52.68' cy='342.56' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='55.61' cy='376.06' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='50.73' cy='341.96' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='74.18' cy='384.21' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='51.71' cy='340.37' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='53.66' cy='337.88' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='49.75' cy='345.13' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='49.75' cy='376.38' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='62.46' cy='377.78' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='65.39' cy='374.03' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='108.39' cy='402.28' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='48.77,337.80 50.34,341.68 51.92,342.94 53.49,342.44 55.06,342.48 56.63,343.45 58.20,345.13 59.77,347.40 61.34,349.75 62.91,352.22 64.48,355.25 66.06,358.89 67.63,362.85 69.20,366.96 70.77,371.04 72.34,374.89 73.91,378.34 75.48,381.30 77.05,383.72 78.62,385.57 80.19,386.98 81.77,388.39 83.34,389.82 84.91,391.30 86.48,392.83 88.05,394.42 89.62,396.06 91.19,397.76 92.76,399.52 94.33,401.33 95.91,403.21 97.48,405.13 99.05,407.11 100.62,409.14 102.19,411.21 103.76,413.31 105.33,415.45 106.90,417.62 108.47,419.82 110.04,422.03 111.62,424.26 113.19,426.50 114.76,428.74 116.33,430.97 117.90,433.20 119.47,435.41 121.04,437.59 122.61,439.75 124.18,441.87 125.76,443.96 127.33,445.99 128.90,447.97 130.47,449.90 132.04,451.75 133.61,453.54 135.18,455.26 136.75,456.89 138.32,458.44 139.89,459.91 141.47,461.29 143.04,462.57 144.61,463.75 146.18,464.84 147.75,465.82 149.32,466.69 150.89,467.46 152.46,468.11 154.03,468.65 155.61,469.07 157.18,469.37 158.75,469.54 160.32,469.59 161.89,469.50 163.46,469.28 165.03,468.91 166.60,468.41 168.17,467.76 169.75,466.95 171.32,465.99 172.89,464.88 172.89,526.22 171.32,524.77 169.75,523.25 168.17,521.67 166.60,520.03 165.03,518.33 163.46,516.57 161.89,514.76 160.32,512.90 158.75,511.00 157.18,509.04 155.61,507.05 154.03,505.01 152.46,502.93 150.89,500.82 149.32,498.68 147.75,496.51 146.18,494.32 144.61,492.10 143.04,489.86 141.47,487.61 139.89,485.34 138.32,483.07 136.75,480.78 135.18,478.49 133.61,476.20 132.04,473.90 130.47,471.60 128.90,469.30 127.33,467.00 125.76,464.71 124.18,462.41 122.61,460.12 121.04,457.83 119.47,455.53 117.90,453.24 116.33,450.95 114.76,448.66 113.19,446.37 111.62,444.08 110.04,441.80 108.47,439.51 106.90,437.22 105.33,434.94 103.76,432.66 102.19,430.39 100.62,428.13 99.05,425.87 97.48,423.62 95.91,421.39 94.33,419.17 92.76,416.98 91.19,414.81 89.62,412.66 88.05,410.56 86.48,408.49 84.91,406.48 83.34,404.53 81.77,402.66 80.19,400.88 78.62,399.18 77.05,396.92 75.48,394.02 73.91,390.68 72.34,387.06 70.77,383.29 69.20,379.41 67.63,375.46 66.06,371.44 64.48,367.43 62.91,363.56 61.34,360.07 59.77,357.16 58.20,354.62 56.63,352.19 55.06,350.92 53.49,350.07 51.92,349.84 50.34,352.40 48.77,358.71 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #999999; fill-opacity: 0.40;' />
+<polyline points='48.77,337.80 50.34,341.68 51.92,342.94 53.49,342.44 55.06,342.48 56.63,343.45 58.20,345.13 59.77,347.40 61.34,349.75 62.91,352.22 64.48,355.25 66.06,358.89 67.63,362.85 69.20,366.96 70.77,371.04 72.34,374.89 73.91,378.34 75.48,381.30 77.05,383.72 78.62,385.57 80.19,386.98 81.77,388.39 83.34,389.82 84.91,391.30 86.48,392.83 88.05,394.42 89.62,396.06 91.19,397.76 92.76,399.52 94.33,401.33 95.91,403.21 97.48,405.13 99.05,407.11 100.62,409.14 102.19,411.21 103.76,413.31 105.33,415.45 106.90,417.62 108.47,419.82 110.04,422.03 111.62,424.26 113.19,426.50 114.76,428.74 116.33,430.97 117.90,433.20 119.47,435.41 121.04,437.59 122.61,439.75 124.18,441.87 125.76,443.96 127.33,445.99 128.90,447.97 130.47,449.90 132.04,451.75 133.61,453.54 135.18,455.26 136.75,456.89 138.32,458.44 139.89,459.91 141.47,461.29 143.04,462.57 144.61,463.75 146.18,464.84 147.75,465.82 149.32,466.69 150.89,467.46 152.46,468.11 154.03,468.65 155.61,469.07 157.18,469.37 158.75,469.54 160.32,469.59 161.89,469.50 163.46,469.28 165.03,468.91 166.60,468.41 168.17,467.76 169.75,466.95 171.32,465.99 172.89,464.88 ' style='stroke-width: 2.13; stroke: none; stroke-linecap: butt;' />
+<polyline points='172.89,526.22 171.32,524.77 169.75,523.25 168.17,521.67 166.60,520.03 165.03,518.33 163.46,516.57 161.89,514.76 160.32,512.90 158.75,511.00 157.18,509.04 155.61,507.05 154.03,505.01 152.46,502.93 150.89,500.82 149.32,498.68 147.75,496.51 146.18,494.32 144.61,492.10 143.04,489.86 141.47,487.61 139.89,485.34 138.32,483.07 136.75,480.78 135.18,478.49 133.61,476.20 132.04,473.90 130.47,471.60 128.90,469.30 127.33,467.00 125.76,464.71 124.18,462.41 122.61,460.12 121.04,457.83 119.47,455.53 117.90,453.24 116.33,450.95 114.76,448.66 113.19,446.37 111.62,444.08 110.04,441.80 108.47,439.51 106.90,437.22 105.33,434.94 103.76,432.66 102.19,430.39 100.62,428.13 99.05,425.87 97.48,423.62 95.91,421.39 94.33,419.17 92.76,416.98 91.19,414.81 89.62,412.66 88.05,410.56 86.48,408.49 84.91,406.48 83.34,404.53 81.77,402.66 80.19,400.88 78.62,399.18 77.05,396.92 75.48,394.02 73.91,390.68 72.34,387.06 70.77,383.29 69.20,379.41 67.63,375.46 66.06,371.44 64.48,367.43 62.91,363.56 61.34,360.07 59.77,357.16 58.20,354.62 56.63,352.19 55.06,350.92 53.49,350.07 51.92,349.84 50.34,352.40 48.77,358.71 ' style='stroke-width: 2.13; stroke: none; stroke-linecap: butt;' />
+<polyline points='48.77,348.25 50.34,347.04 51.92,346.39 53.49,346.26 55.06,346.70 56.63,347.82 58.20,349.87 59.77,352.28 61.34,354.91 62.91,357.89 64.48,361.34 66.06,365.17 67.63,369.15 69.20,373.19 70.77,377.16 72.34,380.98 73.91,384.51 75.48,387.66 77.05,390.32 78.62,392.37 80.19,393.93 81.77,395.52 83.34,397.18 84.91,398.89 86.48,400.66 88.05,402.49 89.62,404.36 91.19,406.28 92.76,408.25 94.33,410.25 95.91,412.30 97.48,414.38 99.05,416.49 100.62,418.63 102.19,420.80 103.76,422.99 105.33,425.20 106.90,427.42 108.47,429.66 110.04,431.91 111.62,434.17 113.19,436.44 114.76,438.70 116.33,440.96 117.90,443.22 119.47,445.47 121.04,447.71 122.61,449.94 124.18,452.14 125.76,454.33 127.33,456.50 128.90,458.64 130.47,460.75 132.04,462.83 133.61,464.87 135.18,466.87 136.75,468.84 138.32,470.76 139.89,472.63 141.47,474.45 143.04,476.22 144.61,477.93 146.18,479.58 147.75,481.17 149.32,482.69 150.89,484.14 152.46,485.52 154.03,486.83 155.61,488.06 157.18,489.21 158.75,490.27 160.32,491.25 161.89,492.13 163.46,492.92 165.03,493.62 166.60,494.22 168.17,494.71 169.75,495.10 171.32,495.38 172.89,495.55 ' style='stroke-width: 2.13; stroke: #F8766D; stroke-linecap: butt;' />
+<polygon points='48.77,325.43 52.20,339.56 55.63,352.09 59.05,362.84 62.48,371.98 65.91,380.10 69.33,387.46 72.76,394.91 76.19,401.59 79.61,406.72 83.04,410.34 86.47,412.69 89.89,414.79 93.32,417.76 96.75,420.82 100.17,423.59 103.60,426.00 107.03,428.23 110.45,430.59 113.88,433.28 117.31,436.01 120.73,438.78 124.16,441.59 127.59,444.42 131.01,447.27 134.44,450.11 137.87,452.92 141.29,455.69 144.72,458.38 148.15,460.99 151.57,463.48 155.00,465.87 158.43,468.13 161.85,470.26 165.28,472.28 168.71,474.18 172.13,475.97 175.56,477.65 178.99,479.25 182.41,480.75 185.84,482.15 189.27,483.47 192.69,484.70 196.12,485.84 199.55,486.90 202.97,487.88 206.40,488.76 209.83,489.57 213.25,490.29 216.68,490.91 220.11,491.45 223.53,491.90 226.96,492.25 230.39,492.50 233.81,492.64 237.24,492.68 240.67,492.60 244.09,492.40 247.52,492.08 250.95,491.63 254.37,491.05 257.80,490.33 261.23,489.48 264.65,488.49 268.08,487.35 271.51,486.08 274.93,484.66 278.36,483.10 281.79,481.40 285.21,479.57 288.64,477.59 292.07,475.47 295.49,473.22 298.92,470.83 302.35,468.31 305.77,465.66 309.20,462.87 312.63,459.95 316.05,456.90 319.48,453.72 319.48,512.31 316.05,512.55 312.63,512.77 309.20,512.98 305.77,513.16 302.35,513.33 298.92,513.47 295.49,513.61 292.07,513.72 288.64,513.82 285.21,513.91 281.79,513.98 278.36,514.04 274.93,514.09 271.51,514.12 268.08,514.14 264.65,514.14 261.23,514.13 257.80,514.11 254.37,514.06 250.95,513.99 247.52,513.90 244.09,513.77 240.67,513.61 237.24,513.41 233.81,513.16 230.39,512.86 226.96,512.50 223.53,512.09 220.11,511.61 216.68,511.06 213.25,510.43 209.83,509.74 206.40,508.96 202.97,508.10 199.55,507.17 196.12,506.15 192.69,505.06 189.27,503.88 185.84,502.62 182.41,501.28 178.99,499.77 175.56,498.07 172.13,496.19 168.71,494.17 165.28,492.02 161.85,489.76 158.43,487.42 155.00,485.00 151.57,482.52 148.15,480.00 144.72,477.42 141.29,474.80 137.87,472.12 134.44,469.38 131.01,466.57 127.59,463.68 124.16,460.71 120.73,457.65 117.31,454.52 113.88,451.32 110.45,448.10 107.03,445.03 103.60,442.22 100.17,439.73 96.75,437.37 93.32,434.80 89.89,431.68 86.47,428.36 83.04,424.97 79.61,421.23 76.19,416.12 72.76,408.86 69.33,400.73 65.91,392.40 62.48,383.40 59.05,374.30 55.63,365.72 52.20,357.97 48.77,350.98 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #999999; fill-opacity: 0.40;' />
+<polyline points='48.77,325.43 52.20,339.56 55.63,352.09 59.05,362.84 62.48,371.98 65.91,380.10 69.33,387.46 72.76,394.91 76.19,401.59 79.61,406.72 83.04,410.34 86.47,412.69 89.89,414.79 93.32,417.76 96.75,420.82 100.17,423.59 103.60,426.00 107.03,428.23 110.45,430.59 113.88,433.28 117.31,436.01 120.73,438.78 124.16,441.59 127.59,444.42 131.01,447.27 134.44,450.11 137.87,452.92 141.29,455.69 144.72,458.38 148.15,460.99 151.57,463.48 155.00,465.87 158.43,468.13 161.85,470.26 165.28,472.28 168.71,474.18 172.13,475.97 175.56,477.65 178.99,479.25 182.41,480.75 185.84,482.15 189.27,483.47 192.69,484.70 196.12,485.84 199.55,486.90 202.97,487.88 206.40,488.76 209.83,489.57 213.25,490.29 216.68,490.91 220.11,491.45 223.53,491.90 226.96,492.25 230.39,492.50 233.81,492.64 237.24,492.68 240.67,492.60 244.09,492.40 247.52,492.08 250.95,491.63 254.37,491.05 257.80,490.33 261.23,489.48 264.65,488.49 268.08,487.35 271.51,486.08 274.93,484.66 278.36,483.10 281.79,481.40 285.21,479.57 288.64,477.59 292.07,475.47 295.49,473.22 298.92,470.83 302.35,468.31 305.77,465.66 309.20,462.87 312.63,459.95 316.05,456.90 319.48,453.72 ' style='stroke-width: 2.13; stroke: none; stroke-linecap: butt;' />
+<polyline points='319.48,512.31 316.05,512.55 312.63,512.77 309.20,512.98 305.77,513.16 302.35,513.33 298.92,513.47 295.49,513.61 292.07,513.72 288.64,513.82 285.21,513.91 281.79,513.98 278.36,514.04 274.93,514.09 271.51,514.12 268.08,514.14 264.65,514.14 261.23,514.13 257.80,514.11 254.37,514.06 250.95,513.99 247.52,513.90 244.09,513.77 240.67,513.61 237.24,513.41 233.81,513.16 230.39,512.86 226.96,512.50 223.53,512.09 220.11,511.61 216.68,511.06 213.25,510.43 209.83,509.74 206.40,508.96 202.97,508.10 199.55,507.17 196.12,506.15 192.69,505.06 189.27,503.88 185.84,502.62 182.41,501.28 178.99,499.77 175.56,498.07 172.13,496.19 168.71,494.17 165.28,492.02 161.85,489.76 158.43,487.42 155.00,485.00 151.57,482.52 148.15,480.00 144.72,477.42 141.29,474.80 137.87,472.12 134.44,469.38 131.01,466.57 127.59,463.68 124.16,460.71 120.73,457.65 117.31,454.52 113.88,451.32 110.45,448.10 107.03,445.03 103.60,442.22 100.17,439.73 96.75,437.37 93.32,434.80 89.89,431.68 86.47,428.36 83.04,424.97 79.61,421.23 76.19,416.12 72.76,408.86 69.33,400.73 65.91,392.40 62.48,383.40 59.05,374.30 55.63,365.72 52.20,357.97 48.77,350.98 ' style='stroke-width: 2.13; stroke: none; stroke-linecap: butt;' />
+<polyline points='48.77,338.20 52.20,348.76 55.63,358.91 59.05,368.57 62.48,377.69 65.91,386.25 69.33,394.10 72.76,401.89 76.19,408.85 79.61,413.98 83.04,417.65 86.47,420.53 89.89,423.24 93.32,426.28 96.75,429.10 100.17,431.66 103.60,434.11 107.03,436.63 110.45,439.34 113.88,442.30 117.31,445.27 120.73,448.22 124.16,451.15 127.59,454.05 131.01,456.92 134.44,459.74 137.87,462.52 141.29,465.24 144.72,467.90 148.15,470.49 151.57,473.00 155.00,475.43 158.43,477.77 161.85,480.01 165.28,482.15 168.71,484.17 172.13,486.08 175.56,487.86 178.99,489.51 182.41,491.01 185.84,492.39 189.27,493.68 192.69,494.88 196.12,496.00 199.55,497.04 202.97,497.99 206.40,498.86 209.83,499.65 213.25,500.36 216.68,500.99 220.11,501.53 223.53,501.99 226.96,502.38 230.39,502.68 233.81,502.90 237.24,503.04 240.67,503.10 244.09,503.08 247.52,502.99 250.95,502.81 254.37,502.55 257.80,502.22 261.23,501.81 264.65,501.31 268.08,500.75 271.51,500.10 274.93,499.37 278.36,498.57 281.79,497.69 285.21,496.74 288.64,495.71 292.07,494.60 295.49,493.41 298.92,492.15 302.35,490.82 305.77,489.41 309.20,487.92 312.63,486.36 316.05,484.73 319.48,483.02 ' style='stroke-width: 2.13; stroke: #00BFC4; stroke-linecap: butt;' />
+<rect x='35.24' y='295.01' width='297.78' height='250.10' style='stroke-width: 1.07; stroke: #333333;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMzM4LjQ5fDYzNi4yN3wzOS40M3wyODkuNTM='>
+    <rect x='338.49' y='39.43' width='297.78' height='250.10' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMzM4LjQ5fDYzNi4yN3wzOS40M3wyODkuNTM=)'>
+<rect x='338.49' y='39.43' width='297.78' height='250.10' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<polygon points='416.67,174.05 419.31,178.61 414.04,178.61 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='572.23' cy='85.92' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='505.56,87.02 508.20,91.58 502.93,91.58 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='410.61,119.13 413.25,123.69 407.98,123.69 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='510.61' cy='88.95' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='556.07,84.01 558.70,88.56 553.43,88.56 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='567.18' cy='82.35' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='558.09,77.75 560.72,82.31 555.45,82.31 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='465.16,91.68 467.79,96.24 462.53,96.24 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='430.82,158.33 433.45,162.89 428.18,162.89 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='574.25,81.08 576.88,85.64 571.62,85.64 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='509.60,94.45 512.24,99.01 506.97,99.01 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='542.94' cy='80.98' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='383.34,124.26 385.97,128.82 380.71,128.82 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='544.96,83.31 547.59,87.87 542.32,87.87 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='523.74' cy='82.90' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='472.23,99.94 474.86,104.50 469.60,104.50 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='436.88,157.42 439.51,161.98 434.24,161.98 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='513.64' cy='80.84' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='508.59,106.82 511.23,111.38 505.96,111.38 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='540.92' cy='85.55' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='520.71,102.53 523.35,107.09 518.08,107.09 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='451.02,151.48 453.65,156.04 448.38,156.04 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='558.09,82.90 560.72,87.46 555.45,87.46 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='568.19' cy='81.55' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='525.76,94.40 528.40,98.96 523.13,98.96 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='488.39,139.48 491.02,144.04 485.76,144.04 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='480.31,146.43 482.94,150.99 477.68,150.99 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='535.87' cy='85.67' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='410.61,122.36 413.25,126.92 407.98,126.92 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='501.52,96.20 504.15,100.76 498.89,100.76 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='491.42' cy='85.04' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='476.27,84.36 478.90,88.92 473.64,88.92 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='527.78' cy='81.17' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='477.28,84.10 479.91,88.66 474.65,88.66 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='496.47' cy='81.48' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='458.09,122.55 460.72,127.11 455.46,127.11 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='510.61,83.54 513.25,88.10 507.98,88.10 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='457.08,87.22 459.71,91.78 454.45,91.78 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='491.42' cy='81.42' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='483.34,108.02 485.97,112.58 480.71,112.58 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='511.62' cy='82.77' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='521.72' cy='82.79' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='512.63,85.78 515.27,90.34 510.00,90.34 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='551.02' cy='80.99' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='440.92,103.15 443.55,107.71 438.28,107.71 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='522.73' cy='80.54' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='527.78' cy='85.60' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='539.91,78.37 542.54,82.93 537.27,82.93 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='493.44,79.16 496.07,83.72 490.81,83.72 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='517.68,77.50 520.32,82.06 515.05,82.06 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='527.78,99.14 530.42,103.70 525.15,103.70 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='467.18,117.80 469.81,122.36 464.55,122.36 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='497.48,79.39 500.11,83.95 494.85,83.95 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='552.03,83.17 554.66,87.73 549.39,87.73 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='537.89,80.49 540.52,85.05 535.25,85.05 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='475.26,103.28 477.89,107.84 472.63,107.84 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='566.17' cy='81.19' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='507.58,78.00 510.22,82.56 504.95,82.56 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='497.48' cy='85.28' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='552.03' cy='81.32' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='431.83,109.48 434.46,114.04 429.19,114.04 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='469.20,170.38 471.83,174.94 466.57,174.94 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='507.58,87.12 510.22,91.68 504.95,91.68 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='517.68' cy='81.82' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='527.78,78.85 530.42,83.41 525.15,83.41 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='549.00,80.30 551.63,84.86 546.36,84.86 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='567.18' cy='83.16' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='503.54,145.63 506.17,150.19 500.91,150.19 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='622.73' cy='101.22' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='514.65' cy='81.78' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='511.62' cy='80.99' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='517.68' cy='81.63' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='557.08,114.87 559.71,119.43 554.44,119.43 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='409.60,163.59 412.24,168.15 406.97,168.15 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='465.16,147.65 467.79,152.21 462.53,152.21 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='498.49,102.23 501.12,106.79 495.86,106.79 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='459.10,111.29 461.73,115.85 456.47,115.85 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='582.33' cy='93.87' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='529.80,114.94 532.44,119.50 527.17,119.50 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='522.73,145.29 525.37,149.85 520.10,149.85 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='567.18,113.70 569.81,118.26 564.55,118.26 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='507.58' cy='83.25' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='533.84' cy='80.81' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='505.56,81.70 508.20,86.26 502.93,86.26 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='478.29,105.43 480.92,109.99 475.66,109.99 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='598.49,77.85 601.12,82.41 595.86,82.41 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='564.15' cy='81.07' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='522.73,82.87 525.37,87.43 520.10,87.43 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='580.31,86.05 582.94,90.61 577.68,90.61 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='504.55,93.89 507.18,98.45 501.92,98.45 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='470.21,89.32 472.84,93.88 467.58,93.88 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='524.75' cy='86.44' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='468.19,109.79 470.82,114.35 465.56,114.35 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='420.71,156.82 423.35,161.38 418.08,161.38 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='527.78' cy='81.40' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='483.34,91.88 485.97,96.44 480.71,96.44 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='534.86' cy='83.08' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='492.43' cy='83.05' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='457.08,93.21 459.71,97.77 454.45,97.77 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='517.68' cy='81.02' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='555.06' cy='82.58' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='524.75,83.43 527.39,87.99 522.12,87.99 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='521.72,79.13 524.36,83.69 519.09,83.69 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='578.29' cy='92.52' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='547.99,90.85 550.62,95.41 545.35,95.41 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='561.12' cy='83.76' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='507.58,78.35 510.22,82.91 504.95,82.91 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='518.69' cy='80.54' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='511.62,78.75 514.26,83.31 508.99,83.31 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='576.27' cy='88.08' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='524.75,84.29 527.39,88.85 522.12,88.85 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='531.82,101.78 534.46,106.34 529.19,106.34 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='588.39,96.03 591.02,100.59 585.76,100.59 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='577.28' cy='84.50' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='520.71' cy='114.23' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='468.19,119.73 470.82,124.29 465.56,124.29 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='487.38,103.84 490.01,108.40 484.75,108.40 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='540.92,77.72 543.55,82.28 538.28,82.28 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='556.07' cy='89.34' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='465.16,89.04 467.79,93.60 462.53,93.60 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='571.22' cy='81.82' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='480.31,97.68 482.94,102.24 477.68,102.24 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='547.99' cy='80.72' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='508.59' cy='81.85' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='469.20,86.46 471.83,91.02 466.57,91.02 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='566.17' cy='82.04' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='445.97,160.14 448.60,164.70 443.33,164.70 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='544.96' cy='86.87' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='500.51,136.59 503.14,141.15 497.88,141.15 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='537.89,101.16 540.52,105.72 535.25,105.72 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='540.92' cy='81.98' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='553.04,83.63 555.67,88.19 550.40,88.19 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='524.75' cy='80.54' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='514.65' cy='81.12' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='492.43' cy='81.41' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='517.68' cy='84.53' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='551.02,113.42 553.65,117.98 548.38,117.98 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='488.39' cy='84.77' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='567.18' cy='82.83' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='534.86' cy='80.79' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='505.56,78.33 508.20,82.89 502.93,82.89 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='517.68,90.11 520.32,94.67 515.05,94.67 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='483.34,151.55 485.97,156.11 480.71,156.11 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='541.93' cy='81.67' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='546.98' cy='86.03' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='494.45' cy='85.51' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='483.34,124.85 485.97,129.41 480.71,129.41 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='536.88,104.86 539.51,109.42 534.24,109.42 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='520.71' cy='81.40' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='460.11' cy='89.07' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='458.09,125.40 460.72,129.96 455.46,129.96 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='542.94' cy='81.05' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='412.63,136.78 415.27,141.34 410.00,141.34 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='492.43' cy='80.81' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='509.60,140.82 512.24,145.38 506.97,145.38 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='499.50' cy='81.10' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='494.45' cy='90.48' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='503.54,92.00 506.17,96.56 500.91,96.56 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='519.70' cy='81.32' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='513.64' cy='85.86' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='476.27,99.66 478.90,104.22 473.64,104.22 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='566.17,78.10 568.80,82.66 563.54,82.66 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='491.42,108.59 494.05,113.15 488.79,113.15 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='502.53,97.21 505.16,101.77 499.90,101.77 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='483.34' cy='109.05' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='543.95,80.20 546.58,84.76 541.31,84.76 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='537.89' cy='80.54' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='580.31,84.29 582.94,88.85 577.68,88.85 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='518.69' cy='81.96' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='610.61' cy='98.30' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='491.42' cy='81.73' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='499.50' cy='86.64' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='542.94' cy='80.80' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='537.89' cy='80.77' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='513.64,87.45 516.28,92.01 511.01,92.01 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='559.10' cy='83.22' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='566.17' cy='85.50' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='540.92' cy='83.36' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='596.47' cy='91.92' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='515.66' cy='80.74' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='526.77' cy='80.54' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='530.81' cy='81.32' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='512.63,123.58 515.27,128.14 510.00,128.14 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='511.62' cy='80.90' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='510.61,87.75 513.25,92.31 507.98,92.31 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='500.51,131.28 503.14,135.84 497.88,135.84 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='505.56' cy='84.55' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='520.71' cy='82.53' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='551.02' cy='97.92' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='492.43,125.21 495.06,129.77 489.80,129.77 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='526.77' cy='81.36' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='476.27,142.66 478.90,147.22 473.64,147.22 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='588.39' cy='102.89' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='547.99' cy='89.81' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='493.44' cy='82.31' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='555.06' cy='80.80' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='446.98' cy='89.73' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='500.51' cy='85.15' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='512.63' cy='88.63' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='477.28' cy='85.90' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='537.89' cy='83.10' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='562.13' cy='84.00' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='531.82,79.93 534.46,84.49 529.19,84.49 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='512.63,88.39 515.27,92.95 510.00,92.95 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='565.16' cy='81.93' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='490.41' cy='89.22' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='477.28,127.95 479.91,132.51 474.65,132.51 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='559.10' cy='81.48' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='494.45' cy='81.08' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='533.84' cy='81.61' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='556.07' cy='82.50' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='497.48' cy='81.08' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='500.51,81.51 503.14,86.07 497.88,86.07 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='542.94,90.98 545.57,95.54 540.30,95.54 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='525.76' cy='81.30' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='488.39,130.61 491.02,135.17 485.76,135.17 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='546.98' cy='82.28' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='575.26' cy='84.36' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='479.30,124.72 481.93,129.28 476.67,129.28 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='522.73' cy='80.54' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='495.46,91.77 498.09,96.33 492.83,96.33 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='399.50,176.34 402.14,180.90 396.87,180.90 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='523.74' cy='84.03' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='523.74' cy='82.41' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='527.78' cy='81.80' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='492.43,89.08 495.06,93.64 489.80,93.64 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='492.43' cy='81.20' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='462.13,112.27 464.76,116.83 459.50,116.83 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='498.49' cy='88.04' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='352.03,176.90 354.66,181.46 349.40,181.46 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='459.10' cy='88.42' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='463.14' cy='89.98' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='492.43' cy='81.10' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='574.25' cy='133.12' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='536.88' cy='82.95' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='452.03' cy='105.02' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='492.43' cy='87.43' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='451.02,87.75 453.65,92.31 448.38,92.31 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='529.80' cy='80.90' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='519.70' cy='91.53' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='454.05' cy='108.34' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='437.89,149.31 440.52,153.87 435.25,153.87 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='479.30,97.56 481.93,102.12 476.67,102.12 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='522.73' cy='80.79' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='534.86' cy='84.30' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='439.91' cy='122.01' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='508.59' cy='81.36' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='477.28' cy='88.61' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='493.44' cy='81.32' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='518.69' cy='81.01' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='492.43' cy='87.85' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='460.11' cy='164.03' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='532.83' cy='89.11' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='542.94' cy='81.76' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='531.82' cy='83.46' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='581.32' cy='85.23' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='501.52' cy='82.08' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='454.05' cy='116.90' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='516.67' cy='112.81' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='471.22' cy='108.70' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='463.14' cy='101.41' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='514.65' cy='83.23' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='469.20' cy='109.33' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='477.28' cy='105.27' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='489.40' cy='83.82' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='389.40,161.61 392.03,166.17 386.77,166.17 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='431.83,140.92 434.46,145.48 429.19,145.48 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='507.58' cy='105.41' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='531.82' cy='82.36' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='507.58' cy='81.79' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='450.01' cy='91.55' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='503.54' cy='91.61' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='464.15' cy='88.64' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='534.86' cy='85.72' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='542.94' cy='83.27' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='513.64' cy='81.73' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='527.78' cy='91.21' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='534.86' cy='80.76' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='526.77' cy='81.50' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='366.17,178.18 368.80,182.74 363.54,182.74 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='509.60' cy='84.99' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='557.08' cy='87.13' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='501.52' cy='82.38' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='505.56' cy='82.05' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='493.44' cy='83.22' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='503.54' cy='124.51' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='546.98' cy='133.24' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='557.08,98.33 559.71,102.89 554.44,102.89 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='514.65' cy='90.71' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='475.26' cy='93.84' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='530.81' cy='133.00' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='455.06' cy='155.72' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='464.15' cy='141.63' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='540.92' cy='89.94' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='488.39' cy='85.06' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='500.51' cy='82.24' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='494.45' cy='83.08' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='533.84' cy='92.83' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='379.30,148.55 381.93,153.11 376.67,153.11 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='514.65' cy='81.01' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='553.04' cy='84.37' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='482.33' cy='89.00' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='551.02' cy='83.71' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='518.69' cy='92.99' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='502.53' cy='81.16' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='513.64' cy='81.24' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='515.66' cy='80.79' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='431.83' cy='96.89' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='492.43' cy='89.83' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='473.24' cy='90.35' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='536.88' cy='98.43' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='431.83,106.82 434.24,106.46 436.66,106.04 439.08,105.57 441.49,105.03 443.91,104.44 446.32,103.79 448.74,103.08 451.16,102.31 453.57,101.47 455.99,100.57 458.41,99.61 460.82,98.59 463.24,97.52 465.66,96.40 468.07,95.25 470.49,94.07 472.91,92.86 475.32,91.66 477.74,90.45 480.16,89.25 482.57,88.07 484.99,86.90 487.41,85.79 489.82,84.74 492.24,83.77 494.66,82.93 497.07,82.27 499.49,81.96 501.91,81.92 504.32,82.01 506.74,82.10 509.16,82.14 511.57,82.12 513.99,82.14 516.40,82.19 518.82,82.23 521.24,82.28 523.65,82.33 526.07,82.28 528.49,82.15 530.90,82.10 533.32,82.18 535.74,82.27 538.15,82.29 540.57,82.28 542.99,82.29 545.40,82.34 547.82,82.41 550.24,82.49 552.65,82.60 555.07,82.72 557.49,82.88 559.90,83.10 562.32,83.37 564.74,83.65 567.15,83.94 569.57,84.24 571.99,84.55 574.40,84.86 576.82,85.18 579.24,85.49 581.65,85.80 584.07,86.09 586.48,86.36 588.90,86.61 591.32,86.83 593.73,87.03 596.15,87.19 598.57,87.33 600.98,87.43 603.40,87.51 605.82,87.57 608.23,87.60 610.65,87.60 613.07,87.58 615.48,87.55 617.90,87.49 620.32,87.42 622.73,87.33 622.73,119.80 620.32,117.69 617.90,115.65 615.48,113.69 613.07,111.81 610.65,110.01 608.23,108.28 605.82,106.64 603.40,105.08 600.98,103.60 598.57,102.21 596.15,100.90 593.73,99.67 591.32,98.53 588.90,97.47 586.48,96.49 584.07,95.58 581.65,94.75 579.24,93.98 576.82,93.28 574.40,92.62 571.99,92.01 569.57,91.45 567.15,90.92 564.74,90.44 562.32,89.99 559.90,89.60 557.49,89.27 555.07,89.00 552.65,88.80 550.24,88.67 547.82,88.58 545.40,88.53 542.99,88.49 540.57,88.43 538.15,88.32 535.74,88.25 533.32,88.22 530.90,88.19 528.49,88.07 526.07,87.96 523.65,87.96 521.24,88.04 518.82,88.07 516.40,88.04 513.99,88.05 511.57,88.08 509.16,87.97 506.74,87.77 504.32,87.64 501.91,87.68 499.49,87.96 497.07,88.47 494.66,89.22 492.24,90.13 489.82,91.19 487.41,92.35 484.99,93.57 482.57,94.80 480.16,96.03 477.74,97.28 475.32,98.55 472.91,99.84 470.49,101.17 468.07,102.55 465.66,103.97 463.24,105.46 460.82,107.02 458.41,108.65 455.99,110.36 453.57,112.16 451.16,114.03 448.74,115.99 446.32,118.03 443.91,120.14 441.49,122.32 439.08,124.58 436.66,126.92 434.24,129.32 431.83,131.79 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #999999; fill-opacity: 0.40;' />
+<polyline points='431.83,106.82 434.24,106.46 436.66,106.04 439.08,105.57 441.49,105.03 443.91,104.44 446.32,103.79 448.74,103.08 451.16,102.31 453.57,101.47 455.99,100.57 458.41,99.61 460.82,98.59 463.24,97.52 465.66,96.40 468.07,95.25 470.49,94.07 472.91,92.86 475.32,91.66 477.74,90.45 480.16,89.25 482.57,88.07 484.99,86.90 487.41,85.79 489.82,84.74 492.24,83.77 494.66,82.93 497.07,82.27 499.49,81.96 501.91,81.92 504.32,82.01 506.74,82.10 509.16,82.14 511.57,82.12 513.99,82.14 516.40,82.19 518.82,82.23 521.24,82.28 523.65,82.33 526.07,82.28 528.49,82.15 530.90,82.10 533.32,82.18 535.74,82.27 538.15,82.29 540.57,82.28 542.99,82.29 545.40,82.34 547.82,82.41 550.24,82.49 552.65,82.60 555.07,82.72 557.49,82.88 559.90,83.10 562.32,83.37 564.74,83.65 567.15,83.94 569.57,84.24 571.99,84.55 574.40,84.86 576.82,85.18 579.24,85.49 581.65,85.80 584.07,86.09 586.48,86.36 588.90,86.61 591.32,86.83 593.73,87.03 596.15,87.19 598.57,87.33 600.98,87.43 603.40,87.51 605.82,87.57 608.23,87.60 610.65,87.60 613.07,87.58 615.48,87.55 617.90,87.49 620.32,87.42 622.73,87.33 ' style='stroke-width: 2.13; stroke: none; stroke-linecap: butt;' />
+<polyline points='622.73,119.80 620.32,117.69 617.90,115.65 615.48,113.69 613.07,111.81 610.65,110.01 608.23,108.28 605.82,106.64 603.40,105.08 600.98,103.60 598.57,102.21 596.15,100.90 593.73,99.67 591.32,98.53 588.90,97.47 586.48,96.49 584.07,95.58 581.65,94.75 579.24,93.98 576.82,93.28 574.40,92.62 571.99,92.01 569.57,91.45 567.15,90.92 564.74,90.44 562.32,89.99 559.90,89.60 557.49,89.27 555.07,89.00 552.65,88.80 550.24,88.67 547.82,88.58 545.40,88.53 542.99,88.49 540.57,88.43 538.15,88.32 535.74,88.25 533.32,88.22 530.90,88.19 528.49,88.07 526.07,87.96 523.65,87.96 521.24,88.04 518.82,88.07 516.40,88.04 513.99,88.05 511.57,88.08 509.16,87.97 506.74,87.77 504.32,87.64 501.91,87.68 499.49,87.96 497.07,88.47 494.66,89.22 492.24,90.13 489.82,91.19 487.41,92.35 484.99,93.57 482.57,94.80 480.16,96.03 477.74,97.28 475.32,98.55 472.91,99.84 470.49,101.17 468.07,102.55 465.66,103.97 463.24,105.46 460.82,107.02 458.41,108.65 455.99,110.36 453.57,112.16 451.16,114.03 448.74,115.99 446.32,118.03 443.91,120.14 441.49,122.32 439.08,124.58 436.66,126.92 434.24,129.32 431.83,131.79 ' style='stroke-width: 2.13; stroke: none; stroke-linecap: butt;' />
+<polyline points='431.83,119.30 434.24,117.89 436.66,116.48 439.08,115.08 441.49,113.68 443.91,112.29 446.32,110.91 448.74,109.53 451.16,108.17 453.57,106.81 455.99,105.47 458.41,104.13 460.82,102.81 463.24,101.49 465.66,100.19 468.07,98.90 470.49,97.62 472.91,96.35 475.32,95.10 477.74,93.86 480.16,92.64 482.57,91.43 484.99,90.24 487.41,89.07 489.82,87.96 492.24,86.95 494.66,86.07 497.07,85.37 499.49,84.96 501.91,84.80 504.32,84.82 506.74,84.94 509.16,85.06 511.57,85.10 513.99,85.09 516.40,85.12 518.82,85.15 521.24,85.16 523.65,85.14 526.07,85.12 528.49,85.11 530.90,85.15 533.32,85.20 535.74,85.26 538.15,85.31 540.57,85.35 542.99,85.39 545.40,85.43 547.82,85.50 550.24,85.58 552.65,85.70 555.07,85.86 557.49,86.08 559.90,86.35 562.32,86.68 564.74,87.05 567.15,87.43 569.57,87.85 571.99,88.28 574.40,88.74 576.82,89.23 579.24,89.74 581.65,90.28 584.07,90.84 586.48,91.43 588.90,92.04 591.32,92.68 593.73,93.35 596.15,94.04 598.57,94.77 600.98,95.52 603.40,96.30 605.82,97.10 608.23,97.94 610.65,98.80 613.07,99.70 615.48,100.62 617.90,101.57 620.32,102.55 622.73,103.57 ' style='stroke-width: 2.13; stroke: #F8766D; stroke-linecap: butt;' />
+<polygon points='352.03,149.43 355.15,149.87 358.27,150.19 361.39,150.41 364.51,150.52 367.63,150.52 370.75,150.41 373.87,150.18 376.99,149.83 380.11,149.37 383.23,148.80 386.35,148.11 389.47,147.31 392.59,146.39 395.71,145.38 398.82,144.27 401.94,143.07 405.06,141.79 408.18,140.45 411.30,139.05 414.42,137.61 417.54,136.14 420.66,134.64 423.78,133.13 426.90,131.60 430.02,130.07 433.14,128.53 436.26,126.99 439.38,125.45 442.50,123.91 445.62,122.37 448.74,120.82 451.86,119.24 454.98,117.63 458.10,115.99 461.22,114.35 464.34,112.73 467.46,111.18 470.58,109.89 473.70,108.81 476.82,107.71 479.94,106.52 483.06,105.36 486.18,104.28 489.30,103.12 492.42,101.78 495.54,100.36 498.66,99.00 501.78,97.55 504.90,95.80 508.02,94.01 511.14,92.70 514.26,91.51 517.38,90.26 520.50,89.00 523.62,87.92 526.74,87.22 529.86,86.76 532.98,86.42 536.10,86.13 539.22,85.85 542.33,85.55 545.45,85.22 548.57,84.87 551.69,84.50 554.81,84.11 557.93,83.66 561.05,83.13 564.17,82.49 567.29,81.71 570.41,80.78 573.53,79.68 576.65,78.42 579.77,77.00 582.89,75.41 586.01,73.67 589.13,71.79 592.25,69.76 595.37,67.60 598.49,65.31 598.49,115.27 595.37,112.83 592.25,110.57 589.13,108.50 586.01,106.63 582.89,104.95 579.77,103.47 576.65,102.20 573.53,101.14 570.41,100.29 567.29,99.65 564.17,99.22 561.05,98.96 557.93,98.85 554.81,98.87 551.69,98.98 548.57,99.16 545.45,99.28 542.33,99.33 539.22,99.39 536.10,99.52 532.98,99.77 529.86,100.18 526.74,100.74 523.62,101.42 520.50,102.22 517.38,103.21 514.26,104.43 511.14,105.76 508.02,107.04 504.90,108.56 501.78,110.33 498.66,111.95 495.54,113.13 492.42,114.20 489.30,115.33 486.18,116.62 483.06,118.00 479.94,119.32 476.82,120.51 473.70,121.72 470.58,123.11 467.46,124.68 464.34,126.34 461.22,128.03 458.10,129.77 454.98,131.57 451.86,133.43 448.74,135.32 445.62,137.23 442.50,139.11 439.38,140.94 436.26,142.68 433.14,144.38 430.02,146.08 426.90,147.77 423.78,149.46 420.66,151.15 417.54,152.85 414.42,154.55 411.30,156.28 408.18,158.03 405.06,159.82 401.94,161.67 398.82,163.58 395.71,165.56 392.59,167.62 389.47,169.76 386.35,172.00 383.23,174.33 380.11,176.76 376.99,179.28 373.87,181.90 370.75,184.61 367.63,187.42 364.51,190.32 361.39,193.31 358.27,196.38 355.15,199.54 352.03,202.79 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #999999; fill-opacity: 0.40;' />
+<polyline points='352.03,149.43 355.15,149.87 358.27,150.19 361.39,150.41 364.51,150.52 367.63,150.52 370.75,150.41 373.87,150.18 376.99,149.83 380.11,149.37 383.23,148.80 386.35,148.11 389.47,147.31 392.59,146.39 395.71,145.38 398.82,144.27 401.94,143.07 405.06,141.79 408.18,140.45 411.30,139.05 414.42,137.61 417.54,136.14 420.66,134.64 423.78,133.13 426.90,131.60 430.02,130.07 433.14,128.53 436.26,126.99 439.38,125.45 442.50,123.91 445.62,122.37 448.74,120.82 451.86,119.24 454.98,117.63 458.10,115.99 461.22,114.35 464.34,112.73 467.46,111.18 470.58,109.89 473.70,108.81 476.82,107.71 479.94,106.52 483.06,105.36 486.18,104.28 489.30,103.12 492.42,101.78 495.54,100.36 498.66,99.00 501.78,97.55 504.90,95.80 508.02,94.01 511.14,92.70 514.26,91.51 517.38,90.26 520.50,89.00 523.62,87.92 526.74,87.22 529.86,86.76 532.98,86.42 536.10,86.13 539.22,85.85 542.33,85.55 545.45,85.22 548.57,84.87 551.69,84.50 554.81,84.11 557.93,83.66 561.05,83.13 564.17,82.49 567.29,81.71 570.41,80.78 573.53,79.68 576.65,78.42 579.77,77.00 582.89,75.41 586.01,73.67 589.13,71.79 592.25,69.76 595.37,67.60 598.49,65.31 ' style='stroke-width: 2.13; stroke: none; stroke-linecap: butt;' />
+<polyline points='598.49,115.27 595.37,112.83 592.25,110.57 589.13,108.50 586.01,106.63 582.89,104.95 579.77,103.47 576.65,102.20 573.53,101.14 570.41,100.29 567.29,99.65 564.17,99.22 561.05,98.96 557.93,98.85 554.81,98.87 551.69,98.98 548.57,99.16 545.45,99.28 542.33,99.33 539.22,99.39 536.10,99.52 532.98,99.77 529.86,100.18 526.74,100.74 523.62,101.42 520.50,102.22 517.38,103.21 514.26,104.43 511.14,105.76 508.02,107.04 504.90,108.56 501.78,110.33 498.66,111.95 495.54,113.13 492.42,114.20 489.30,115.33 486.18,116.62 483.06,118.00 479.94,119.32 476.82,120.51 473.70,121.72 470.58,123.11 467.46,124.68 464.34,126.34 461.22,128.03 458.10,129.77 454.98,131.57 451.86,133.43 448.74,135.32 445.62,137.23 442.50,139.11 439.38,140.94 436.26,142.68 433.14,144.38 430.02,146.08 426.90,147.77 423.78,149.46 420.66,151.15 417.54,152.85 414.42,154.55 411.30,156.28 408.18,158.03 405.06,159.82 401.94,161.67 398.82,163.58 395.71,165.56 392.59,167.62 389.47,169.76 386.35,172.00 383.23,174.33 380.11,176.76 376.99,179.28 373.87,181.90 370.75,184.61 367.63,187.42 364.51,190.32 361.39,193.31 358.27,196.38 355.15,199.54 352.03,202.79 ' style='stroke-width: 2.13; stroke: none; stroke-linecap: butt;' />
+<polyline points='352.03,176.11 355.15,174.71 358.27,173.29 361.39,171.86 364.51,170.42 367.63,168.97 370.75,167.51 373.87,166.04 376.99,164.56 380.11,163.06 383.23,161.56 386.35,160.05 389.47,158.53 392.59,157.00 395.71,155.47 398.82,153.92 401.94,152.37 405.06,150.81 408.18,149.24 411.30,147.66 414.42,146.08 417.54,144.49 420.66,142.90 423.78,141.29 426.90,139.69 430.02,138.07 433.14,136.46 436.26,134.83 439.38,133.19 442.50,131.51 445.62,129.80 448.74,128.07 451.86,126.33 454.98,124.60 458.10,122.88 461.22,121.19 464.34,119.54 467.46,117.93 470.58,116.50 473.70,115.26 476.82,114.11 479.94,112.92 483.06,111.68 486.18,110.45 489.30,109.22 492.42,107.99 495.54,106.75 498.66,105.48 501.78,103.94 504.90,102.18 508.02,100.52 511.14,99.23 514.26,97.97 517.38,96.73 520.50,95.61 523.62,94.67 526.74,93.98 529.86,93.47 532.98,93.10 536.10,92.83 539.22,92.62 542.33,92.44 545.45,92.25 548.57,92.02 551.69,91.74 554.81,91.49 557.93,91.25 561.05,91.04 564.17,90.85 567.29,90.68 570.41,90.53 573.53,90.41 576.65,90.31 579.77,90.23 582.89,90.18 586.01,90.15 589.13,90.15 592.25,90.17 595.37,90.22 598.49,90.29 ' style='stroke-width: 2.13; stroke: #00BFC4; stroke-linecap: butt;' />
+<rect x='338.49' y='39.43' width='297.78' height='250.10' style='stroke-width: 1.07; stroke: #333333;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMzM4LjQ5fDYzNi4yN3wyOTUuMDF8NTQ1LjEx'>
+    <rect x='338.49' y='295.01' width='297.78' height='250.10' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMzM4LjQ5fDYzNi4yN3wyOTUuMDF8NTQ1LjEx)'>
+<rect x='338.49' y='295.01' width='297.78' height='250.10' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<polygon points='416.67,489.18 419.31,493.74 414.04,493.74 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='572.23' cy='347.35' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='505.56,360.12 508.20,364.68 502.93,364.68 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='410.61,412.60 413.25,417.16 407.98,417.16 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='510.61' cy='380.95' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='556.07,360.22 558.70,364.78 553.43,364.78 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='567.18' cy='345.43' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='558.09,341.67 560.72,346.23 555.45,346.23 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='465.16,383.01 467.79,387.57 462.53,387.57 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='430.82,492.96 433.45,497.52 428.18,497.52 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='574.25,347.98 576.88,352.54 571.62,352.54 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='509.60,416.69 512.24,421.25 506.97,421.25 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='542.94' cy='339.29' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='383.34,408.18 385.97,412.74 380.71,412.74 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='544.96,362.16 547.59,366.72 542.32,366.72 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='523.74' cy='338.48' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='472.23,398.85 474.86,403.41 469.60,403.41 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='436.88,503.98 439.51,508.54 434.24,508.54 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='513.64' cy='337.95' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='508.59,420.43 511.23,424.99 505.96,424.99 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='540.92' cy='356.87' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='520.71,398.15 523.35,402.71 518.08,402.71 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='451.02,501.05 453.65,505.61 448.38,505.61 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='558.09,352.13 560.72,356.69 555.45,356.69 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='568.19' cy='337.38' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='525.76,420.22 528.40,424.78 523.13,424.78 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='488.39,492.15 491.02,496.71 485.76,496.71 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='480.31,482.80 482.94,487.36 477.68,487.36 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='535.87' cy='358.12' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='410.61,417.12 413.25,421.68 407.98,421.68 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='501.52,400.58 504.15,405.14 498.89,405.14 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='491.42' cy='359.62' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='476.27,364.77 478.90,369.33 473.64,369.33 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='527.78' cy='343.69' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='477.28,364.00 479.91,368.56 474.65,368.56 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='496.47' cy='341.98' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='458.09,450.06 460.72,454.62 455.46,454.62 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='510.61,366.62 513.25,371.18 507.98,371.18 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='457.08,368.95 459.71,373.51 454.45,373.51 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='491.42' cy='342.65' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='483.34,422.77 485.97,427.33 480.71,427.33 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='511.62' cy='349.98' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='521.72' cy='340.40' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='512.63,366.39 515.27,370.95 510.00,370.95 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='551.02' cy='337.57' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='440.92,417.08 443.55,421.64 438.28,421.64 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='522.73' cy='336.95' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='527.78' cy='353.46' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='539.91,341.70 542.54,346.26 537.27,346.26 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='493.44,346.40 496.07,350.96 490.81,350.96 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='517.68,336.74 520.32,341.30 515.05,341.30 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='527.78,421.35 530.42,425.91 525.15,425.91 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='467.18,430.18 469.81,434.74 464.55,434.74 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='497.48,339.42 500.11,343.98 494.85,343.98 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='552.03,362.97 554.66,367.53 549.39,367.53 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='537.89,336.47 540.52,341.03 535.25,341.03 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='475.26,419.43 477.89,423.99 472.63,423.99 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='566.17' cy='337.83' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='507.58,338.92 510.22,343.48 504.95,343.48 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='497.48' cy='355.75' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='552.03' cy='338.66' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='431.83,399.77 434.46,404.33 429.19,404.33 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='469.20,508.65 471.83,513.21 466.57,513.21 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='507.58,388.48 510.22,393.04 504.95,393.04 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='517.68' cy='338.68' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='527.78,339.57 530.42,344.13 525.15,344.13 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='549.00,343.08 551.63,347.64 546.36,347.64 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='567.18' cy='339.23' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='503.54,500.84 506.17,505.40 500.91,505.40 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='622.73' cy='361.81' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='514.65' cy='340.61' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='511.62' cy='337.80' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='517.68' cy='337.96' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='557.08,449.79 559.71,454.35 554.44,454.35 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='409.60,504.83 412.24,509.39 406.97,509.39 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='465.16,491.44 467.79,496.00 462.53,496.00 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='498.49,426.02 501.12,430.58 495.86,430.58 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='459.10,432.20 461.73,436.76 456.47,436.76 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='582.33' cy='350.99' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='529.80,439.55 532.44,444.11 527.17,444.11 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='522.73,499.37 525.37,503.93 520.10,503.93 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='567.18,436.83 569.81,441.39 564.55,441.39 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='507.58' cy='349.78' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='533.84' cy='341.03' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='505.56,357.23 508.20,361.79 502.93,361.79 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='478.29,436.33 480.92,440.89 475.66,440.89 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='598.49,335.67 601.12,340.23 595.86,340.23 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='564.15' cy='337.61' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='522.73,360.67 525.37,365.23 520.10,365.23 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='580.31,342.41 582.94,346.97 577.68,346.97 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='504.55,398.49 507.18,403.05 501.92,403.05 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='470.21,387.76 472.84,392.32 467.58,392.32 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='524.75' cy='343.52' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='468.19,416.59 470.82,421.15 465.56,421.15 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='420.71,501.69 423.35,506.25 418.08,506.25 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='527.78' cy='339.83' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='483.34,392.61 485.97,397.17 480.71,397.17 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='534.86' cy='340.53' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='492.43' cy='347.51' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='457.08,391.56 459.71,396.12 454.45,396.12 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='517.68' cy='338.38' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='555.06' cy='345.47' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='524.75,376.35 527.39,380.91 522.12,380.91 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='521.72,335.65 524.36,340.21 519.09,340.21 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='578.29' cy='350.02' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='547.99,382.74 550.62,387.30 545.35,387.30 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='561.12' cy='356.41' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='507.58,338.92 510.22,343.48 504.95,343.48 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='518.69' cy='336.39' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='511.62,340.48 514.26,345.04 508.99,345.04 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='576.27' cy='388.02' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='524.75,364.52 527.39,369.08 522.12,369.08 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='531.82,418.46 534.46,423.02 529.19,423.02 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='588.39,396.55 591.02,401.11 585.76,401.11 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='577.28' cy='340.26' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='520.71' cy='436.82' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='468.19,434.78 470.82,439.34 465.56,439.34 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='487.38,417.34 490.01,421.90 484.75,421.90 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='540.92,333.74 543.55,338.30 538.28,338.30 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='556.07' cy='369.83' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='465.16,388.64 467.79,393.20 462.53,393.20 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='571.22' cy='343.22' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='480.31,400.32 482.94,404.88 477.68,404.88 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='547.99' cy='345.76' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='508.59' cy='339.29' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='469.20,364.90 471.83,369.45 466.57,369.45 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='566.17' cy='338.47' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='445.97,483.63 448.60,488.19 443.33,488.19 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='544.96' cy='363.92' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='500.51,486.67 503.14,491.23 497.88,491.23 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='537.89,407.14 540.52,411.70 535.25,411.70 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='540.92' cy='342.80' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='553.04,365.79 555.67,370.35 550.40,370.35 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='524.75' cy='336.39' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='514.65' cy='339.22' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='492.43' cy='347.03' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='517.68' cy='359.47' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='551.02,441.83 553.65,446.39 548.38,446.39 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='488.39' cy='351.76' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='567.18' cy='349.69' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='534.86' cy='337.79' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='505.56,340.07 508.20,344.63 502.93,344.63 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='517.68,376.98 520.32,381.54 515.05,381.54 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='483.34,495.57 485.97,500.13 480.71,500.13 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='541.93' cy='344.09' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='546.98' cy='343.08' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='494.45' cy='378.91' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='483.34,458.25 485.97,462.81 480.71,462.81 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='536.88,408.07 539.51,412.63 534.24,412.63 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='520.71' cy='337.20' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='460.11' cy='374.09' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='458.09,441.61 460.72,446.17 455.46,446.17 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='542.94' cy='341.32' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='412.63,451.99 415.27,456.55 410.00,456.55 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='492.43' cy='340.17' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='509.60,475.75 512.24,480.31 506.97,480.31 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='499.50' cy='341.20' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='494.45' cy='383.91' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='503.54,393.22 506.17,397.78 500.91,397.78 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='519.70' cy='344.20' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='513.64' cy='364.55' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='476.27,423.63 478.90,428.19 473.64,428.19 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='566.17,339.48 568.80,344.04 563.54,344.04 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='491.42,437.50 494.05,442.06 488.79,442.06 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='502.53,407.88 505.16,412.44 499.90,412.44 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='483.34' cy='419.33' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='543.95,351.70 546.58,356.26 541.31,356.26 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='537.89' cy='337.64' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='580.31,341.59 582.94,346.15 577.68,346.15 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='518.69' cy='338.20' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='610.61' cy='359.17' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='491.42' cy='342.65' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='499.50' cy='368.16' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='542.94' cy='345.59' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='537.89' cy='344.30' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='513.64,374.57 516.28,379.13 511.01,379.13 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='559.10' cy='345.72' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='566.17' cy='360.13' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='540.92' cy='344.43' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='596.47' cy='380.93' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='515.66' cy='339.65' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='526.77' cy='343.44' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='530.81' cy='337.43' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='512.63,454.43 515.27,458.99 510.00,458.99 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='511.62' cy='339.25' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='510.61,398.06 513.25,402.62 507.98,402.62 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='500.51,468.00 503.14,472.56 497.88,472.56 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='505.56' cy='361.62' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='520.71' cy='342.87' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='551.02' cy='398.45' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='492.43,482.72 495.06,487.28 489.80,487.28 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='526.77' cy='347.09' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='476.27,475.40 478.90,479.96 473.64,479.96 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='588.39' cy='361.51' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='547.99' cy='380.43' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='493.44' cy='352.04' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='555.06' cy='338.64' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='446.98' cy='373.20' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='500.51' cy='359.61' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='512.63' cy='378.48' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='477.28' cy='362.75' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='537.89' cy='353.88' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='562.13' cy='339.89' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='531.82,348.91 534.46,353.47 529.19,353.47 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='512.63,388.57 515.27,393.13 510.00,393.13 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='565.16' cy='352.33' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='490.41' cy='370.17' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='477.28,445.79 479.91,450.35 474.65,450.35 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='559.10' cy='343.58' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='494.45' cy='341.91' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='533.84' cy='344.68' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='556.07' cy='340.81' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='497.48' cy='341.90' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='500.51,362.23 503.14,366.79 497.88,366.79 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='542.94,384.81 545.57,389.37 540.30,389.37 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='525.76' cy='346.58' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='488.39,464.80 491.02,469.36 485.76,469.36 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='546.98' cy='339.03' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='575.26' cy='342.86' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='479.30,460.83 481.93,465.39 476.67,465.39 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='522.73' cy='343.88' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='495.46,390.77 498.09,395.33 492.83,395.33 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='399.50,500.34 402.14,504.90 396.87,504.90 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='523.74' cy='340.95' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='523.74' cy='338.73' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='527.78' cy='342.39' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='492.43,376.97 495.06,381.53 489.80,381.53 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='492.43' cy='339.13' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='462.13,438.77 464.76,443.33 459.50,443.33 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='498.49' cy='368.79' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='352.03,476.16 354.66,480.72 349.40,480.72 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='459.10' cy='377.77' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='463.14' cy='380.47' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='492.43' cy='338.58' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='574.25' cy='486.85' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='536.88' cy='341.85' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='452.03' cy='397.97' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='492.43' cy='368.08' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='451.02,364.24 453.65,368.80 448.38,368.80 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='529.80' cy='341.72' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='519.70' cy='384.76' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='454.05' cy='407.62' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='437.89,463.65 440.52,468.21 435.25,468.21 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='479.30,411.66 481.93,416.22 476.67,416.22 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='522.73' cy='337.96' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='534.86' cy='348.15' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='439.91' cy='418.26' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='508.59' cy='345.96' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='477.28' cy='370.15' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='493.44' cy='341.08' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='518.69' cy='342.08' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='492.43' cy='376.50' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='460.11' cy='508.13' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='532.83' cy='372.38' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='542.94' cy='338.76' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='531.82' cy='339.25' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='581.32' cy='348.71' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='501.52' cy='344.11' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='454.05' cy='430.65' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='516.67' cy='446.17' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='471.22' cy='422.21' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='463.14' cy='401.77' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='514.65' cy='339.64' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='469.20' cy='423.48' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='477.28' cy='413.81' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='489.40' cy='349.18' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='389.40,471.63 392.03,476.19 386.77,476.19 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='431.83,453.40 434.46,457.96 429.19,457.96 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='507.58' cy='409.65' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='531.82' cy='338.94' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='507.58' cy='343.38' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='450.01' cy='378.05' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='503.54' cy='382.24' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='464.15' cy='374.01' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='534.86' cy='356.33' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='542.94' cy='343.45' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='513.64' cy='338.57' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='527.78' cy='389.81' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='534.86' cy='341.64' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='526.77' cy='340.56' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='366.17,499.70 368.80,504.26 363.54,504.26 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='509.60' cy='344.19' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='557.08' cy='363.39' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='501.52' cy='341.27' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='505.56' cy='344.43' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='493.44' cy='350.40' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='503.54' cy='457.44' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='546.98' cy='472.71' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='557.08,413.08 559.71,417.64 554.44,417.64 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='514.65' cy='380.81' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='475.26' cy='384.51' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='530.81' cy='470.10' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='455.06' cy='496.26' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='464.15' cy='469.93' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='540.92' cy='365.24' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='488.39' cy='357.60' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='500.51' cy='348.37' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='494.45' cy='345.50' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='533.84' cy='374.69' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='379.30,454.76 381.93,459.32 376.67,459.32 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='514.65' cy='340.29' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='553.04' cy='342.56' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='482.33' cy='376.06' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='551.02' cy='341.96' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='518.69' cy='384.21' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='502.53' cy='340.37' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='513.64' cy='337.88' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='515.66' cy='345.13' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='431.83' cy='376.38' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='492.43' cy='377.78' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='473.24' cy='374.03' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='536.88' cy='402.28' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='431.83,392.15 434.24,392.92 436.66,393.46 439.08,393.79 441.49,393.90 443.91,393.79 446.32,393.45 448.74,392.89 451.16,392.10 453.57,391.08 455.99,389.83 458.41,388.36 460.82,386.67 463.24,384.77 465.66,382.68 468.07,380.43 470.49,378.04 472.91,375.53 475.32,372.94 477.74,370.28 480.16,367.57 482.57,364.83 484.99,362.05 487.41,359.26 489.82,356.53 492.24,353.93 494.66,351.57 497.07,349.62 499.49,348.45 501.91,347.88 504.32,347.56 506.74,347.26 509.16,346.87 511.57,346.44 513.99,346.14 516.40,345.96 518.82,345.75 521.24,345.64 523.65,345.56 526.07,345.26 528.49,344.78 530.90,344.53 533.32,344.68 535.74,344.91 538.15,345.01 540.57,344.96 542.99,344.93 545.40,345.00 547.82,345.14 550.24,345.30 552.65,345.47 555.07,345.65 557.49,345.85 559.90,346.09 562.32,346.39 564.74,346.64 567.15,346.85 569.57,347.03 571.99,347.16 574.40,347.26 576.82,347.30 579.24,347.27 581.65,347.16 584.07,346.96 586.48,346.65 588.90,346.23 591.32,345.68 593.73,345.00 596.15,344.19 598.57,343.25 600.98,342.18 603.40,340.98 605.82,339.67 608.23,338.23 610.65,336.68 613.07,335.02 615.48,333.25 617.90,331.38 620.32,329.41 622.73,327.34 622.73,409.32 620.32,405.82 617.90,402.46 615.48,399.25 613.07,396.17 610.65,393.24 608.23,390.45 605.82,387.81 603.40,385.33 600.98,382.99 598.57,380.81 596.15,378.79 593.73,376.92 591.32,375.20 588.90,373.64 586.48,372.21 584.07,370.92 581.65,369.76 579.24,368.70 576.82,367.73 574.40,366.84 571.99,366.00 569.57,365.22 567.15,364.47 564.74,363.77 562.32,363.11 559.90,362.50 557.49,361.97 555.07,361.50 552.65,361.14 550.24,360.89 547.82,360.73 545.40,360.65 542.99,360.60 540.57,360.49 538.15,360.22 535.74,360.00 533.32,359.94 530.90,359.90 528.49,359.72 526.07,359.59 523.65,359.77 521.24,360.19 518.82,360.49 516.40,360.71 513.99,361.06 511.57,361.46 509.16,361.58 506.74,361.57 504.32,361.77 501.91,362.42 499.49,363.59 497.07,365.28 494.66,367.43 492.24,369.97 489.82,372.81 487.41,375.83 484.99,378.88 482.57,381.81 480.16,384.67 477.74,387.51 475.32,390.33 472.91,393.15 470.49,395.98 468.07,398.85 465.66,401.79 463.24,404.81 460.82,407.93 458.41,411.18 455.99,414.55 453.57,418.06 451.16,421.71 448.74,425.48 446.32,429.38 443.91,433.41 441.49,437.55 439.08,441.80 436.66,446.15 434.24,450.62 431.83,455.18 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #999999; fill-opacity: 0.40;' />
+<polyline points='431.83,392.15 434.24,392.92 436.66,393.46 439.08,393.79 441.49,393.90 443.91,393.79 446.32,393.45 448.74,392.89 451.16,392.10 453.57,391.08 455.99,389.83 458.41,388.36 460.82,386.67 463.24,384.77 465.66,382.68 468.07,380.43 470.49,378.04 472.91,375.53 475.32,372.94 477.74,370.28 480.16,367.57 482.57,364.83 484.99,362.05 487.41,359.26 489.82,356.53 492.24,353.93 494.66,351.57 497.07,349.62 499.49,348.45 501.91,347.88 504.32,347.56 506.74,347.26 509.16,346.87 511.57,346.44 513.99,346.14 516.40,345.96 518.82,345.75 521.24,345.64 523.65,345.56 526.07,345.26 528.49,344.78 530.90,344.53 533.32,344.68 535.74,344.91 538.15,345.01 540.57,344.96 542.99,344.93 545.40,345.00 547.82,345.14 550.24,345.30 552.65,345.47 555.07,345.65 557.49,345.85 559.90,346.09 562.32,346.39 564.74,346.64 567.15,346.85 569.57,347.03 571.99,347.16 574.40,347.26 576.82,347.30 579.24,347.27 581.65,347.16 584.07,346.96 586.48,346.65 588.90,346.23 591.32,345.68 593.73,345.00 596.15,344.19 598.57,343.25 600.98,342.18 603.40,340.98 605.82,339.67 608.23,338.23 610.65,336.68 613.07,335.02 615.48,333.25 617.90,331.38 620.32,329.41 622.73,327.34 ' style='stroke-width: 2.13; stroke: none; stroke-linecap: butt;' />
+<polyline points='622.73,409.32 620.32,405.82 617.90,402.46 615.48,399.25 613.07,396.17 610.65,393.24 608.23,390.45 605.82,387.81 603.40,385.33 600.98,382.99 598.57,380.81 596.15,378.79 593.73,376.92 591.32,375.20 588.90,373.64 586.48,372.21 584.07,370.92 581.65,369.76 579.24,368.70 576.82,367.73 574.40,366.84 571.99,366.00 569.57,365.22 567.15,364.47 564.74,363.77 562.32,363.11 559.90,362.50 557.49,361.97 555.07,361.50 552.65,361.14 550.24,360.89 547.82,360.73 545.40,360.65 542.99,360.60 540.57,360.49 538.15,360.22 535.74,360.00 533.32,359.94 530.90,359.90 528.49,359.72 526.07,359.59 523.65,359.77 521.24,360.19 518.82,360.49 516.40,360.71 513.99,361.06 511.57,361.46 509.16,361.58 506.74,361.57 504.32,361.77 501.91,362.42 499.49,363.59 497.07,365.28 494.66,367.43 492.24,369.97 489.82,372.81 487.41,375.83 484.99,378.88 482.57,381.81 480.16,384.67 477.74,387.51 475.32,390.33 472.91,393.15 470.49,395.98 468.07,398.85 465.66,401.79 463.24,404.81 460.82,407.93 458.41,411.18 455.99,414.55 453.57,418.06 451.16,421.71 448.74,425.48 446.32,429.38 443.91,433.41 441.49,437.55 439.08,441.80 436.66,446.15 434.24,450.62 431.83,455.18 ' style='stroke-width: 2.13; stroke: none; stroke-linecap: butt;' />
+<polyline points='431.83,423.66 434.24,421.77 436.66,419.81 439.08,417.79 441.49,415.72 443.91,413.60 446.32,411.42 448.74,409.18 451.16,406.90 453.57,404.57 455.99,402.19 458.41,399.77 460.82,397.30 463.24,394.79 465.66,392.23 468.07,389.64 470.49,387.01 472.91,384.34 475.32,381.63 477.74,378.89 480.16,376.12 482.57,373.32 484.99,370.47 487.41,367.55 489.82,364.67 492.24,361.95 494.66,359.50 497.07,357.45 499.49,356.02 501.91,355.15 504.32,354.66 506.74,354.41 509.16,354.23 511.57,353.95 513.99,353.60 516.40,353.33 518.82,353.12 521.24,352.92 523.65,352.67 526.07,352.43 528.49,352.25 530.90,352.22 533.32,352.31 535.74,352.46 538.15,352.61 540.57,352.72 542.99,352.77 545.40,352.83 547.82,352.94 550.24,353.09 552.65,353.31 555.07,353.58 557.49,353.91 559.90,354.30 562.32,354.75 564.74,355.21 567.15,355.66 569.57,356.12 571.99,356.58 574.40,357.05 576.82,357.51 579.24,357.98 581.65,358.46 584.07,358.94 586.48,359.43 588.90,359.93 591.32,360.44 593.73,360.96 596.15,361.49 598.57,362.03 600.98,362.59 603.40,363.16 605.82,363.74 608.23,364.34 610.65,364.96 613.07,365.59 615.48,366.25 617.90,366.92 620.32,367.62 622.73,368.33 ' style='stroke-width: 2.13; stroke: #F8766D; stroke-linecap: butt;' />
+<polygon points='352.03,419.80 355.15,423.45 358.27,426.84 361.39,429.97 364.51,432.83 367.63,435.43 370.75,437.75 373.87,439.81 376.99,441.59 380.11,443.10 383.23,444.33 386.35,445.28 389.47,445.97 392.59,446.39 395.71,446.57 398.82,446.50 401.94,446.22 405.06,445.74 408.18,445.09 411.30,444.30 414.42,443.38 417.54,442.35 420.66,441.25 423.78,440.08 426.90,438.85 430.02,437.58 433.14,436.26 436.26,434.90 439.38,433.53 442.50,432.24 445.62,430.96 448.74,429.64 451.86,428.24 454.98,426.71 458.10,425.05 461.22,423.26 464.34,421.39 467.46,419.48 470.58,417.96 473.70,416.70 476.82,415.25 479.94,413.48 483.06,411.58 486.18,409.59 489.30,407.21 492.42,404.36 495.54,401.26 498.66,398.32 501.78,395.08 504.90,391.04 508.02,386.88 511.14,383.71 514.26,380.61 517.38,377.27 520.50,373.90 523.62,371.07 526.74,369.25 529.86,367.98 532.98,366.98 536.10,366.08 539.22,365.16 542.33,364.14 545.45,363.01 548.57,361.75 551.69,360.36 554.81,358.89 557.93,357.27 561.05,355.44 564.17,353.35 567.29,350.93 570.41,348.15 573.53,344.98 576.65,341.42 579.77,337.48 582.89,333.17 586.01,328.49 589.13,323.46 592.25,318.09 595.37,312.40 598.49,306.38 598.49,413.06 595.37,408.96 592.25,405.22 589.13,401.85 586.01,398.85 582.89,396.23 579.77,394.01 576.65,392.19 573.53,390.79 570.41,389.82 567.29,389.25 564.17,389.07 561.05,389.24 557.93,389.71 554.81,390.41 551.69,391.28 548.57,392.25 545.45,393.03 542.33,393.57 539.22,394.06 536.10,394.66 532.98,395.49 529.86,396.64 526.74,398.12 523.62,399.91 520.50,402.13 517.38,404.91 514.26,408.20 511.14,411.60 508.02,414.69 504.90,418.29 501.78,422.36 498.66,425.96 495.54,428.54 492.42,430.87 489.30,433.30 486.18,435.92 483.06,438.56 479.94,440.82 476.82,442.58 473.70,444.27 470.58,446.19 467.46,448.30 464.34,450.43 461.22,452.47 458.10,454.47 454.98,456.49 451.86,458.54 448.74,460.61 445.62,462.67 442.50,464.69 439.38,466.61 436.26,468.40 433.14,470.10 430.02,471.76 426.90,473.38 423.78,474.96 420.66,476.51 417.54,478.03 414.42,479.55 411.30,481.08 408.18,482.63 405.06,484.25 401.94,485.94 398.82,487.73 395.71,489.65 392.59,491.70 389.47,493.92 386.35,496.29 383.23,498.84 380.11,501.57 376.99,504.47 373.87,507.54 370.75,510.79 367.63,514.21 364.51,517.80 361.39,521.55 358.27,525.46 355.15,529.52 352.03,533.74 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #999999; fill-opacity: 0.40;' />
+<polyline points='352.03,419.80 355.15,423.45 358.27,426.84 361.39,429.97 364.51,432.83 367.63,435.43 370.75,437.75 373.87,439.81 376.99,441.59 380.11,443.10 383.23,444.33 386.35,445.28 389.47,445.97 392.59,446.39 395.71,446.57 398.82,446.50 401.94,446.22 405.06,445.74 408.18,445.09 411.30,444.30 414.42,443.38 417.54,442.35 420.66,441.25 423.78,440.08 426.90,438.85 430.02,437.58 433.14,436.26 436.26,434.90 439.38,433.53 442.50,432.24 445.62,430.96 448.74,429.64 451.86,428.24 454.98,426.71 458.10,425.05 461.22,423.26 464.34,421.39 467.46,419.48 470.58,417.96 473.70,416.70 476.82,415.25 479.94,413.48 483.06,411.58 486.18,409.59 489.30,407.21 492.42,404.36 495.54,401.26 498.66,398.32 501.78,395.08 504.90,391.04 508.02,386.88 511.14,383.71 514.26,380.61 517.38,377.27 520.50,373.90 523.62,371.07 526.74,369.25 529.86,367.98 532.98,366.98 536.10,366.08 539.22,365.16 542.33,364.14 545.45,363.01 548.57,361.75 551.69,360.36 554.81,358.89 557.93,357.27 561.05,355.44 564.17,353.35 567.29,350.93 570.41,348.15 573.53,344.98 576.65,341.42 579.77,337.48 582.89,333.17 586.01,328.49 589.13,323.46 592.25,318.09 595.37,312.40 598.49,306.38 ' style='stroke-width: 2.13; stroke: none; stroke-linecap: butt;' />
+<polyline points='598.49,413.06 595.37,408.96 592.25,405.22 589.13,401.85 586.01,398.85 582.89,396.23 579.77,394.01 576.65,392.19 573.53,390.79 570.41,389.82 567.29,389.25 564.17,389.07 561.05,389.24 557.93,389.71 554.81,390.41 551.69,391.28 548.57,392.25 545.45,393.03 542.33,393.57 539.22,394.06 536.10,394.66 532.98,395.49 529.86,396.64 526.74,398.12 523.62,399.91 520.50,402.13 517.38,404.91 514.26,408.20 511.14,411.60 508.02,414.69 504.90,418.29 501.78,422.36 498.66,425.96 495.54,428.54 492.42,430.87 489.30,433.30 486.18,435.92 483.06,438.56 479.94,440.82 476.82,442.58 473.70,444.27 470.58,446.19 467.46,448.30 464.34,450.43 461.22,452.47 458.10,454.47 454.98,456.49 451.86,458.54 448.74,460.61 445.62,462.67 442.50,464.69 439.38,466.61 436.26,468.40 433.14,470.10 430.02,471.76 426.90,473.38 423.78,474.96 420.66,476.51 417.54,478.03 414.42,479.55 411.30,481.08 408.18,482.63 405.06,484.25 401.94,485.94 398.82,487.73 395.71,489.65 392.59,491.70 389.47,493.92 386.35,496.29 383.23,498.84 380.11,501.57 376.99,504.47 373.87,507.54 370.75,510.79 367.63,514.21 364.51,517.80 361.39,521.55 358.27,525.46 355.15,529.52 352.03,533.74 ' style='stroke-width: 2.13; stroke: none; stroke-linecap: butt;' />
+<polyline points='352.03,476.77 355.15,476.49 358.27,476.15 361.39,475.76 364.51,475.32 367.63,474.82 370.75,474.27 373.87,473.68 376.99,473.03 380.11,472.33 383.23,471.59 386.35,470.79 389.47,469.94 392.59,469.05 395.71,468.11 398.82,467.12 401.94,466.08 405.06,464.99 408.18,463.86 411.30,462.69 414.42,461.46 417.54,460.19 420.66,458.88 423.78,457.52 426.90,456.12 430.02,454.67 433.14,453.18 436.26,451.65 439.38,450.07 442.50,448.46 445.62,446.82 448.74,445.12 451.86,443.39 454.98,441.60 458.10,439.76 461.22,437.86 464.34,435.91 467.46,433.89 470.58,432.07 473.70,430.48 476.82,428.91 479.94,427.15 483.06,425.07 486.18,422.76 489.30,420.25 492.42,417.62 495.54,414.90 498.66,412.14 501.78,408.72 504.90,404.66 508.02,400.79 511.14,397.66 514.26,394.40 517.38,391.09 520.50,388.02 523.62,385.49 526.74,383.69 529.86,382.31 532.98,381.24 536.10,380.37 539.22,379.61 542.33,378.86 545.45,378.02 548.57,377.00 551.69,375.82 554.81,374.65 557.93,373.49 561.05,372.34 564.17,371.21 567.29,370.09 570.41,368.98 573.53,367.89 576.65,366.81 579.77,365.75 582.89,364.70 586.01,363.67 589.13,362.65 592.25,361.66 595.37,360.68 598.49,359.72 ' style='stroke-width: 2.13; stroke: #00BFC4; stroke-linecap: butt;' />
+<rect x='338.49' y='295.01' width='297.78' height='250.10' style='stroke-width: 1.07; stroke: #333333;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMzUuMjR8MzMzLjAxfDIyLjc4fDM5LjQz'>
+    <rect x='35.24' y='22.78' width='297.78' height='16.65' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMzUuMjR8MzMzLjAxfDIyLjc4fDM5LjQz)'>
+<rect x='35.24' y='22.78' width='297.78' height='16.65' style='stroke-width: 1.07; stroke: #333333; fill: #D9D9D9;' />
+<text x='184.13' y='34.14' text-anchor='middle' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='10.76px' lengthAdjust='spacingAndGlyphs'>bili</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMzM4LjQ5fDYzNi4yN3wyMi43OHwzOS40Mw=='>
+    <rect x='338.49' y='22.78' width='297.78' height='16.65' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMzM4LjQ5fDYzNi4yN3wyMi43OHwzOS40Mw==)'>
+<rect x='338.49' y='22.78' width='297.78' height='16.65' style='stroke-width: 1.07; stroke: #333333; fill: #D9D9D9;' />
+<text x='487.38' y='34.14' text-anchor='middle' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='30.82px' lengthAdjust='spacingAndGlyphs'>albumin</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNjM2LjI3fDY1Mi45MnwzOS40M3wyODkuNTM='>
+    <rect x='636.27' y='39.43' width='16.65' height='250.10' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNjM2LjI3fDY1Mi45MnwzOS40M3wyODkuNTM=)'>
+<rect x='636.27' y='39.43' width='16.65' height='250.10' style='stroke-width: 1.07; stroke: #333333; fill: #D9D9D9;' />
+<text transform='translate(641.57,164.48) rotate(90)' text-anchor='middle' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>1</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNjM2LjI3fDY1Mi45MnwyOTUuMDF8NTQ1LjEx'>
+    <rect x='636.27' y='295.01' width='16.65' height='250.10' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNjM2LjI3fDY1Mi45MnwyOTUuMDF8NTQ1LjEx)'>
+<rect x='636.27' y='295.01' width='16.65' height='250.10' style='stroke-width: 1.07; stroke: #333333; fill: #D9D9D9;' />
+<text transform='translate(641.57,420.06) rotate(90)' text-anchor='middle' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>3</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<polyline points='45.84,547.85 45.84,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='143.57,547.85 143.57,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='241.30,547.85 241.30,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='45.84' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='143.57' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>10</text>
+<text x='241.30' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>20</text>
+<polyline points='356.07,547.85 356.07,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='457.08,547.85 457.08,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='558.09,547.85 558.09,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='356.07' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='457.08' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>3</text>
+<text x='558.09' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text x='30.31' y='249.98' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.3</text>
+<text x='30.31' y='178.66' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.6</text>
+<text x='30.31' y='107.34' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.9</text>
+<polyline points='32.50,246.95 35.24,246.95 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='32.50,175.63 35.24,175.63 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='32.50,104.31 35.24,104.31 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='30.31' y='505.56' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.3</text>
+<text x='30.31' y='434.24' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.6</text>
+<text x='30.31' y='362.92' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.9</text>
+<polyline points='32.50,502.53 35.24,502.53 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='32.50,431.21 35.24,431.21 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='32.50,359.89 35.24,359.89 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text transform='translate(13.05,292.27) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='39.13px' lengthAdjust='spacingAndGlyphs'>Survival</text>
+<rect x='663.88' y='267.33' width='50.64' height='49.89' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<text x='663.88' y='276.04' style='font-size: 11.00px; font-family: sans;' textLength='26.91px' lengthAdjust='spacingAndGlyphs'>event</text>
+<rect x='663.88' y='282.66' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<circle cx='672.52' cy='291.30' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<rect x='663.88' y='282.66' width='17.28' height='17.28' style='stroke-width: 0.75; stroke: none; fill: #999999; fill-opacity: 0.40;' />
+<line x1='665.61' y1='291.30' x2='679.43' y2='291.30' style='stroke-width: 2.13; stroke: #F8766D; stroke-linecap: butt;' />
+<rect x='663.88' y='299.94' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<polygon points='672.52,305.54 675.15,310.10 669.88,310.10 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<rect x='663.88' y='299.94' width='17.28' height='17.28' style='stroke-width: 0.75; stroke: none; fill: #999999; fill-opacity: 0.40;' />
+<line x1='665.61' y1='308.58' x2='679.43' y2='308.58' style='stroke-width: 2.13; stroke: #00BFC4; stroke-linecap: butt;' />
+<text x='686.64' y='294.33' style='font-size: 8.80px; font-family: sans;' textLength='27.88px' lengthAdjust='spacingAndGlyphs'>FALSE</text>
+<text x='686.64' y='311.61' style='font-size: 8.80px; font-family: sans;' textLength='23.96px' lengthAdjust='spacingAndGlyphs'>TRUE</text>
+<text x='35.24' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='212.79px' lengthAdjust='spacingAndGlyphs'>gg_variable survival panel multi time</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/snapshots/gg-variable-survival-panel-single-time.svg
+++ b/tests/testthat/_snaps/snapshots/gg-variable-survival-panel-single-time.svg
@@ -1,0 +1,745 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpMzUuMjR8MzQxLjM0fDM5LjQzfDU0NS4xMQ=='>
+    <rect x='35.24' y='39.43' width='306.10' height='505.68' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMzUuMjR8MzQxLjM0fDM5LjQzfDU0NS4xMQ==)'>
+<rect x='35.24' y='39.43' width='306.10' height='505.68' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<polygon points='191.80,433.16 194.44,437.72 189.17,437.72 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='57.19' cy='131.35' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='60.20,142.13 62.84,146.69 57.57,146.69 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='64.22,249.49 66.85,254.05 61.59,254.05 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='80.29' cy='141.45' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='54.17,132.06 56.81,136.62 51.54,136.62 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='56.18' cy='119.41' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='49.15,111.13 51.78,115.69 46.52,115.69 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='78.29,157.72 80.92,162.28 75.65,162.28 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='172.72,380.57 175.35,385.13 170.08,385.13 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='60.20,122.28 62.84,126.84 57.57,126.84 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='82.30,166.99 84.94,171.55 79.67,171.55 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='53.17' cy='114.81' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='54.17,266.65 56.81,271.21 51.54,271.21 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='54.17,129.74 56.81,134.30 51.54,134.30 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='53.17' cy='121.24' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='73.26,185.36 75.89,189.92 70.63,189.92 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='160.66,377.55 163.29,382.11 158.03,382.11 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='53.17' cy='114.34' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='97.37,208.35 100.01,212.91 94.74,212.91 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='52.17' cy='130.11' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='80.29,194.01 82.93,198.57 77.66,198.57 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='220.94,357.67 223.57,362.23 218.31,362.23 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='67.23,128.36 69.87,132.92 64.60,132.92 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='53.17' cy='116.71' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='98.38,166.83 101.01,171.39 95.74,171.39 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='263.13,317.55 265.76,322.11 260.50,322.11 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='218.93,340.80 221.56,345.36 216.30,345.36 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='53.17' cy='130.51' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='82.30,260.31 84.94,264.87 79.67,264.87 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='93.35,172.84 95.99,177.40 90.72,177.40 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='64.22' cy='128.40' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='54.17,133.24 56.81,137.80 51.54,137.80 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='54.17' cy='115.46' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='58.19,132.39 60.83,136.95 55.56,136.95 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='49.15' cy='116.48' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='117.46,260.95 120.10,265.51 114.83,265.51 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='79.29,130.49 81.92,135.05 76.66,135.05 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='53.17,142.82 55.80,147.38 50.54,147.38 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='59.20' cy='116.29' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='114.45,212.37 117.08,216.93 111.82,216.93 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='67.23' cy='120.80' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='57.19' cy='120.88' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='79.29,138.01 81.92,142.57 76.66,142.57 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='52.17' cy='114.85' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='103.40,196.08 106.03,200.64 100.77,200.64 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='51.16' cy='113.33' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='65.23' cy='130.25' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='54.17,113.23 56.81,117.79 51.54,117.79 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='57.19,115.86 59.82,120.42 54.56,120.42 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='54.17,110.29 56.81,114.85 51.54,114.85 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='106.41,182.65 109.05,187.21 103.78,187.21 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='72.26,245.06 74.89,249.62 69.62,249.62 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='59.20,116.62 61.83,121.18 56.57,121.18 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='64.22,129.25 66.85,133.81 61.59,133.81 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='57.19,120.31 59.82,124.87 54.56,124.87 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='69.24,196.49 71.88,201.05 66.61,201.05 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='53.17' cy='115.52' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='54.17,111.99 56.81,116.55 51.54,116.55 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='55.18' cy='129.21' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='52.17' cy='115.96' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='59.20,217.24 61.83,221.80 56.57,221.80 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='272.17,420.88 274.80,425.44 269.54,425.44 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='67.23,142.48 69.87,147.04 64.60,147.04 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='58.19' cy='117.62' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='60.20,114.83 62.84,119.39 57.57,119.39 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='57.19,119.65 59.82,124.21 54.56,124.21 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='53.17' cy='122.10' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='247.06,338.13 249.69,342.69 244.42,342.69 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='52.17' cy='182.50' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='58.19' cy='117.48' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='51.16' cy='114.87' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='53.17' cy='116.98' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='130.52,235.27 133.16,239.83 127.89,239.83 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='217.92,398.15 220.56,402.71 215.29,402.71 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='168.70,344.88 171.33,349.44 166.07,349.44 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='112.44,193.00 115.07,197.56 109.81,197.56 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='109.43,223.29 112.06,227.85 106.79,227.85 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='54.17' cy='157.93' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='118.47,235.49 121.10,240.05 115.84,240.05 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='190.80,336.98 193.43,341.54 188.17,341.54 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='91.34,231.36 93.98,235.92 88.71,235.92 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='59.20' cy='122.40' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='50.16' cy='114.25' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='67.23,124.35 69.87,128.91 64.60,128.91 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='96.37,203.69 99.00,208.25 93.74,208.25 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='57.19,111.49 59.82,116.05 54.56,116.05 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='52.17' cy='115.13' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='66.23,128.25 68.86,132.81 63.60,132.81 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='62.21,138.91 64.84,143.47 59.58,143.47 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='96.37,165.12 99.00,169.68 93.74,169.68 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='60.20,149.84 62.84,154.40 57.57,154.40 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='59.20' cy='133.09' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='78.29,218.29 80.92,222.85 75.65,222.85 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='220.94,375.53 223.57,380.09 218.31,380.09 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='56.18' cy='116.21' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='66.23,158.38 68.86,162.94 63.60,162.94 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='56.18' cy='121.83' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='64.22' cy='121.72' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='69.24,162.83 71.88,167.39 66.61,167.39 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='55.18' cy='114.95' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='55.18' cy='120.17' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='71.25,130.14 73.89,134.70 68.62,134.70 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='57.19,115.76 59.82,120.32 54.56,120.32 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='57.19' cy='153.40' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='67.23,154.94 69.87,159.50 64.60,159.50 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='52.17' cy='124.11' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='50.16,113.13 52.79,117.69 47.52,117.69 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='51.16' cy='113.33' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='65.23,114.49 67.86,119.05 62.59,119.05 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='101.39' cy='138.55' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='66.23,133.02 68.86,137.58 63.60,137.58 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='113.45,191.48 116.08,196.04 110.81,196.04 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='78.29,172.28 80.92,176.84 75.65,176.84 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='53.17' cy='126.57' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='76.28' cy='226.01' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='111.44,251.50 114.07,256.06 108.80,256.06 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='81.30,198.38 83.93,202.94 78.67,202.94 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='52.17,111.05 54.80,115.61 49.53,115.61 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='81.30' cy='142.77' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='59.20,148.89 61.83,153.45 56.57,153.45 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='52.17' cy='117.62' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='97.37,177.79 100.01,182.35 94.74,182.35 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='52.17' cy='113.96' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='59.20' cy='117.73' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='58.19,140.28 60.83,144.84 55.56,144.84 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='51.16' cy='118.37' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='208.88,386.64 211.52,391.20 206.25,391.20 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='55.18' cy='134.50' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='220.94,307.90 223.57,312.46 218.31,312.46 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='74.27,189.43 76.90,193.99 71.63,193.99 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='65.23' cy='118.15' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='61.21,130.79 63.84,135.35 58.57,135.35 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='53.17' cy='113.33' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='50.16' cy='115.28' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='54.17' cy='116.24' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='57.19' cy='126.69' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='119.47,230.42 122.11,234.98 116.84,234.98 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='57.19' cy='127.50' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='57.19' cy='121.02' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='55.18' cy='114.19' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='56.18,113.07 58.82,117.63 53.55,117.63 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='75.27,152.47 77.90,157.03 72.64,157.03 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='327.42,357.91 330.06,362.47 324.79,362.47 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='53.17' cy='117.12' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='58.19' cy='131.72' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='58.19' cy='129.98' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='118.47,268.63 121.10,273.19 115.84,273.19 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='76.28,201.81 78.91,206.37 73.64,206.37 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='56.18' cy='116.23' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='55.18' cy='141.88' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='69.24,270.47 71.88,275.03 66.61,275.03 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='51.16' cy='115.04' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='70.25,308.53 72.88,313.09 67.62,313.09 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='52.17' cy='114.25' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='302.31,322.04 304.94,326.60 299.68,326.60 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='52.17' cy='115.22' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='80.29' cy='146.58' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='71.25,158.79 73.89,163.35 68.62,163.35 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='52.17' cy='115.95' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='69.24' cy='131.14' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='78.29,184.41 80.92,188.97 75.65,188.97 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='49.15,112.31 51.78,116.87 46.52,116.87 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='131.53,214.25 134.16,218.81 128.90,218.81 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='86.32,176.21 88.95,180.77 83.69,180.77 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='103.40' cy='208.68' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='55.18,119.32 57.81,123.88 52.55,123.88 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='50.16' cy='113.33' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='59.20,133.01 61.83,137.57 56.57,137.57 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='58.19' cy='118.10' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='51.16' cy='172.75' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='59.20' cy='117.33' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='76.28' cy='133.75' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='51.16' cy='114.22' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='54.17' cy='114.12' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='78.29,143.57 80.92,148.13 75.65,148.13 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='55.18' cy='122.31' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='52.17' cy='129.91' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='64.22' cy='122.77' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='93.35' cy='151.41' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='60.20' cy='114.02' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='52.17' cy='113.33' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='51.16' cy='115.95' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='156.64,264.40 159.28,268.96 154.01,268.96 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='54.17' cy='114.56' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='66.23,144.58 68.86,149.14 63.60,149.14 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='186.78,290.13 189.41,294.69 184.15,294.69 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='53.17' cy='126.75' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='59.20' cy='120.00' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='69.24' cy='171.45' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='292.26,269.85 294.90,274.41 289.63,274.41 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='55.18' cy='116.10' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='154.63,328.18 157.27,332.74 152.00,332.74 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='61.21' cy='188.09' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='83.31' cy='144.33' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='60.20' cy='119.26' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='52.17' cy='114.21' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='53.17' cy='144.08' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='67.23' cy='128.77' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='93.35' cy='140.38' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='52.17' cy='131.26' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='51.16' cy='121.92' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='51.16' cy='124.91' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='53.17,118.45 55.80,123.01 50.54,123.01 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='71.25,146.71 73.89,151.27 68.62,151.27 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='52.17' cy='117.98' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='52.17' cy='142.35' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='85.32,278.99 87.95,283.55 82.68,283.55 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='53.17' cy='116.49' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='55.18' cy='115.14' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='59.20' cy='116.92' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='58.19' cy='119.90' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='51.16' cy='115.15' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='55.18,123.73 57.81,128.29 52.55,128.29 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='105.41,155.38 108.04,159.94 102.78,159.94 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='51.16' cy='115.88' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='160.66,287.89 163.29,292.45 158.03,292.45 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='51.16' cy='119.18' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='62.21' cy='126.13' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='84.31,268.21 86.95,272.77 81.68,272.77 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='55.18' cy='113.33' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='91.34,158.04 93.98,162.60 88.71,162.60 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='187.79,440.79 190.42,445.35 185.15,445.35 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='56.18' cy='125.00' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='53.17' cy='119.61' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='51.16' cy='117.56' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='69.24,149.02 71.88,153.58 66.61,153.58 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='53.17' cy='115.54' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='91.34,226.57 93.98,231.13 88.71,231.13 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='79.29' cy='138.41' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='80.29,442.68 82.93,447.24 77.66,447.24 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='50.16' cy='139.71' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='55.18' cy='144.90' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='55.18' cy='115.21' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='176.74' cy='289.17' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='61.21' cy='121.39' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='62.21' cy='195.20' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='52.17' cy='136.39' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='54.17,144.58 56.81,149.14 51.54,149.14 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='50.16' cy='114.56' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='90.34' cy='150.09' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='65.23' cy='206.29' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='126.51,350.42 129.14,354.98 123.87,354.98 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='85.32,177.38 87.95,181.94 82.68,181.94 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='52.17' cy='114.19' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='67.23' cy='125.92' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='107.42' cy='252.01' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='54.17' cy='116.10' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='59.20' cy='140.34' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='52.17' cy='115.97' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='51.16' cy='114.92' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='57.19' cy='137.80' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='117.46' cy='392.52' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='77.28' cy='141.99' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='53.17' cy='117.41' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='57.19' cy='123.13' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='51.16' cy='129.04' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='57.19' cy='118.50' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='77.28' cy='234.94' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='102.40' cy='221.26' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='78.29' cy='207.52' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='74.27' cy='183.15' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='57.19' cy='122.35' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='80.29' cy='209.62' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='81.30' cy='196.05' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='51.16' cy='124.32' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='112.44,391.56 115.07,396.12 109.81,396.12 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='110.43,322.37 113.06,326.92 107.80,326.92 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='82.30' cy='196.52' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='56.18' cy='119.44' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='56.18' cy='117.54' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='51.16' cy='150.16' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='68.24' cy='150.36' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='62.21' cy='140.42' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='68.24' cy='130.66' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='56.18' cy='122.48' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='56.18' cy='117.34' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='102.40' cy='149.02' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='51.16' cy='114.09' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='62.21' cy='116.54' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='225.96,446.97 228.59,451.53 223.33,451.53 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='59.20' cy='128.22' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='57.19' cy='135.39' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='59.20' cy='119.50' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='54.17' cy='118.38' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='66.23' cy='122.31' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='110.43' cy='260.38' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='133.54' cy='289.55' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='86.32,179.96 88.95,184.52 83.69,184.52 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='60.20' cy='147.35' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='78.29' cy='157.83' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='132.53' cy='288.75' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='131.53' cy='364.74' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='112.44' cy='317.61' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='70.25' cy='144.78' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='54.17' cy='128.45' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='58.19' cy='119.02' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='57.19' cy='121.83' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='70.25' cy='154.43' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='98.38,347.89 101.01,352.45 95.74,352.45 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='56.18' cy='114.91' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='53.17' cy='126.16' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='56.18' cy='141.63' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='51.16' cy='123.95' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='75.27' cy='154.99' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='52.17' cy='115.41' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='54.17' cy='115.69' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='50.16' cy='114.20' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='50.16' cy='168.02' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='63.22' cy='144.41' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='66.23' cy='146.16' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='110.43' cy='173.17' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='49.15,108.63 50.77,114.86 52.38,116.77 54.00,115.83 55.61,115.56 57.23,117.11 58.84,119.51 60.46,122.13 62.07,124.33 63.69,126.25 65.30,128.71 66.92,131.98 68.53,135.72 70.15,139.73 71.76,143.74 73.38,147.46 74.99,150.69 76.61,153.30 78.22,155.26 79.84,156.55 81.45,157.38 83.07,158.31 84.68,159.38 86.30,160.62 87.91,162.03 89.53,163.61 91.14,165.36 92.76,167.29 94.37,169.40 95.99,171.66 97.60,174.09 99.22,176.67 100.83,179.39 102.45,182.25 104.06,185.23 105.68,188.33 107.29,191.53 108.91,194.82 110.52,198.20 112.14,201.65 113.75,205.15 115.37,208.71 116.98,212.29 118.60,215.90 120.21,219.51 121.83,223.12 123.44,226.71 125.06,230.27 126.67,233.78 128.29,237.23 129.90,240.61 131.52,243.91 133.13,247.10 134.75,250.19 136.36,253.16 137.98,256.00 139.59,258.69 141.21,261.24 142.82,263.62 144.44,265.83 146.05,267.86 147.67,269.70 149.28,271.35 150.90,272.79 152.51,274.02 154.13,275.03 155.74,275.81 157.36,276.35 158.97,276.65 160.59,276.69 162.20,276.47 163.82,275.98 165.43,275.21 167.05,274.15 168.66,272.78 170.28,271.11 171.89,269.13 173.51,266.81 175.12,264.16 176.74,261.15 176.74,357.57 175.12,356.53 173.51,355.29 171.89,353.86 170.28,352.24 168.66,350.45 167.05,348.48 165.43,346.35 163.82,344.06 162.20,341.63 160.59,339.05 158.97,336.34 157.36,333.50 155.74,330.54 154.13,327.47 152.51,324.30 150.90,321.04 149.28,317.69 147.67,314.26 146.05,310.76 144.44,307.20 142.82,303.59 141.21,299.94 139.59,296.24 137.98,292.52 136.36,288.77 134.75,285.00 133.13,281.22 131.52,277.43 129.90,273.64 128.29,269.85 126.67,266.06 125.06,262.28 123.44,258.51 121.83,254.76 120.21,251.02 118.60,247.30 116.98,243.61 115.37,239.95 113.75,236.31 112.14,232.71 110.52,229.15 108.91,225.63 107.29,222.16 105.68,218.74 104.06,215.39 102.45,212.09 100.83,208.87 99.22,205.73 97.60,202.67 95.99,199.70 94.37,196.84 92.76,194.09 91.14,191.47 89.53,188.98 87.91,186.64 86.30,184.47 84.68,182.50 83.07,180.74 81.45,179.23 79.84,177.94 78.22,176.00 76.61,173.29 74.99,170.08 73.38,166.59 71.76,162.98 70.15,159.30 68.53,155.54 66.92,151.70 65.30,147.85 63.69,144.07 62.07,140.54 60.46,137.47 58.84,134.43 57.23,130.83 55.61,128.83 54.00,127.82 52.38,127.62 50.77,131.70 49.15,141.50 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #999999; fill-opacity: 0.40;' />
+<polyline points='49.15,108.63 50.77,114.86 52.38,116.77 54.00,115.83 55.61,115.56 57.23,117.11 58.84,119.51 60.46,122.13 62.07,124.33 63.69,126.25 65.30,128.71 66.92,131.98 68.53,135.72 70.15,139.73 71.76,143.74 73.38,147.46 74.99,150.69 76.61,153.30 78.22,155.26 79.84,156.55 81.45,157.38 83.07,158.31 84.68,159.38 86.30,160.62 87.91,162.03 89.53,163.61 91.14,165.36 92.76,167.29 94.37,169.40 95.99,171.66 97.60,174.09 99.22,176.67 100.83,179.39 102.45,182.25 104.06,185.23 105.68,188.33 107.29,191.53 108.91,194.82 110.52,198.20 112.14,201.65 113.75,205.15 115.37,208.71 116.98,212.29 118.60,215.90 120.21,219.51 121.83,223.12 123.44,226.71 125.06,230.27 126.67,233.78 128.29,237.23 129.90,240.61 131.52,243.91 133.13,247.10 134.75,250.19 136.36,253.16 137.98,256.00 139.59,258.69 141.21,261.24 142.82,263.62 144.44,265.83 146.05,267.86 147.67,269.70 149.28,271.35 150.90,272.79 152.51,274.02 154.13,275.03 155.74,275.81 157.36,276.35 158.97,276.65 160.59,276.69 162.20,276.47 163.82,275.98 165.43,275.21 167.05,274.15 168.66,272.78 170.28,271.11 171.89,269.13 173.51,266.81 175.12,264.16 176.74,261.15 ' style='stroke-width: 2.13; stroke: none; stroke-linecap: butt;' />
+<polyline points='176.74,357.57 175.12,356.53 173.51,355.29 171.89,353.86 170.28,352.24 168.66,350.45 167.05,348.48 165.43,346.35 163.82,344.06 162.20,341.63 160.59,339.05 158.97,336.34 157.36,333.50 155.74,330.54 154.13,327.47 152.51,324.30 150.90,321.04 149.28,317.69 147.67,314.26 146.05,310.76 144.44,307.20 142.82,303.59 141.21,299.94 139.59,296.24 137.98,292.52 136.36,288.77 134.75,285.00 133.13,281.22 131.52,277.43 129.90,273.64 128.29,269.85 126.67,266.06 125.06,262.28 123.44,258.51 121.83,254.76 120.21,251.02 118.60,247.30 116.98,243.61 115.37,239.95 113.75,236.31 112.14,232.71 110.52,229.15 108.91,225.63 107.29,222.16 105.68,218.74 104.06,215.39 102.45,212.09 100.83,208.87 99.22,205.73 97.60,202.67 95.99,199.70 94.37,196.84 92.76,194.09 91.14,191.47 89.53,188.98 87.91,186.64 86.30,184.47 84.68,182.50 83.07,180.74 81.45,179.23 79.84,177.94 78.22,176.00 76.61,173.29 74.99,170.08 73.38,166.59 71.76,162.98 70.15,159.30 68.53,155.54 66.92,151.70 65.30,147.85 63.69,144.07 62.07,140.54 60.46,137.47 58.84,134.43 57.23,130.83 55.61,128.83 54.00,127.82 52.38,127.62 50.77,131.70 49.15,141.50 ' style='stroke-width: 2.13; stroke: none; stroke-linecap: butt;' />
+<polyline points='49.15,125.06 50.77,123.28 52.38,122.19 54.00,121.83 55.61,122.20 57.23,123.97 58.84,126.97 60.46,129.80 62.07,132.43 63.69,135.16 65.30,138.28 66.92,141.84 68.53,145.63 70.15,149.51 71.76,153.36 73.38,157.02 74.99,160.38 76.61,163.30 78.22,165.63 79.84,167.25 81.45,168.30 83.07,169.52 84.68,170.94 86.30,172.55 87.91,174.33 89.53,176.29 91.14,178.41 92.76,180.69 94.37,183.12 95.99,185.68 97.60,188.38 99.22,191.20 100.83,194.13 102.45,197.17 104.06,200.31 105.68,203.54 107.29,206.85 108.91,210.23 110.52,213.68 112.14,217.18 113.75,220.73 115.37,224.33 116.98,227.95 118.60,231.60 120.21,235.27 121.83,238.94 123.44,242.61 125.06,246.27 126.67,249.92 128.29,253.54 129.90,257.12 131.52,260.67 133.13,264.16 134.75,267.60 136.36,270.96 137.98,274.26 139.59,277.47 141.21,280.59 142.82,283.60 144.44,286.52 146.05,289.31 147.67,291.98 149.28,294.52 150.90,296.91 152.51,299.16 154.13,301.25 155.74,303.17 157.36,304.93 158.97,306.49 160.59,307.87 162.20,309.05 163.82,310.02 165.43,310.78 167.05,311.31 168.66,311.62 170.28,311.68 171.89,311.49 173.51,311.05 175.12,310.34 176.74,309.36 ' style='stroke-width: 2.13; stroke: #F8766D; stroke-linecap: butt;' />
+<polygon points='49.15,80.46 52.67,101.49 56.20,119.37 59.72,133.67 63.24,144.85 66.76,154.33 70.29,162.75 73.81,171.58 77.33,179.44 80.85,185.50 84.38,189.59 87.90,191.82 91.42,194.01 94.94,198.47 98.47,203.70 101.99,208.70 105.51,213.09 109.03,217.01 112.56,221.02 116.08,225.59 119.60,230.54 123.12,235.88 126.65,241.57 130.17,247.58 133.69,253.83 137.21,260.26 140.74,266.80 144.26,273.35 147.78,279.85 151.30,286.22 154.83,292.40 158.35,298.34 161.87,304.00 165.39,309.35 168.92,314.37 172.44,319.05 175.96,323.37 179.48,327.34 183.00,330.93 186.53,334.14 190.05,336.97 193.57,339.57 197.09,341.93 200.62,344.08 204.14,346.00 207.66,347.71 211.18,349.21 214.71,350.48 218.23,351.54 221.75,352.37 225.27,352.97 228.80,353.34 232.32,353.46 235.84,353.32 239.36,352.92 242.89,352.25 246.41,351.29 249.93,350.03 253.45,348.46 256.98,346.58 260.50,344.36 264.02,341.81 267.54,338.92 271.07,335.68 274.59,332.08 278.11,328.14 281.63,323.85 285.16,319.20 288.68,314.21 292.20,308.87 295.72,303.18 299.25,297.15 302.77,290.78 306.29,284.07 309.81,277.03 313.34,269.66 316.86,261.97 320.38,253.94 323.90,245.59 327.42,236.92 327.42,377.70 323.90,379.31 320.38,380.86 316.86,382.36 313.34,383.80 309.81,385.19 306.29,386.53 302.77,387.82 299.25,389.06 295.72,390.25 292.20,391.39 288.68,392.49 285.16,393.54 281.63,394.55 278.11,395.52 274.59,396.45 271.07,397.32 267.54,398.15 264.02,398.93 260.50,399.65 256.98,400.31 253.45,400.88 249.93,401.38 246.41,401.77 242.89,402.06 239.36,402.22 235.84,402.25 232.32,402.13 228.80,401.85 225.27,401.40 221.75,400.77 218.23,399.95 214.71,398.94 211.18,397.73 207.66,396.32 204.14,394.70 200.62,392.87 197.09,390.84 193.57,388.60 190.05,386.16 186.53,383.48 183.00,380.24 179.48,376.38 175.96,371.97 172.44,367.09 168.92,361.81 165.39,356.20 161.87,350.35 158.35,344.31 154.83,338.15 151.30,331.90 147.78,325.59 144.26,319.26 140.74,312.91 137.21,306.56 133.69,300.20 130.17,293.85 126.65,287.52 123.12,281.22 119.60,275.01 116.08,268.94 112.56,263.09 109.03,257.38 105.51,252.07 101.99,247.48 98.47,243.47 94.94,239.41 91.42,234.60 87.90,229.46 84.38,224.75 80.85,220.36 77.33,214.36 73.81,205.10 70.29,194.65 66.76,183.90 63.24,172.30 59.72,161.21 56.20,152.10 52.67,145.72 49.15,141.86 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #999999; fill-opacity: 0.40;' />
+<polyline points='49.15,80.46 52.67,101.49 56.20,119.37 59.72,133.67 63.24,144.85 66.76,154.33 70.29,162.75 73.81,171.58 77.33,179.44 80.85,185.50 84.38,189.59 87.90,191.82 91.42,194.01 94.94,198.47 98.47,203.70 101.99,208.70 105.51,213.09 109.03,217.01 112.56,221.02 116.08,225.59 119.60,230.54 123.12,235.88 126.65,241.57 130.17,247.58 133.69,253.83 137.21,260.26 140.74,266.80 144.26,273.35 147.78,279.85 151.30,286.22 154.83,292.40 158.35,298.34 161.87,304.00 165.39,309.35 168.92,314.37 172.44,319.05 175.96,323.37 179.48,327.34 183.00,330.93 186.53,334.14 190.05,336.97 193.57,339.57 197.09,341.93 200.62,344.08 204.14,346.00 207.66,347.71 211.18,349.21 214.71,350.48 218.23,351.54 221.75,352.37 225.27,352.97 228.80,353.34 232.32,353.46 235.84,353.32 239.36,352.92 242.89,352.25 246.41,351.29 249.93,350.03 253.45,348.46 256.98,346.58 260.50,344.36 264.02,341.81 267.54,338.92 271.07,335.68 274.59,332.08 278.11,328.14 281.63,323.85 285.16,319.20 288.68,314.21 292.20,308.87 295.72,303.18 299.25,297.15 302.77,290.78 306.29,284.07 309.81,277.03 313.34,269.66 316.86,261.97 320.38,253.94 323.90,245.59 327.42,236.92 ' style='stroke-width: 2.13; stroke: none; stroke-linecap: butt;' />
+<polyline points='327.42,377.70 323.90,379.31 320.38,380.86 316.86,382.36 313.34,383.80 309.81,385.19 306.29,386.53 302.77,387.82 299.25,389.06 295.72,390.25 292.20,391.39 288.68,392.49 285.16,393.54 281.63,394.55 278.11,395.52 274.59,396.45 271.07,397.32 267.54,398.15 264.02,398.93 260.50,399.65 256.98,400.31 253.45,400.88 249.93,401.38 246.41,401.77 242.89,402.06 239.36,402.22 235.84,402.25 232.32,402.13 228.80,401.85 225.27,401.40 221.75,400.77 218.23,399.95 214.71,398.94 211.18,397.73 207.66,396.32 204.14,394.70 200.62,392.87 197.09,390.84 193.57,388.60 190.05,386.16 186.53,383.48 183.00,380.24 179.48,376.38 175.96,371.97 172.44,367.09 168.92,361.81 165.39,356.20 161.87,350.35 158.35,344.31 154.83,338.15 151.30,331.90 147.78,325.59 144.26,319.26 140.74,312.91 137.21,306.56 133.69,300.20 130.17,293.85 126.65,287.52 123.12,281.22 119.60,275.01 116.08,268.94 112.56,263.09 109.03,257.38 105.51,252.07 101.99,247.48 98.47,243.47 94.94,239.41 91.42,234.60 87.90,229.46 84.38,224.75 80.85,220.36 77.33,214.36 73.81,205.10 70.29,194.65 66.76,183.90 63.24,172.30 59.72,161.21 56.20,152.10 52.67,145.72 49.15,141.86 ' style='stroke-width: 2.13; stroke: none; stroke-linecap: butt;' />
+<polyline points='49.15,111.16 52.67,123.61 56.20,135.74 59.72,147.44 63.24,158.57 66.76,169.11 70.29,178.70 73.81,188.34 77.33,196.90 80.85,202.93 84.38,207.17 87.90,210.64 91.42,214.31 94.94,218.94 98.47,223.58 101.99,228.09 105.51,232.58 109.03,237.19 112.56,242.06 116.08,247.26 119.60,252.78 123.12,258.55 126.65,264.54 130.17,270.71 133.69,277.02 137.21,283.41 140.74,289.85 144.26,296.31 147.78,302.72 151.30,309.06 154.83,315.27 158.35,321.33 161.87,327.18 165.39,332.78 168.92,338.09 172.44,343.07 175.96,347.67 179.48,351.86 183.00,355.59 186.53,358.81 190.05,361.57 193.57,364.08 197.09,366.39 200.62,368.48 204.14,370.35 207.66,372.02 211.18,373.47 214.71,374.71 218.23,375.75 221.75,376.57 225.27,377.18 228.80,377.59 232.32,377.79 235.84,377.78 239.36,377.57 242.89,377.15 246.41,376.53 249.93,375.70 253.45,374.67 256.98,373.44 260.50,372.01 264.02,370.37 267.54,368.54 271.07,366.50 274.59,364.27 278.11,361.83 281.63,359.20 285.16,356.37 288.68,353.35 292.20,350.13 295.72,346.71 299.25,343.10 302.77,339.30 306.29,335.30 309.81,331.11 313.34,326.73 316.86,322.16 320.38,317.40 323.90,312.45 327.42,307.31 ' style='stroke-width: 2.13; stroke: #00BFC4; stroke-linecap: butt;' />
+<rect x='35.24' y='39.43' width='306.10' height='505.68' style='stroke-width: 1.07; stroke: #333333;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMzQ2LjgyfDY1Mi45MnwzOS40M3w1NDUuMTE='>
+    <rect x='346.82' y='39.43' width='306.10' height='505.68' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMzQ2LjgyfDY1Mi45MnwzOS40M3w1NDUuMTE=)'>
+<rect x='346.82' y='39.43' width='306.10' height='505.68' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<polygon points='427.19,433.16 429.82,437.72 424.55,437.72 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='587.09' cy='131.35' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='518.56,142.13 521.19,146.69 515.93,146.69 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='420.96,249.49 423.59,254.05 418.32,254.05 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='523.75' cy='141.45' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='570.47,132.06 573.11,136.62 567.84,136.62 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='581.90' cy='119.41' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='572.55,111.13 575.18,115.69 569.92,115.69 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='477.02,157.72 479.66,162.28 474.39,162.28 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='441.72,380.57 444.35,385.13 439.09,385.13 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='589.16,122.28 591.80,126.84 586.53,126.84 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='522.71,166.99 525.34,171.55 520.08,171.55 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='556.98' cy='114.81' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='392.92,266.65 395.55,271.21 390.29,271.21 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='559.05,129.74 561.69,134.30 556.42,134.30 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='537.25' cy='121.24' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='484.29,185.36 486.93,189.92 481.66,189.92 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='447.95,377.55 450.58,382.11 445.32,382.11 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='526.86' cy='114.34' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='521.67,208.35 524.31,212.91 519.04,212.91 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='554.90' cy='130.11' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='534.13,194.01 536.77,198.57 531.50,198.57 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='462.49,357.67 465.12,362.23 459.86,362.23 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='572.55,128.36 575.18,132.92 569.92,132.92 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='582.93' cy='116.71' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='539.32,166.83 541.96,171.39 536.69,171.39 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='500.91,317.55 503.54,322.11 498.27,322.11 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='492.60,340.80 495.23,345.36 489.97,345.36 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='549.71' cy='130.51' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='420.96,260.31 423.59,264.87 418.32,264.87 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='514.40,172.84 517.04,177.40 511.77,177.40 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='504.02' cy='128.40' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='488.45,133.24 491.08,137.80 485.81,137.80 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='541.40' cy='115.46' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='489.48,132.39 492.12,136.95 486.85,136.95 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='509.21' cy='116.48' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='469.76,260.95 472.39,265.51 467.12,265.51 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='523.75,130.49 526.38,135.05 521.12,135.05 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='468.72,142.82 471.35,147.38 466.09,147.38 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='504.02' cy='116.29' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='495.71,212.37 498.35,216.93 493.08,216.93 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='524.79' cy='120.80' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='535.17' cy='120.88' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='525.83,138.01 528.46,142.57 523.19,142.57 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='565.28' cy='114.85' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='452.11,196.08 454.74,200.64 449.47,200.64 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='536.21' cy='113.33' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='541.40' cy='130.25' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='553.86,113.23 556.49,117.79 551.23,117.79 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='506.10,115.86 508.73,120.42 503.47,120.42 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='531.02,110.29 533.65,114.85 528.39,114.85 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='541.40,182.65 544.03,187.21 538.77,187.21 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='479.10,245.06 481.73,249.62 476.47,249.62 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='510.25,116.62 512.88,121.18 507.62,121.18 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='566.32,129.25 568.95,133.81 563.69,133.81 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='551.78,120.31 554.42,124.87 549.15,124.87 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='487.41,196.49 490.04,201.05 484.78,201.05 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='580.86' cy='115.52' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='520.63,111.99 523.27,116.55 518.00,116.55 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='510.25' cy='129.21' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='566.32' cy='115.96' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='442.76,217.24 445.39,221.80 440.13,221.80 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='481.18,420.88 483.81,425.44 478.55,425.44 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='520.63,142.48 523.27,147.04 518.00,147.04 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='531.02' cy='117.62' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='541.40,114.83 544.03,119.39 538.77,119.39 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='563.21,119.65 565.84,124.21 560.57,124.21 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='581.90' cy='122.10' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='516.48,338.13 519.11,342.69 513.85,342.69 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='639.00' cy='182.50' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='527.90' cy='117.48' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='524.79' cy='114.87' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='531.02' cy='116.98' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='571.51,235.27 574.15,239.83 568.88,239.83 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='419.92,398.15 422.55,402.71 417.28,402.71 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='477.02,344.88 479.66,349.44 474.39,349.44 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='511.29,193.00 513.92,197.56 508.66,197.56 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='470.79,223.29 473.43,227.85 468.16,227.85 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='597.47' cy='157.93' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='543.48,235.49 546.11,240.05 540.85,240.05 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='536.21,336.98 538.84,341.54 533.58,341.54 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='581.90,231.36 584.53,235.92 579.26,235.92 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='520.63' cy='122.40' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='547.63' cy='114.25' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='518.56,124.35 521.19,128.91 515.93,128.91 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='490.52,203.69 493.16,208.25 487.89,208.25 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='614.08,111.49 616.72,116.05 611.45,116.05 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='578.78' cy='115.13' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='536.21,128.25 538.84,132.81 533.58,132.81 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='595.39,138.91 598.03,143.47 592.76,143.47 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='517.52,165.12 520.15,169.68 514.89,169.68 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='482.22,149.84 484.85,154.40 479.58,154.40 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='538.29' cy='133.09' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='480.14,218.29 482.77,222.85 477.51,222.85 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='431.34,375.53 433.97,380.09 428.71,380.09 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='541.40' cy='116.21' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='495.71,158.38 498.35,162.94 493.08,162.94 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='548.67' cy='121.83' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='505.06' cy='121.72' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='468.72,162.83 471.35,167.39 466.09,167.39 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='531.02' cy='114.95' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='569.44' cy='120.17' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='538.29,130.14 540.92,134.70 535.65,134.70 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='535.17,115.76 537.80,120.32 532.54,120.32 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='593.32' cy='153.40' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='562.17,154.94 564.80,159.50 559.54,159.50 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='575.67' cy='124.11' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='520.63,113.13 523.27,117.69 518.00,117.69 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='532.06' cy='113.33' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='524.79,114.49 527.42,119.05 522.16,119.05 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='591.24' cy='138.55' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='538.29,133.02 540.92,137.58 535.65,137.58 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='545.55,191.48 548.19,196.04 542.92,196.04 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='603.70,172.28 606.33,176.84 601.07,176.84 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='592.28' cy='126.57' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='534.13' cy='226.01' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='480.14,251.50 482.77,256.06 477.51,256.06 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='499.87,198.38 502.50,202.94 497.24,202.94 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='554.90,111.05 557.53,115.61 552.27,115.61 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='570.47' cy='142.77' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='477.02,148.89 479.66,153.45 474.39,153.45 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='586.05' cy='117.62' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='492.60,177.79 495.23,182.35 489.97,182.35 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='562.17' cy='113.96' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='521.67' cy='117.73' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='481.18,140.28 483.81,144.84 478.55,144.84 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='580.86' cy='118.37' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='457.30,386.64 459.93,391.20 454.66,391.20 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='559.05' cy='134.50' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='513.37,307.90 516.00,312.46 510.73,312.46 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='551.78,189.43 554.42,193.99 549.15,193.99 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='554.90' cy='118.15' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='567.36,130.79 569.99,135.35 564.73,135.35 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='538.29' cy='113.33' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='527.90' cy='115.28' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='505.06' cy='116.24' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='531.02' cy='126.69' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='565.28,230.42 567.92,234.98 562.65,234.98 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='500.91' cy='127.50' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='581.90' cy='121.02' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='548.67' cy='114.19' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='518.56,113.07 521.19,117.63 515.93,117.63 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='531.02,152.47 533.65,157.03 528.39,157.03 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='495.71,357.91 498.35,362.47 493.08,362.47 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='555.94' cy='117.12' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='561.13' cy='131.72' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='507.14' cy='129.98' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='495.71,268.63 498.35,273.19 493.08,273.19 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='550.75,201.81 553.38,206.37 548.11,206.37 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='534.13' cy='116.23' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='471.83' cy='141.88' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='469.76,270.47 472.39,275.03 467.12,275.03 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='556.98' cy='115.04' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='423.03,308.53 425.66,313.09 420.40,313.09 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='505.06' cy='114.25' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='522.71,322.04 525.34,326.60 520.08,326.60 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='512.33' cy='115.22' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='507.14' cy='146.58' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='516.48,158.79 519.11,163.35 513.85,163.35 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='533.09' cy='115.95' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='526.86' cy='131.14' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='488.45,184.41 491.08,188.97 485.81,188.97 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='580.86,112.31 583.49,116.87 578.23,116.87 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='504.02,214.25 506.65,218.81 501.39,218.81 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='515.44,176.21 518.08,180.77 512.81,180.77 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='495.71' cy='208.68' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='558.01,119.32 560.65,123.88 555.38,123.88 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='551.78' cy='113.33' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='595.39,133.01 598.03,137.57 592.76,137.57 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='532.06' cy='118.10' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='626.54' cy='172.75' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='504.02' cy='117.33' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='512.33' cy='133.75' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='556.98' cy='114.22' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='551.78' cy='114.12' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='526.86,143.57 529.50,148.13 524.23,148.13 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='573.59' cy='122.31' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='580.86' cy='129.91' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='554.90' cy='122.77' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='612.01' cy='151.41' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='528.94' cy='114.02' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='540.36' cy='113.33' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='544.52' cy='115.95' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='525.83,264.40 528.46,268.96 523.19,268.96 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='524.79' cy='114.56' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='523.75,144.58 526.38,149.14 521.12,149.14 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='513.37,290.13 516.00,294.69 510.73,294.69 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='518.56' cy='126.75' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='534.13' cy='120.00' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='565.28' cy='171.45' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='505.06,269.85 507.69,274.41 502.43,274.41 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='540.36' cy='116.10' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='488.45,328.18 491.08,332.74 485.81,332.74 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='603.70' cy='188.09' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='562.17' cy='144.33' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='506.10' cy='119.26' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='569.44' cy='114.21' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='458.34' cy='144.08' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='513.37' cy='128.77' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='525.83' cy='140.38' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='489.48' cy='131.26' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='551.78' cy='121.92' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='576.70' cy='124.91' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='545.55,118.45 548.19,123.01 542.92,123.01 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='525.83,146.71 528.46,151.27 523.19,151.27 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='579.82' cy='117.98' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='502.98' cy='142.35' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='489.48,278.99 492.12,283.55 486.85,283.55 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='573.59' cy='116.49' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='507.14' cy='115.14' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='547.63' cy='116.92' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='570.47' cy='119.90' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='510.25' cy='115.15' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='513.37,123.73 516.00,128.29 510.73,128.29 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='556.98,155.38 559.61,159.94 554.34,159.94 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='539.32' cy='115.88' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='500.91,287.89 503.54,292.45 498.27,292.45 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='561.13' cy='119.18' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='590.20' cy='126.13' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='491.56,268.21 494.19,272.77 488.93,272.77 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='536.21' cy='113.33' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='508.17,158.04 510.81,162.60 505.54,162.60 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='409.53,440.79 412.17,445.35 406.90,445.35 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='537.25' cy='125.00' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='537.25' cy='119.61' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='541.40' cy='117.56' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='505.06,149.02 507.69,153.58 502.43,153.58 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='505.06' cy='115.54' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='473.91,226.57 476.54,231.13 471.28,231.13 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='511.29' cy='138.41' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='360.73,442.68 363.36,447.24 358.10,447.24 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='470.79' cy='139.71' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='474.95' cy='144.90' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='505.06' cy='115.21' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='589.16' cy='289.17' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='550.75' cy='121.39' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='463.53' cy='195.20' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='505.06' cy='136.39' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='462.49,144.58 465.12,149.14 459.86,149.14 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='543.48' cy='114.56' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='533.09' cy='150.09' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='465.60' cy='206.29' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='448.99,350.42 451.62,354.98 446.36,354.98 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='491.56,177.38 494.19,181.94 488.93,181.94 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='536.21' cy='114.19' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='548.67' cy='125.92' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='451.07' cy='252.01' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='521.67' cy='116.10' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='489.48' cy='140.34' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='506.10' cy='115.97' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='532.06' cy='114.92' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='505.06' cy='137.80' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='471.83' cy='392.52' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='546.59' cy='141.99' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='556.98' cy='117.41' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='545.55' cy='123.13' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='596.43' cy='129.04' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='514.40' cy='118.50' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='465.60' cy='234.94' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='529.98' cy='221.26' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='483.25' cy='207.52' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='474.95' cy='183.15' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='527.90' cy='122.35' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='481.18' cy='209.62' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='489.48' cy='196.05' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='501.94' cy='124.32' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='399.15,391.56 401.78,396.12 396.52,396.12 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='442.76,322.37 445.39,326.92 440.13,326.92 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='520.63' cy='196.52' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='545.55' cy='119.44' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='520.63' cy='117.54' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='461.45' cy='150.16' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='516.48' cy='150.36' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='475.99' cy='140.42' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='548.67' cy='130.66' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='556.98' cy='122.48' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='526.86' cy='117.34' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='541.40' cy='149.02' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='548.67' cy='114.09' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='540.36' cy='116.54' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='375.27,446.97 377.90,451.53 372.64,451.53 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='522.71' cy='128.22' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='571.51' cy='135.39' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='514.40' cy='119.50' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='518.56' cy='118.38' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='506.10' cy='122.31' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='516.48' cy='260.38' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='561.13' cy='289.55' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='571.51,179.96 574.15,184.52 568.88,184.52 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='527.90' cy='147.35' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='487.41' cy='157.83' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='544.52' cy='288.75' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='466.64' cy='364.74' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='475.99' cy='317.61' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='554.90' cy='144.78' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='500.91' cy='128.45' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='513.37' cy='119.02' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='507.14' cy='121.83' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='547.63' cy='154.43' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='388.77,347.89 391.40,352.45 386.13,352.45 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='527.90' cy='114.91' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='567.36' cy='126.16' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='494.68' cy='141.63' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='565.28' cy='123.95' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='532.06' cy='154.99' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='515.44' cy='115.41' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='526.86' cy='115.69' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='528.94' cy='114.20' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='442.76' cy='168.02' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='505.06' cy='144.41' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='485.33' cy='146.16' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='550.75' cy='173.17' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='442.76,201.21 445.24,200.01 447.73,198.62 450.21,197.03 452.70,195.25 455.18,193.27 457.66,191.09 460.15,188.71 462.63,186.12 465.12,183.33 467.60,180.33 470.09,177.12 472.57,173.71 475.05,170.13 477.54,166.39 480.02,162.53 482.51,158.57 484.99,154.56 487.47,150.52 489.96,146.49 492.44,142.48 494.93,138.52 497.41,134.63 499.89,130.89 502.38,127.38 504.86,124.15 507.35,121.35 509.83,119.14 512.32,118.09 514.80,117.97 517.28,118.26 519.77,118.57 522.25,118.70 524.74,118.64 527.22,118.70 529.70,118.88 532.19,118.98 534.67,119.15 537.16,119.33 539.64,119.17 542.12,118.74 544.61,118.56 547.09,118.83 549.58,119.12 552.06,119.21 554.55,119.15 557.03,119.19 559.51,119.35 562.00,119.59 564.48,119.88 566.97,120.23 569.45,120.64 571.93,121.18 574.42,121.90 576.90,122.81 579.39,123.76 581.87,124.73 584.35,125.73 586.84,126.75 589.32,127.80 591.81,128.86 594.29,129.91 596.77,130.93 599.26,131.91 601.74,132.82 604.23,133.65 606.71,134.39 609.20,135.04 611.68,135.59 614.16,136.04 616.65,136.40 619.13,136.66 621.62,136.84 624.10,136.94 626.58,136.95 629.07,136.90 631.55,136.77 634.04,136.59 636.52,136.34 639.00,136.04 639.00,244.63 636.52,237.56 634.04,230.75 631.55,224.19 629.07,217.90 626.58,211.87 624.10,206.11 621.62,200.62 619.13,195.40 616.65,190.46 614.16,185.80 611.68,181.42 609.20,177.32 606.71,173.50 604.23,169.95 601.74,166.68 599.26,163.65 596.77,160.86 594.29,158.30 591.81,155.93 589.32,153.74 586.84,151.71 584.35,149.82 581.87,148.07 579.39,146.44 576.90,144.96 574.42,143.64 571.93,142.53 569.45,141.65 566.97,140.98 564.48,140.52 562.00,140.24 559.51,140.07 557.03,139.94 554.55,139.71 552.06,139.36 549.58,139.11 547.09,139.04 544.61,138.93 542.12,138.53 539.64,138.15 537.16,138.15 534.67,138.43 532.19,138.51 529.70,138.42 527.22,138.46 524.74,138.55 522.25,138.19 519.77,137.52 517.28,137.08 514.80,137.23 512.32,138.15 509.83,139.87 507.35,142.36 504.86,145.41 502.38,148.95 499.89,152.84 497.41,156.92 494.93,161.02 492.44,165.14 489.96,169.31 487.47,173.56 484.99,177.89 482.51,182.34 480.02,186.93 477.54,191.70 475.05,196.68 472.57,201.88 470.09,207.35 467.60,213.07 465.12,219.07 462.63,225.34 460.15,231.89 457.66,238.69 455.18,245.75 452.70,253.06 450.21,260.62 447.73,268.41 445.24,276.44 442.76,284.70 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #999999; fill-opacity: 0.40;' />
+<polyline points='442.76,201.21 445.24,200.01 447.73,198.62 450.21,197.03 452.70,195.25 455.18,193.27 457.66,191.09 460.15,188.71 462.63,186.12 465.12,183.33 467.60,180.33 470.09,177.12 472.57,173.71 475.05,170.13 477.54,166.39 480.02,162.53 482.51,158.57 484.99,154.56 487.47,150.52 489.96,146.49 492.44,142.48 494.93,138.52 497.41,134.63 499.89,130.89 502.38,127.38 504.86,124.15 507.35,121.35 509.83,119.14 512.32,118.09 514.80,117.97 517.28,118.26 519.77,118.57 522.25,118.70 524.74,118.64 527.22,118.70 529.70,118.88 532.19,118.98 534.67,119.15 537.16,119.33 539.64,119.17 542.12,118.74 544.61,118.56 547.09,118.83 549.58,119.12 552.06,119.21 554.55,119.15 557.03,119.19 559.51,119.35 562.00,119.59 564.48,119.88 566.97,120.23 569.45,120.64 571.93,121.18 574.42,121.90 576.90,122.81 579.39,123.76 581.87,124.73 584.35,125.73 586.84,126.75 589.32,127.80 591.81,128.86 594.29,129.91 596.77,130.93 599.26,131.91 601.74,132.82 604.23,133.65 606.71,134.39 609.20,135.04 611.68,135.59 614.16,136.04 616.65,136.40 619.13,136.66 621.62,136.84 624.10,136.94 626.58,136.95 629.07,136.90 631.55,136.77 634.04,136.59 636.52,136.34 639.00,136.04 ' style='stroke-width: 2.13; stroke: none; stroke-linecap: butt;' />
+<polyline points='639.00,244.63 636.52,237.56 634.04,230.75 631.55,224.19 629.07,217.90 626.58,211.87 624.10,206.11 621.62,200.62 619.13,195.40 616.65,190.46 614.16,185.80 611.68,181.42 609.20,177.32 606.71,173.50 604.23,169.95 601.74,166.68 599.26,163.65 596.77,160.86 594.29,158.30 591.81,155.93 589.32,153.74 586.84,151.71 584.35,149.82 581.87,148.07 579.39,146.44 576.90,144.96 574.42,143.64 571.93,142.53 569.45,141.65 566.97,140.98 564.48,140.52 562.00,140.24 559.51,140.07 557.03,139.94 554.55,139.71 552.06,139.36 549.58,139.11 547.09,139.04 544.61,138.93 542.12,138.53 539.64,138.15 537.16,138.15 534.67,138.43 532.19,138.51 529.70,138.42 527.22,138.46 524.74,138.55 522.25,138.19 519.77,137.52 517.28,137.08 514.80,137.23 512.32,138.15 509.83,139.87 507.35,142.36 504.86,145.41 502.38,148.95 499.89,152.84 497.41,156.92 494.93,161.02 492.44,165.14 489.96,169.31 487.47,173.56 484.99,177.89 482.51,182.34 480.02,186.93 477.54,191.70 475.05,196.68 472.57,201.88 470.09,207.35 467.60,213.07 465.12,219.07 462.63,225.34 460.15,231.89 457.66,238.69 455.18,245.75 452.70,253.06 450.21,260.62 447.73,268.41 445.24,276.44 442.76,284.70 ' style='stroke-width: 2.13; stroke: none; stroke-linecap: butt;' />
+<polyline points='442.76,242.96 445.24,238.23 447.73,233.52 450.21,228.82 452.70,224.16 455.18,219.51 457.66,214.89 460.15,210.30 462.63,205.73 465.12,201.20 467.60,196.70 470.09,192.23 472.57,187.80 475.05,183.40 477.54,179.05 480.02,174.73 482.51,170.46 484.99,166.22 487.47,162.04 489.96,157.90 492.44,153.81 494.93,149.77 497.41,145.77 499.89,141.87 502.38,138.16 504.86,134.78 507.35,131.85 509.83,129.50 512.32,128.12 514.80,127.60 517.28,127.67 519.77,128.05 522.25,128.45 524.74,128.60 527.22,128.58 529.70,128.65 532.19,128.75 534.67,128.79 537.16,128.74 539.64,128.66 542.12,128.64 544.61,128.75 547.09,128.94 549.58,129.12 552.06,129.28 554.55,129.43 557.03,129.56 559.51,129.71 562.00,129.92 564.48,130.20 566.97,130.60 569.45,131.14 571.93,131.86 574.42,132.77 576.90,133.88 579.39,135.10 581.87,136.40 584.35,137.77 586.84,139.23 589.32,140.77 591.81,142.40 594.29,144.11 596.77,145.90 599.26,147.78 601.74,149.75 604.23,151.80 606.71,153.94 609.20,156.18 611.68,158.50 614.16,160.92 616.65,163.43 619.13,166.03 621.62,168.73 624.10,171.52 626.58,174.41 629.07,177.40 631.55,180.48 634.04,183.67 636.52,186.95 639.00,190.34 ' style='stroke-width: 2.13; stroke: #F8766D; stroke-linecap: butt;' />
+<polygon points='360.73,343.69 363.94,345.15 367.15,346.26 370.35,346.99 373.56,347.35 376.77,347.34 379.97,346.96 383.18,346.19 386.39,345.04 389.59,343.50 392.80,341.58 396.01,339.27 399.22,336.59 402.42,333.54 405.63,330.15 408.84,326.43 412.04,322.42 415.25,318.15 418.46,313.66 421.66,308.99 424.87,304.17 428.08,299.25 431.29,294.24 434.49,289.18 437.70,284.08 440.91,278.96 444.11,273.82 447.32,268.66 450.53,263.50 453.73,258.37 456.94,253.22 460.15,248.03 463.36,242.74 466.56,237.36 469.77,231.89 472.98,226.40 476.18,221.00 479.39,215.80 482.60,211.49 485.80,207.86 489.01,204.19 492.22,200.22 495.43,196.35 498.63,192.74 501.84,188.83 505.05,184.38 508.25,179.61 511.46,175.09 514.67,170.23 517.87,164.36 521.08,158.39 524.29,154.00 527.50,150.02 530.70,145.85 533.91,141.62 537.12,138.01 540.32,135.68 543.53,134.13 546.74,133.01 549.94,132.05 553.15,131.11 556.36,130.09 559.57,129.00 562.77,127.84 565.98,126.60 569.19,125.27 572.39,123.77 575.60,122.00 578.81,119.85 582.01,117.25 585.22,114.14 588.43,110.48 591.64,106.26 594.84,101.49 598.05,96.20 601.26,90.39 604.46,84.09 607.67,77.32 610.88,70.09 614.08,62.42 614.08,229.48 610.88,221.32 607.67,213.77 604.46,206.85 601.26,200.58 598.05,194.96 594.84,190.02 591.64,185.77 588.43,182.23 585.22,179.39 582.01,177.26 578.81,175.79 575.60,174.93 572.39,174.58 569.19,174.64 565.98,175.02 562.77,175.61 559.57,176.02 556.36,176.19 553.15,176.37 549.94,176.80 546.74,177.65 543.53,179.02 540.32,180.88 537.12,183.18 533.91,185.83 530.70,189.13 527.50,193.22 524.29,197.68 521.08,201.95 517.87,207.03 514.67,212.95 511.46,218.37 508.25,222.33 505.05,225.90 501.84,229.68 498.63,233.98 495.43,238.60 492.22,243.03 489.01,246.98 485.80,251.05 482.60,255.70 479.39,260.94 476.18,266.48 472.98,272.14 469.77,277.97 466.56,283.99 463.36,290.19 460.15,296.52 456.94,302.90 453.73,309.20 450.53,315.31 447.32,321.12 444.11,326.81 440.91,332.49 437.70,338.16 434.49,343.81 431.29,349.46 428.08,355.12 424.87,360.82 421.66,366.59 418.46,372.45 415.25,378.45 412.04,384.62 408.84,391.00 405.63,397.62 402.42,404.50 399.22,411.68 396.01,419.16 392.80,426.96 389.59,435.07 386.39,443.51 383.18,452.27 379.97,461.35 376.77,470.73 373.56,480.42 370.35,490.41 367.15,500.69 363.94,511.27 360.73,522.13 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #999999; fill-opacity: 0.40;' />
+<polyline points='360.73,343.69 363.94,345.15 367.15,346.26 370.35,346.99 373.56,347.35 376.77,347.34 379.97,346.96 383.18,346.19 386.39,345.04 389.59,343.50 392.80,341.58 396.01,339.27 399.22,336.59 402.42,333.54 405.63,330.15 408.84,326.43 412.04,322.42 415.25,318.15 418.46,313.66 421.66,308.99 424.87,304.17 428.08,299.25 431.29,294.24 434.49,289.18 437.70,284.08 440.91,278.96 444.11,273.82 447.32,268.66 450.53,263.50 453.73,258.37 456.94,253.22 460.15,248.03 463.36,242.74 466.56,237.36 469.77,231.89 472.98,226.40 476.18,221.00 479.39,215.80 482.60,211.49 485.80,207.86 489.01,204.19 492.22,200.22 495.43,196.35 498.63,192.74 501.84,188.83 505.05,184.38 508.25,179.61 511.46,175.09 514.67,170.23 517.87,164.36 521.08,158.39 524.29,154.00 527.50,150.02 530.70,145.85 533.91,141.62 537.12,138.01 540.32,135.68 543.53,134.13 546.74,133.01 549.94,132.05 553.15,131.11 556.36,130.09 559.57,129.00 562.77,127.84 565.98,126.60 569.19,125.27 572.39,123.77 575.60,122.00 578.81,119.85 582.01,117.25 585.22,114.14 588.43,110.48 591.64,106.26 594.84,101.49 598.05,96.20 601.26,90.39 604.46,84.09 607.67,77.32 610.88,70.09 614.08,62.42 ' style='stroke-width: 2.13; stroke: none; stroke-linecap: butt;' />
+<polyline points='614.08,229.48 610.88,221.32 607.67,213.77 604.46,206.85 601.26,200.58 598.05,194.96 594.84,190.02 591.64,185.77 588.43,182.23 585.22,179.39 582.01,177.26 578.81,175.79 575.60,174.93 572.39,174.58 569.19,174.64 565.98,175.02 562.77,175.61 559.57,176.02 556.36,176.19 553.15,176.37 549.94,176.80 546.74,177.65 543.53,179.02 540.32,180.88 537.12,183.18 533.91,185.83 530.70,189.13 527.50,193.22 524.29,197.68 521.08,201.95 517.87,207.03 514.67,212.95 511.46,218.37 508.25,222.33 505.05,225.90 501.84,229.68 498.63,233.98 495.43,238.60 492.22,243.03 489.01,246.98 485.80,251.05 482.60,255.70 479.39,260.94 476.18,266.48 472.98,272.14 469.77,277.97 466.56,283.99 463.36,290.19 460.15,296.52 456.94,302.90 453.73,309.20 450.53,315.31 447.32,321.12 444.11,326.81 440.91,332.49 437.70,338.16 434.49,343.81 431.29,349.46 428.08,355.12 424.87,360.82 421.66,366.59 418.46,372.45 415.25,378.45 412.04,384.62 408.84,391.00 405.63,397.62 402.42,404.50 399.22,411.68 396.01,419.16 392.80,426.96 389.59,435.07 386.39,443.51 383.18,452.27 379.97,461.35 376.77,470.73 373.56,480.42 370.35,490.41 367.15,500.69 363.94,511.27 360.73,522.13 ' style='stroke-width: 2.13; stroke: none; stroke-linecap: butt;' />
+<polyline points='360.73,432.91 363.94,428.21 367.15,423.47 370.35,418.70 373.56,413.89 376.77,409.04 379.97,404.15 383.18,399.23 386.39,394.28 389.59,389.29 392.80,384.27 396.01,379.22 399.22,374.14 402.42,369.02 405.63,363.88 408.84,358.72 412.04,353.52 415.25,348.30 418.46,343.06 421.66,337.79 424.87,332.50 428.08,327.18 431.29,321.85 434.49,316.49 437.70,311.12 440.91,305.73 444.11,300.32 447.32,294.89 450.53,289.40 453.73,283.78 456.94,278.06 460.15,272.28 463.36,266.47 466.56,260.67 469.77,254.93 472.98,249.27 476.18,243.74 479.39,238.37 482.60,233.60 485.80,229.46 489.01,225.58 492.22,221.63 495.43,217.47 498.63,213.36 501.84,209.26 505.05,205.14 508.25,200.97 511.46,196.73 514.67,191.59 517.87,185.69 521.08,180.17 524.29,175.84 527.50,171.62 530.70,167.49 533.91,163.72 537.12,160.59 540.32,158.28 543.53,156.57 546.74,155.33 549.94,154.43 553.15,153.74 556.36,153.14 559.57,152.51 562.77,151.72 565.98,150.81 569.19,149.96 572.39,149.17 575.60,148.46 578.81,147.82 582.01,147.26 585.22,146.77 588.43,146.35 591.64,146.01 594.84,145.76 598.05,145.58 601.26,145.48 604.46,145.47 607.67,145.54 610.88,145.70 614.08,145.95 ' style='stroke-width: 2.13; stroke: #00BFC4; stroke-linecap: butt;' />
+<rect x='346.82' y='39.43' width='306.10' height='505.68' style='stroke-width: 1.07; stroke: #333333;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMzUuMjR8MzQxLjM0fDIyLjc4fDM5LjQz'>
+    <rect x='35.24' y='22.78' width='306.10' height='16.65' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMzUuMjR8MzQxLjM0fDIyLjc4fDM5LjQz)'>
+<rect x='35.24' y='22.78' width='306.10' height='16.65' style='stroke-width: 1.07; stroke: #333333; fill: #D9D9D9;' />
+<text x='188.29' y='34.14' text-anchor='middle' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='10.76px' lengthAdjust='spacingAndGlyphs'>bili</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMzQ2LjgyfDY1Mi45MnwyMi43OHwzOS40Mw=='>
+    <rect x='346.82' y='22.78' width='306.10' height='16.65' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMzQ2LjgyfDY1Mi45MnwyMi43OHwzOS40Mw==)'>
+<rect x='346.82' y='22.78' width='306.10' height='16.65' style='stroke-width: 1.07; stroke: #333333; fill: #D9D9D9;' />
+<text x='499.87' y='34.14' text-anchor='middle' style='font-size: 8.80px; fill: #1A1A1A; font-family: sans;' textLength='30.82px' lengthAdjust='spacingAndGlyphs'>albumin</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<polyline points='46.14,547.85 46.14,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='146.60,547.85 146.60,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='247.06,547.85 247.06,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='46.14' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='146.60' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>10</text>
+<text x='247.06' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>20</text>
+<polyline points='364.89,547.85 364.89,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='468.72,547.85 468.72,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='572.55,547.85 572.55,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='364.89' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='468.72' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>3</text>
+<text x='572.55' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text x='30.31' y='513.82' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<text x='30.31' y='434.33' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.6</text>
+<text x='30.31' y='354.84' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.7</text>
+<text x='30.31' y='275.34' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.8</text>
+<text x='30.31' y='195.85' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.9</text>
+<text x='30.31' y='116.36' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<polyline points='32.50,510.79 35.24,510.79 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='32.50,431.30 35.24,431.30 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='32.50,351.81 35.24,351.81 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='32.50,272.32 35.24,272.32 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='32.50,192.82 35.24,192.82 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='32.50,113.33 35.24,113.33 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text transform='translate(13.05,292.27) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='84.99px' lengthAdjust='spacingAndGlyphs'>Survival at 1 year</text>
+<rect x='663.88' y='267.33' width='50.64' height='49.89' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<text x='663.88' y='276.04' style='font-size: 11.00px; font-family: sans;' textLength='26.91px' lengthAdjust='spacingAndGlyphs'>event</text>
+<rect x='663.88' y='282.66' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<circle cx='672.52' cy='291.30' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<rect x='663.88' y='282.66' width='17.28' height='17.28' style='stroke-width: 0.75; stroke: none; fill: #999999; fill-opacity: 0.40;' />
+<line x1='665.61' y1='291.30' x2='679.43' y2='291.30' style='stroke-width: 2.13; stroke: #F8766D; stroke-linecap: butt;' />
+<rect x='663.88' y='299.94' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<polygon points='672.52,305.54 675.15,310.10 669.88,310.10 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<rect x='663.88' y='299.94' width='17.28' height='17.28' style='stroke-width: 0.75; stroke: none; fill: #999999; fill-opacity: 0.40;' />
+<line x1='665.61' y1='308.58' x2='679.43' y2='308.58' style='stroke-width: 2.13; stroke: #00BFC4; stroke-linecap: butt;' />
+<text x='686.64' y='294.33' style='font-size: 8.80px; font-family: sans;' textLength='27.88px' lengthAdjust='spacingAndGlyphs'>FALSE</text>
+<text x='686.64' y='311.61' style='font-size: 8.80px; font-family: sans;' textLength='23.96px' lengthAdjust='spacingAndGlyphs'>TRUE</text>
+<text x='35.24' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='219.41px' lengthAdjust='spacingAndGlyphs'>gg_variable survival panel single time</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/snapshots/gg-variable-survival-single-time.svg
+++ b/tests/testthat/_snaps/snapshots/gg-variable-survival-single-time.svg
@@ -1,0 +1,377 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpMzUuMjR8NjUyLjkyfDIyLjc4fDU0NS4xMQ=='>
+    <rect x='35.24' y='22.78' width='617.68' height='522.33' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMzUuMjR8NjUyLjkyfDIyLjc4fDU0NS4xMQ==)'>
+<rect x='35.24' y='22.78' width='617.68' height='522.33' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<polygon points='351.17,499.10 353.81,503.66 348.54,503.66 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='79.53' cy='77.57' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='85.61,93.78 88.25,98.34 82.98,98.34 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='93.72,243.30 96.35,247.86 91.09,247.86 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='126.16' cy='91.64' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='73.45,79.75 76.08,84.31 70.82,84.31 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='77.50' cy='60.94' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='63.31,50.60 65.95,55.16 60.68,55.16 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='122.10,115.49 124.74,120.05 119.47,120.05 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='312.66,425.85 315.29,430.41 310.02,430.41 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='85.61,66.13 88.25,70.69 82.98,70.69 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='130.21,128.40 132.84,132.96 127.58,132.96 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='71.42' cy='54.54' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='73.45,267.19 76.08,271.75 70.82,271.75 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='73.45,76.53 76.08,81.09 70.82,81.09 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='71.42' cy='63.49' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='111.97,153.98 114.60,158.54 109.33,158.54 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='288.33,421.65 290.96,426.21 285.70,426.21 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='71.42' cy='53.88' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='160.62,186.00 163.25,190.56 157.99,190.56 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='69.40' cy='75.85' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='126.16,166.03 128.79,170.59 123.52,170.59 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='409.96,393.96 412.59,398.52 407.33,398.52 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='99.80,74.60 102.44,79.16 97.17,79.16 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='71.42' cy='57.18' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='162.65,128.17 165.28,132.73 160.01,132.73 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='495.10,338.09 497.74,342.65 492.47,342.65 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='405.91,370.46 408.54,375.02 403.27,375.02 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='71.42' cy='76.40' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='130.21,258.36 132.84,262.92 127.58,262.92 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='152.51,136.55 155.14,141.11 149.88,141.11 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='93.72' cy='73.46' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='73.45,81.40 76.08,85.96 70.82,85.96 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='73.45' cy='55.43' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='81.56,80.21 84.19,84.77 78.93,84.77 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='63.31' cy='56.86' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='201.16,259.26 203.80,263.82 198.53,263.82 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='124.13,77.57 126.76,82.13 121.50,82.13 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='71.42,94.74 74.06,99.30 68.79,99.30 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='83.59' cy='56.60' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='195.08,191.60 197.71,196.16 192.45,196.16 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='99.80' cy='62.87' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='79.53' cy='62.99' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='124.13,88.03 126.76,92.59 121.50,92.59 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='69.40' cy='54.59' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='172.78,168.91 175.41,173.47 170.15,173.47 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='67.37' cy='52.48' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='95.75' cy='76.04' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='73.45,53.53 76.08,58.09 70.82,58.09 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='79.53,57.20 82.16,61.76 76.90,61.76 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='73.45,49.44 76.08,54.00 70.82,54.00 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='178.86,150.21 181.50,154.77 176.23,154.77 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='109.94,237.14 112.57,241.69 107.31,241.69 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='83.59,58.25 86.22,62.81 80.95,62.81 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='93.72,75.84 96.35,80.40 91.09,80.40 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='79.53,63.38 82.16,67.94 76.90,67.94 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='103.86,169.49 106.49,174.05 101.23,174.05 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='71.42' cy='55.52' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='73.45,51.80 76.08,56.36 70.82,56.36 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='75.48' cy='74.59' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='69.40' cy='56.13' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='83.59,198.39 86.22,202.95 80.95,202.95 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='513.35,481.99 515.98,486.55 510.71,486.55 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='99.80,94.27 102.44,98.83 97.17,98.83 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='81.56' cy='58.45' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='85.61,55.76 88.25,60.32 82.98,60.32 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='79.53,62.47 82.16,67.03 76.90,67.03 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='71.42' cy='64.68' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='462.67,366.74 465.30,371.30 460.04,371.30 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='69.40' cy='148.80' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='81.56' cy='58.26' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='67.37' cy='54.61' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='71.42' cy='57.56' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='227.52,223.49 230.15,228.05 224.88,228.05 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='403.88,450.34 406.51,454.90 401.25,454.90 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='304.55,376.15 307.18,380.71 301.92,380.71 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='191.03,164.63 193.66,169.19 188.39,169.19 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='184.95,206.82 187.58,211.38 182.31,211.38 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='73.45' cy='114.59' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='203.19,223.80 205.82,228.36 200.56,228.36 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='349.15,365.14 351.78,369.70 346.51,369.70 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='148.46,218.04 151.09,222.60 145.82,222.60 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='83.59' cy='65.11' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='65.34' cy='53.76' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='99.80,69.02 102.44,73.58 97.17,73.58 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='158.59,179.51 161.22,184.07 155.96,184.07 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='79.53,51.10 82.16,55.66 76.90,55.66 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='69.40' cy='54.98' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='97.78,74.45 100.41,79.01 95.14,79.01 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='89.67,89.29 92.30,93.85 87.04,93.85 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='158.59,125.79 161.22,130.35 155.96,130.35 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='85.61,104.51 88.25,109.07 82.98,109.07 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='83.59' cy='79.99' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='122.10,199.84 124.74,204.40 119.47,204.40 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='409.96,418.83 412.59,423.39 407.33,423.39 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='77.50' cy='56.49' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='97.78,116.40 100.41,120.96 95.14,120.96 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='77.50' cy='64.32' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='93.72' cy='64.16' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='103.86,122.61 106.49,127.17 101.23,127.17 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='75.48' cy='54.73' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='75.48' cy='62.00' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='107.91,77.07 110.55,81.63 105.28,81.63 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='79.53,57.05 82.16,61.60 76.90,61.60 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='79.53' cy='108.27' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='99.80,111.62 102.44,116.18 97.17,116.18 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='69.40' cy='67.49' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='65.34,53.39 67.97,57.95 62.71,57.95 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='67.37' cy='52.48' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='95.75,55.28 98.38,59.84 93.12,59.84 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='168.73' cy='87.59' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='97.78,81.09 100.41,85.65 95.14,85.65 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='193.05,162.51 195.69,167.07 190.42,167.07 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='122.10,135.76 124.74,140.32 119.47,140.32 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='71.42' cy='70.92' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='118.05' cy='209.40' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='189.00,246.10 191.63,250.66 186.37,250.66 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='128.18,172.11 130.82,176.67 125.55,176.67 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='69.40,50.49 72.03,55.05 66.76,55.05 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='128.18' cy='93.48' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='83.59,103.20 86.22,107.76 80.95,107.76 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='69.40' cy='58.45' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='160.62,143.44 163.25,148.00 157.99,148.00 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='69.40' cy='53.34' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='83.59' cy='58.60' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='81.56,91.20 84.19,95.76 78.93,95.76 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='67.37' cy='59.49' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='385.64,434.30 388.27,438.86 383.00,438.86 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='75.48' cy='81.96' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='409.96,324.64 412.59,329.20 407.33,329.20 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='113.99,159.65 116.63,164.21 111.36,164.21 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='95.75' cy='59.19' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='87.64,77.98 90.27,82.54 85.01,82.54 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='71.42' cy='52.48' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='65.34' cy='55.19' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='73.45' cy='56.53' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='79.53' cy='71.09' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='205.22,216.74 207.85,221.30 202.58,221.30 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='79.53' cy='72.21' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='79.53' cy='63.18' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='75.48' cy='53.67' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='77.50,53.31 80.14,57.87 74.87,57.87 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='116.02,108.17 118.65,112.73 113.39,112.73 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='624.84,394.29 627.47,398.85 622.21,398.85 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='71.42' cy='57.76' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='81.56' cy='78.08' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='81.56' cy='75.66' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='203.19,269.96 205.82,274.52 200.56,274.52 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='118.05,176.89 120.68,181.45 115.42,181.45 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='77.50' cy='56.51' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='75.48' cy='92.23' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='103.86,272.52 106.49,277.08 101.23,277.08 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='67.37' cy='54.85' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='105.89,325.52 108.52,330.08 103.25,330.08 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='69.40' cy='53.75' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='574.16,344.34 576.80,348.90 571.53,348.90 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='69.40' cy='55.11' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='126.16' cy='98.79' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='107.91,116.98 110.55,121.54 105.28,121.54 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='69.40' cy='56.12' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='103.86' cy='77.28' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='122.10,152.67 124.74,157.23 119.47,157.23 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='63.31,52.25 65.95,56.81 60.68,56.81 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='229.54,194.22 232.18,198.78 226.91,198.78 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='138.32,141.24 140.95,145.80 135.69,145.80 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='172.78' cy='185.27' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='75.48,62.01 78.11,66.57 72.85,66.57 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='65.34' cy='52.48' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='83.59,81.08 86.22,85.64 80.95,85.64 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='81.56' cy='59.12' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='67.37' cy='135.22' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='83.59' cy='58.04' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='118.05' cy='80.91' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='67.37' cy='53.71' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='73.45' cy='53.57' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='122.10,95.78 124.74,100.34 119.47,100.34 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='75.48' cy='64.97' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='69.40' cy='75.57' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='93.72' cy='65.62' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='152.51' cy='105.50' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='85.61' cy='53.44' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='69.40' cy='52.48' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='67.37' cy='56.13' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='280.22,264.07 282.86,268.63 277.59,268.63 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='73.45' cy='54.19' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='97.78,97.19 100.41,101.75 95.14,101.75 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='341.04,299.90 343.67,304.46 338.40,304.46 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='71.42' cy='71.17' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='83.59' cy='61.76' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='103.86' cy='133.41' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='553.89,271.65 556.52,276.21 551.26,276.21 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='75.48' cy='56.33' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='276.17,352.88 278.80,357.44 273.54,357.44 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='87.64' cy='156.60' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='132.24' cy='95.65' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='85.61' cy='60.74' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='69.40' cy='53.70' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='71.42' cy='95.30' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='99.80' cy='73.98' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='152.51' cy='90.15' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='69.40' cy='77.45' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='67.37' cy='64.44' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='67.37' cy='68.60' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='71.42,60.79 74.06,65.35 68.79,65.35 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='107.91,100.16 110.55,104.72 105.28,104.72 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='69.40' cy='58.95' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='69.40' cy='92.90' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='136.29,284.38 138.93,288.94 133.66,288.94 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='71.42' cy='56.88' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='75.48' cy='55.00' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='83.59' cy='57.47' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='81.56' cy='61.62' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='67.37' cy='55.00' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='75.48,68.15 78.11,72.71 72.85,72.71 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='176.84,112.23 179.47,116.79 174.20,116.79 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='67.37' cy='56.02' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='288.33,296.78 290.96,301.33 285.70,301.33 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='67.37' cy='60.61' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='89.67' cy='70.30' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='134.27,269.36 136.90,273.92 131.63,273.92 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='75.48' cy='52.48' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='148.46,115.93 151.09,120.49 145.82,120.49 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='343.06,509.73 345.70,514.29 340.43,514.29 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='77.50' cy='68.73' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='71.42' cy='61.22' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='67.37' cy='58.37' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='103.86,103.38 106.49,107.94 101.23,107.94 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='71.42' cy='55.55' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='148.46,211.38 151.09,215.94 145.82,215.94 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='124.13' cy='87.41' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='126.16,512.36 128.79,516.92 123.52,516.92 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='65.34' cy='89.21' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='75.48' cy='96.44' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='75.48' cy='55.09' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='320.77' cy='297.36' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='87.64' cy='63.70' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='89.67' cy='166.49' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='69.40' cy='84.60' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='73.45,97.18 76.08,101.74 70.82,101.74 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='65.34' cy='54.19' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='146.43' cy='103.66' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='95.75' cy='181.93' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='219.41,383.87 222.04,388.43 216.77,388.43 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='136.29,142.88 138.93,147.44 133.66,147.44 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='69.40' cy='53.67' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='99.80' cy='70.01' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='180.89' cy='245.62' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='73.45' cy='56.33' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='83.59' cy='90.10' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='69.40' cy='56.15' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='67.37' cy='54.69' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='79.53' cy='86.56' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='201.16' cy='441.30' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='120.08' cy='92.39' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='71.42' cy='58.16' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='79.53' cy='66.12' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='67.37' cy='74.35' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='79.53' cy='59.67' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='120.08' cy='221.84' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='170.75' cy='202.79' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='122.10' cy='183.66' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='113.99' cy='149.71' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='79.53' cy='65.04' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='126.16' cy='186.57' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='128.18' cy='167.67' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='67.37' cy='67.78' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='191.03,441.16 193.66,445.72 188.39,445.72 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<polygon points='186.97,344.79 189.60,349.35 184.34,349.35 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='130.21' cy='168.33' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='77.50' cy='60.98' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='77.50' cy='58.34' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='67.37' cy='103.77' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='101.83' cy='104.05' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='89.67' cy='90.21' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='101.83' cy='76.61' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='77.50' cy='65.22' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='77.50' cy='58.05' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='170.75' cy='102.19' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='67.37' cy='53.53' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='89.67' cy='56.95' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='420.10,518.33 422.73,522.89 417.46,522.89 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='83.59' cy='73.21' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='79.53' cy='83.20' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='83.59' cy='61.07' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='73.45' cy='59.51' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='97.78' cy='64.97' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='186.97' cy='257.27' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='233.60' cy='297.89' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='138.32,146.47 140.95,151.03 135.69,151.03 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='85.61' cy='99.85' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='122.10' cy='114.46' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='231.57' cy='296.78' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='229.54' cy='402.61' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='191.03' cy='336.98' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='105.89' cy='96.27' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='73.45' cy='73.53' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='81.56' cy='60.40' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='79.53' cy='64.31' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='105.89' cy='109.72' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='162.65,380.34 165.28,384.90 160.01,384.90 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<circle cx='77.50' cy='54.67' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='71.42' cy='70.34' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='77.50' cy='91.89' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='67.37' cy='67.26' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='116.02' cy='110.49' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='69.40' cy='55.37' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='73.45' cy='55.75' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='65.34' cy='53.68' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='65.34' cy='128.64' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='91.70' cy='95.76' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='97.78' cy='98.19' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<circle cx='186.97' cy='135.81' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<polygon points='63.31,46.53 70.42,56.78 77.53,61.45 84.64,67.35 91.75,80.01 98.85,93.76 105.96,108.44 113.07,124.40 120.18,137.29 127.29,145.88 134.39,152.98 141.50,160.29 148.61,167.80 155.72,175.47 162.83,183.25 169.93,191.23 177.04,199.63 184.15,208.70 191.26,218.59 198.37,228.25 205.47,237.40 212.58,246.12 219.69,254.48 226.80,262.51 233.91,270.27 241.01,277.76 248.12,285.01 255.23,292.03 262.34,298.82 269.44,305.39 276.55,311.74 283.66,317.87 290.77,323.79 297.88,329.48 304.98,334.96 312.09,340.20 319.20,345.23 326.31,350.02 333.42,354.58 340.52,358.89 347.63,362.96 354.74,366.79 361.85,370.35 368.96,373.65 376.06,376.69 383.17,379.44 390.28,381.91 397.39,384.09 404.50,385.96 411.60,387.51 418.71,388.74 425.82,389.63 432.93,390.18 440.04,390.36 447.14,390.18 454.25,389.61 461.36,388.65 468.47,387.29 475.58,385.52 482.68,383.34 489.79,380.74 496.90,377.73 504.01,374.29 511.12,370.43 518.22,366.15 525.33,361.46 532.44,356.35 539.55,350.83 546.65,344.90 553.76,338.56 560.87,331.82 567.98,324.67 575.09,317.13 582.19,309.18 589.30,300.84 596.41,292.09 603.52,282.95 610.63,273.40 617.73,263.45 624.84,253.10 624.84,393.77 617.73,397.49 610.63,401.08 603.52,404.54 596.41,407.86 589.30,411.05 582.19,414.09 575.09,416.99 567.98,419.75 560.87,422.37 553.76,424.84 546.65,427.16 539.55,429.35 532.44,431.39 525.33,433.29 518.22,435.05 511.12,436.67 504.01,438.15 496.90,439.49 489.79,440.69 482.68,441.75 475.58,442.66 468.47,443.42 461.36,444.02 454.25,444.45 447.14,444.70 440.04,444.76 432.93,444.62 425.82,444.26 418.71,443.68 411.60,442.85 404.50,441.77 397.39,440.42 390.28,438.79 383.17,436.87 376.06,434.65 368.96,432.12 361.85,429.27 354.74,426.10 347.63,422.58 340.52,418.72 333.42,414.51 326.31,409.95 319.20,405.01 312.09,399.71 304.98,394.03 297.88,387.98 290.77,381.54 283.66,374.71 276.55,367.49 269.44,359.87 262.34,351.87 255.23,343.47 248.12,334.68 241.01,325.51 233.91,315.97 226.80,306.06 219.69,295.82 212.58,285.27 205.47,274.46 198.37,263.45 191.26,252.33 184.15,241.36 177.04,231.06 169.93,221.47 162.83,212.64 155.72,204.53 148.61,197.01 141.50,189.82 134.39,182.67 127.29,175.34 120.18,165.37 113.07,151.35 105.96,137.04 98.85,122.09 91.75,103.95 84.64,89.70 77.53,79.45 70.42,75.89 63.31,85.67 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #999999; fill-opacity: 0.40;' />
+<polyline points='63.31,46.53 70.42,56.78 77.53,61.45 84.64,67.35 91.75,80.01 98.85,93.76 105.96,108.44 113.07,124.40 120.18,137.29 127.29,145.88 134.39,152.98 141.50,160.29 148.61,167.80 155.72,175.47 162.83,183.25 169.93,191.23 177.04,199.63 184.15,208.70 191.26,218.59 198.37,228.25 205.47,237.40 212.58,246.12 219.69,254.48 226.80,262.51 233.91,270.27 241.01,277.76 248.12,285.01 255.23,292.03 262.34,298.82 269.44,305.39 276.55,311.74 283.66,317.87 290.77,323.79 297.88,329.48 304.98,334.96 312.09,340.20 319.20,345.23 326.31,350.02 333.42,354.58 340.52,358.89 347.63,362.96 354.74,366.79 361.85,370.35 368.96,373.65 376.06,376.69 383.17,379.44 390.28,381.91 397.39,384.09 404.50,385.96 411.60,387.51 418.71,388.74 425.82,389.63 432.93,390.18 440.04,390.36 447.14,390.18 454.25,389.61 461.36,388.65 468.47,387.29 475.58,385.52 482.68,383.34 489.79,380.74 496.90,377.73 504.01,374.29 511.12,370.43 518.22,366.15 525.33,361.46 532.44,356.35 539.55,350.83 546.65,344.90 553.76,338.56 560.87,331.82 567.98,324.67 575.09,317.13 582.19,309.18 589.30,300.84 596.41,292.09 603.52,282.95 610.63,273.40 617.73,263.45 624.84,253.10 ' style='stroke-width: 2.13; stroke: none; stroke-linecap: butt;' />
+<polyline points='624.84,393.77 617.73,397.49 610.63,401.08 603.52,404.54 596.41,407.86 589.30,411.05 582.19,414.09 575.09,416.99 567.98,419.75 560.87,422.37 553.76,424.84 546.65,427.16 539.55,429.35 532.44,431.39 525.33,433.29 518.22,435.05 511.12,436.67 504.01,438.15 496.90,439.49 489.79,440.69 482.68,441.75 475.58,442.66 468.47,443.42 461.36,444.02 454.25,444.45 447.14,444.70 440.04,444.76 432.93,444.62 425.82,444.26 418.71,443.68 411.60,442.85 404.50,441.77 397.39,440.42 390.28,438.79 383.17,436.87 376.06,434.65 368.96,432.12 361.85,429.27 354.74,426.10 347.63,422.58 340.52,418.72 333.42,414.51 326.31,409.95 319.20,405.01 312.09,399.71 304.98,394.03 297.88,387.98 290.77,381.54 283.66,374.71 276.55,367.49 269.44,359.87 262.34,351.87 255.23,343.47 248.12,334.68 241.01,325.51 233.91,315.97 226.80,306.06 219.69,295.82 212.58,285.27 205.47,274.46 198.37,263.45 191.26,252.33 184.15,241.36 177.04,231.06 169.93,221.47 162.83,212.64 155.72,204.53 148.61,197.01 141.50,189.82 134.39,182.67 127.29,175.34 120.18,165.37 113.07,151.35 105.96,137.04 98.85,122.09 91.75,103.95 84.64,89.70 77.53,79.45 70.42,75.89 63.31,85.67 ' style='stroke-width: 2.13; stroke: none; stroke-linecap: butt;' />
+<polyline points='63.31,66.10 70.42,66.33 77.53,70.45 84.64,78.52 91.75,91.98 98.85,107.93 105.96,122.74 113.07,137.88 120.18,151.33 127.29,160.61 134.39,167.83 141.50,175.05 148.61,182.41 155.72,190.00 162.83,197.94 169.93,206.35 177.04,215.34 184.15,225.03 191.26,235.46 198.37,245.85 205.47,255.93 212.58,265.70 219.69,275.15 226.80,284.29 233.91,293.12 241.01,301.64 248.12,309.85 255.23,317.75 262.34,325.34 269.44,332.63 276.55,339.61 283.66,346.29 290.77,352.66 297.88,358.73 304.98,364.49 312.09,369.96 319.20,375.12 326.31,379.98 333.42,384.54 340.52,388.81 347.63,392.77 354.74,396.44 361.85,399.81 368.96,402.89 376.06,405.67 383.17,408.16 390.28,410.35 397.39,412.25 404.50,413.86 411.60,415.18 418.71,416.21 425.82,416.95 432.93,417.40 440.04,417.56 447.14,417.44 454.25,417.03 461.36,416.33 468.47,415.35 475.58,414.09 482.68,412.55 489.79,410.72 496.90,408.61 504.01,406.22 511.12,403.55 518.22,400.60 525.33,397.37 532.44,393.87 539.55,390.09 546.65,386.03 553.76,381.70 560.87,377.09 567.98,372.21 575.09,367.06 582.19,361.64 589.30,355.94 596.41,349.98 603.52,343.75 610.63,337.24 617.73,330.47 624.84,323.44 ' style='stroke-width: 2.13; stroke: #3366FF; stroke-linecap: butt;' />
+<rect x='35.24' y='22.78' width='617.68' height='522.33' style='stroke-width: 1.07; stroke: #333333;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='30.31' y='498.34' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.6</text>
+<text x='30.31' y='387.63' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.7</text>
+<text x='30.31' y='276.92' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.8</text>
+<text x='30.31' y='166.21' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.9</text>
+<text x='30.31' y='55.51' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<polyline points='32.50,495.31 35.24,495.31 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='32.50,384.60 35.24,384.60 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='32.50,273.90 35.24,273.90 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='32.50,163.19 35.24,163.19 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='32.50,52.48 35.24,52.48 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='57.23,547.85 57.23,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='259.95,547.85 259.95,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='462.67,547.85 462.67,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='57.23' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='259.95' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>10</text>
+<text x='462.67' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='9.79px' lengthAdjust='spacingAndGlyphs'>20</text>
+<text x='344.08' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='13.44px' lengthAdjust='spacingAndGlyphs'>bili</text>
+<text transform='translate(13.05,283.95) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='84.99px' lengthAdjust='spacingAndGlyphs'>Survival at 1 year</text>
+<rect x='663.88' y='259.00' width='50.64' height='49.89' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<text x='663.88' y='267.71' style='font-size: 11.00px; font-family: sans;' textLength='26.91px' lengthAdjust='spacingAndGlyphs'>event</text>
+<rect x='663.88' y='274.33' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<circle cx='672.52' cy='282.97' r='1.95' style='stroke-width: 0.71; stroke: none; fill: #F8766D;' />
+<rect x='663.88' y='291.61' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<polygon points='672.52,297.21 675.15,301.77 669.88,301.77 ' style='stroke-width: 0.71; stroke: none; fill: #00BFC4;' />
+<text x='686.64' y='286.00' style='font-size: 8.80px; font-family: sans;' textLength='27.88px' lengthAdjust='spacingAndGlyphs'>FALSE</text>
+<text x='686.64' y='303.28' style='font-size: 8.80px; font-family: sans;' textLength='23.96px' lengthAdjust='spacingAndGlyphs'>TRUE</text>
+<text x='35.24' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='183.44px' lengthAdjust='spacingAndGlyphs'>gg_variable survival single time</text>
+</g>
+</svg>

--- a/tests/testthat/test_snapshots.R
+++ b/tests/testthat/test_snapshots.R
@@ -528,6 +528,76 @@ if (requireNamespace("kernelshap", quietly = TRUE)) {
   })
 }
 
+# Survival — pbc, plot.gg_variable() across all four survival paths
+#
+# plot.gg_variable()'s survival branch forks twice: on `panel`, and on whether
+# gg_dta carries one time or several. The four combinations differ in both
+# faceting and y-axis title, and none of them had a visual baseline:
+#
+#   panel = FALSE, one time    no facet                y = "Survival at <t> year"
+#   panel = FALSE, many times  facet_wrap(~time)       y = "Survival"
+#   panel = TRUE,  one time    facet_wrap(~variable)   y = "Survival at <t> year"
+#   panel = TRUE,  many times  facet_grid(time ~ var)  y = "Survival"
+#
+# The two single-time paths are the ones carrying the hard-coded time unit, so
+# they are the ones that a change to that axis title has to redraw. Before this
+# block the only guard on that title was expect_equal() on p$labels$y, which
+# cannot see the rest of the panel.
+#
+# This block sits last in the file deliberately. expect_doppelganger() consumes
+# the RNG whenever a plot draws geom_jitter (see the note in
+# test_determinism.R), so a new block inserted higher up would shift the stream
+# for every jitter-dependent snapshot below it. Appending cannot.
+local({
+  data(pbc, package = "randomForestSRC")
+  pbc$time <- pbc$days / 364.25
+  pbc_sub <- pbc[, c("time", "status", "treatment", "age", "bili", "albumin")]
+
+  # Same data subset and seed as the survival fixture above. importance and
+  # tree.err are omitted because gg_variable() reads neither, and permutation
+  # importance would draw from the RNG for nothing.
+  set.seed(42L)
+  rfsrc_pbc <- randomForestSRC::rfsrc(
+    Surv(time, status) ~ .,
+    data = pbc_sub,
+    ntree = 100L
+  )
+
+  # bili and albumin are both numeric, so these four plots draw geom_point plus
+  # geom_smooth and never geom_jitter. The baselines therefore do not depend on
+  # RNG state at draw time.
+  gg_one <- gg_variable(rfsrc_pbc, time = 1)
+  gg_many <- gg_variable(rfsrc_pbc, time = c(1, 3))
+
+  test_that("snapshot: gg_variable survival single time", {
+    vdiffr::expect_doppelganger(
+      "gg_variable survival single time",
+      plot(gg_one, xvar = "bili")
+    )
+  })
+
+  test_that("snapshot: gg_variable survival multiple times", {
+    vdiffr::expect_doppelganger(
+      "gg_variable survival multi time",
+      plot(gg_many, xvar = "bili")
+    )
+  })
+
+  test_that("snapshot: gg_variable survival panel single time", {
+    vdiffr::expect_doppelganger(
+      "gg_variable survival panel single time",
+      plot(gg_one, xvar = c("bili", "albumin"), panel = TRUE)
+    )
+  })
+
+  test_that("snapshot: gg_variable survival panel multiple times", {
+    vdiffr::expect_doppelganger(
+      "gg_variable survival panel multi time",
+      plot(gg_many, xvar = c("bili", "albumin"), panel = TRUE)
+    )
+  })
+})
+
 } else {
 
 ## ---- Preserve baselines when the vdiffr comparison is opted out ------------


### PR DESCRIPTION
`plot.gg_variable()`'s survival branch had no visual baseline at all. The four
`gg-variable-*` files under `tests/testthat/_snaps/snapshots/` were regression or
classification, and `grep -l "Survival" tests/testthat/_snaps/snapshots/*.svg`
matched only the two `gg_rfsrc` survival files.

Surfaced during the final review of #250, which changes the survival y-axis title
from a hard-coded `"Survival at <t> year"` to `"Survival at <t>"` with a new
`time_units` argument. That change had no visual cover: a plain
`expect_equal(p$labels$y, ...)` was its only guard, and an assertion on one label
cannot see the rest of the panel.

## What is covered

The survival branch forks twice — on `panel`, and on whether the object carries
one time or several. That is four paths, not two, and they differ in both
faceting and y-axis title. Each now has a baseline:

| `panel` | times | y-axis title | faceting | baseline |
|---|---|---|---|---|
| `FALSE` | 1 | `Survival at 1 year` | none | `gg-variable-survival-single-time` |
| `FALSE` | 2 | `Survival` | `facet_wrap(~time)` | `gg-variable-survival-multi-time` |
| `TRUE` | 1 | `Survival at 1 year` | `facet_wrap(~variable)` | `gg-variable-survival-panel-single-time` |
| `TRUE` | 2 | `Survival` | `facet_grid(time ~ variable)` | `gg-variable-survival-panel-multi-time` |

The two single-time rows are the sites that render a time unit into the axis
title (`R/plot.gg_variable.R:345` and `:524`). Both baselines contain
`Survival at 1 year` as a contiguous string in the SVG, so a change to that title
produces a real image diff rather than passing silently.

## Why the block sits at the foot of the file

`test_determinism.R` records a live hazard: `expect_doppelganger()` consumes the
RNG whenever a plot draws `geom_jitter`, because the draw happens at build time.
Its comment notes that the jitter-dependent snapshot blocks "are stable today
only because execution within a file is sequential; inserting a test earlier in
`test_snapshots.R` would shift them."

So the new block is appended rather than folded into the existing `pbc` fixture,
and it uses all-numeric predictors (`bili`, `albumin`), which draw `geom_point`
plus `geom_smooth` and never `geom_jitter`. It re-fits a small `pbc` forest of
its own — about 0.3s — rather than reaching into another `local({})` scope.

## Verification

- `devtools::document()` — no churn.
- `lintr::lint_package()` — 0 lints.
- `NOT_CRAN=true VDIFFR_RUN_TESTS=true devtools::test()` — `FAIL 0 | PASS 1951`.
  Run twice: the first created the four baselines, the second compared against
  them clean (`WARN 62 → 58`, the four "Adding new file snapshot" warnings gone).
- **All 54 pre-existing baselines are byte-identical** after both runs (md5
  compared before and after), and none was pruned. 58 tracked now.
- `R CMD check --as-cran` from a clean `git archive` export, with the manual:
  `Status: 1 NOTE` — the pre-existing CRAN incoming-feasibility maintainer note.
  The `tests` step is unchanged at 18s, since CI runs snapshots with
  `VDIFFR_RUN_TESTS: "false"`, so this adds nothing to the CRAN check budget.

## Note for #250

This branch is based on `main`, so the two single-time baselines pin today's
`"Survival at 1 year"`. **When #250 merges it will need to regenerate
`gg-variable-survival-single-time.svg` and
`gg-variable-survival-panel-single-time.svg`** — that regeneration is the point,
since it makes the relabel visible as an SVG diff in #250's own review.

Tests and `NEWS.md` only. No version bump, no change to `R/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)