### PR TITLE
Correct the failure mode in the cross-branch baseline bullet

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,10 +86,12 @@ Further notes, so nobody re-derives them:
   one merges. It happened on 2026-08-29: #252 added four `plot.gg_variable()` survival
   baselines while #250, which removed the hard-coded `"year"` from that same axis title,
   sat in review. Two of the four baked in `Survival at 1 year`, and #250 would have
-  merged clean and left `main` red. **Before merging a PR that changes rendered output,
-  re-check `main` for baselines added since you branched**, then merge `main` in,
-  regenerate, and push. `git diff --stat <merge-commit>..HEAD` afterwards should name
-  only the baselines you meant to touch.
+  merged clean and left `main` quietly wrong: green in CI, which never compares an SVG,
+  and failing only for whoever next ran the suite locally with the guard on. **Before
+  merging a PR that changes rendered output, re-check `main` for baselines added since
+  you branched**, then merge `main` in, regenerate, and push.
+  `git diff --stat <merge-commit>..HEAD` afterwards should name only the baselines you
+  meant to touch.
 - All 58 baselines are tracked today. That was not true on 2026-08-06, when one unguarded run
   pruned 49 files and the 9 untracked ones survived only because a stale copy happened to
   remain in `ggRandomForests.Rcheck/00_pkg_src/`. That is not a backup and will not reliably

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,12 +86,12 @@ Further notes, so nobody re-derives them:
   one merges. It happened on 2026-08-29: #252 added four `plot.gg_variable()` survival
   baselines while #250, which removed the hard-coded `"year"` from that same axis title,
   sat in review. Two of the four baked in `Survival at 1 year`, and #250 would have
-  merged clean and left `main` quietly wrong: green in CI, which never compares an SVG,
-  and failing only for whoever next ran the suite locally with the guard on. **Before
-  merging a PR that changes rendered output, re-check `main` for baselines added since
-  you branched**, then merge `main` in, regenerate, and push.
-  `git diff --stat <merge-commit>..HEAD` afterwards should name only the baselines you
-  meant to touch.
+  merged clean and left `main` quietly wrong. CI would have stayed green, because it never
+  compares an SVG, and the mismatch would have surfaced only when someone next ran the
+  suite locally with the guard on. **Before merging a PR that changes rendered output,
+  re-check `main` for baselines added since you branched**, then merge `main` in,
+  regenerate, and push. `git diff --stat <merge-commit>..HEAD` afterwards should name only
+  the baselines you meant to touch.
 - All 58 baselines are tracked today. That was not true on 2026-08-06, when one unguarded run
   pruned 49 files and the 9 untracked ones survived only because a stale copy happened to
   remain in `ggRandomForests.Rcheck/00_pkg_src/`. That is not a backup and will not reliably


### PR DESCRIPTION
Follow-up to #256, which landed the cross-branch vdiffr baseline bullet in `AGENTS.md`. One clause in it describes the wrong failure mode.

> Two of the four baked in `Survival at 1 year`, and #250 would have merged clean and left `main` red.

`main` would have gone **green, not red**. All three check workflows set `VDIFFR_RUN_TESTS: "false"` — `R-CMD-check.yaml:53`, `test-coverage.yaml:33`, `check-manual.yaml:33` — so CI never compares a single SVG, and a stale baseline cannot redden it.

## Why the distinction earns a PR

It is the whole teaching value of the bullet. A red `main` announces itself, and a reader told to expect one will go looking for a signal that never appears. A silently wrong `main` waits for whoever next runs the suite locally with the guard on — and their `git status` then shows two baselines changing for no reason they can account for, which reads as their own bug rather than an inherited one.

The section already makes exactly this argument eleven lines further down, where it notes that the CI setting "is why the hazard stays invisible until someone runs the suite on a laptop". This brings the new bullet into line with the section it sits in.

## Scope

Wording only, inside one bullet. The bullet's operational advice — re-check `main` for baselines added since you branched, then merge, regenerate, push, and confirm with `git diff --stat` — is unchanged and was already correct, as were the three `49` → `58` count fixes #256 made alongside it.

No code, no tests, no version bump. `AGENTS.md` is read by no test in the suite (`grep -rln AGENTS tests/` is empty), so there is nothing to run beyond review.

Raised first as a post-merge comment on #256 (#issuecomment-5468348000).

🤖 Generated with [Claude Code](https://claude.com/claude-code)