### PR TITLE
Pin the UBSAN container by digest

### DIFF
--- a/.github/workflows/upstream-ubsan.yaml
+++ b/.github/workflows/upstream-ubsan.yaml
@@ -19,7 +19,26 @@ jobs:
   upstream-ubsan:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/r-hub/containers/gcc16:latest
+      # Pinned by DIGEST, not by tag. Three regressions reached this workflow
+      # through the floating :latest reference: an r-hub binary repo whose
+      # PACKAGES index resolved but whose tarballs 404'd (#246), an image with
+      # no UBSAN runtime (#247), and one with no libuv headers (#248). None was
+      # visible until a manual dispatch, because this workflow has no automatic
+      # trigger.
+      #
+      # This digest is the image under which run 33282093658 built the full
+      # dependency tree and produced a LIVE calibration signal (the known
+      # randomForestSRC entry.c:184 diagnostic reproduced), so the sanitizer is
+      # known to be correctly instrumented here.
+      #
+      # The dnf installs in "Provide and prove the build prerequisites" are NOT
+      # made redundant by this pin: this exact image still ships without
+      # libubsan and without libuv-devel. The pin stops NEW drift; the installs
+      # fix what is already absent. Removing either breaks the workflow.
+      #
+      # To move: dispatch against a new digest, confirm the calibration step
+      # still goes red, then update here.
+      image: ghcr.io/r-hub/containers/gcc16@sha256:fb5a9bc713098627de4ea5dcebebab0794c540b663fb8e5b61592de0d6137ec2
     env:
       R_LIBS_USER: ${{ github.workspace }}/.ubsan-library
       R_MAKEVARS_USER: ${{ github.workspace }}/tools/Makevars.ubsan


### PR DESCRIPTION
Pins `ghcr.io/r-hub/containers/gcc16` by digest instead of `:latest`.

```
sha256:fb5a9bc713098627de4ea5dcebebab0794c540b663fb8e5b61592de0d6137ec2
```

## Why this digest

It is the image under which [run 33282093658](https://github.com/ehrlinger/ggRandomForests/actions/runs/33282093658) built the entire dependency tree **and** produced a live calibration signal: the known `randomForestSRC` `entry.c:184` diagnostic reproduced as expected. So the sanitizer is known to be correctly instrumented under this image, which is the property worth freezing.

## Why pin at all

Three regressions reached this workflow through the floating tag, none visible until a manual dispatch, because the workflow has no automatic trigger:

| Regression | Fixed by |
|---|---|
| r-hub binary repo: `PACKAGES` resolved, tarballs 404 | [#246](https://github.com/ehrlinger/ggRandomForests/pull/246) |
| image shipped without the UBSAN runtime | [#247](https://github.com/ehrlinger/ggRandomForests/pull/247) |
| image shipped without libuv headers | [#248](https://github.com/ehrlinger/ggRandomForests/pull/248) |

## Measured, not assumed

The digest was **identical** across runs `33267620518`, `33278882599` and `33282093658`, so `:latest` did **not** move during this work; the drift happened before it. The `Status: Downloaded newer image` line in the logs is a cold runner cache, not a tag move. Stating this because "the tag is moving under us" would be a tidier story and is not what the evidence shows.

## ⚠️ The `dnf` installs are not redundant

This exact pinned image **still ships without `libubsan` and without `libuv-devel`**. The pin stops *new* drift; the installs fix what is *already* absent. Removing either on the theory that the pin covers it breaks the workflow immediately. The step comment says so at the call site.

## ⚠️ Pinned ahead of a clean verdict

At the maintainer's direction. The run under this digest **halts on a live varPro finding** ([kogalur/varPro#6](https://github.com/kogalur/varPro/issues/6)), so the gate is not green. What is being pinned is a *build environment* proven to compile everything and to detect a known defect, not a passing result. My preference had been to pin after a clean run; recording the distinction rather than the preference.

## Moving the pin later

Dispatch against a new digest, confirm the calibration step still goes red, then update the digest here. A calibration that cannot go red cannot certify anything downstream, which is the lesson from [#249](https://github.com/ehrlinger/ggRandomForests/pull/249).

CI cannot exercise this change: the workflow is `workflow_dispatch` only. Verification is a manual dispatch after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)