### PR TITLE
Separate "baselines not pruned" from "SVGs compared" in the RC2 evidence

### DIFF
--- a/release-checklist-v4.0.0.md
+++ b/release-checklist-v4.0.0.md
@@ -120,6 +120,13 @@ unsupervised variable priority where that method is discussed.
   no documentation drift, 0 lints, 1,975 passes, 0 failures, 58 existing
   warnings, 6 documented skips. All 58 vdiffr baselines present before and
   after; the working tree was byte-identical, so nothing was pruned.
+- ⚠️ **Read those two facts separately.** "58 baselines present before and after"
+  evidences only that **nothing was pruned**; it says nothing about whether any
+  SVG matched. The visual comparisons are evidenced by the **pass count**, because
+  that suite ran with `VDIFFR_RUN_TESTS=true`. **CI cannot supply this evidence at
+  all:** `R-CMD-check`, `test-coverage` and `check-manual` all set
+  `VDIFFR_RUN_TESTS: "false"`, so no CI job ever compares an SVG, and a green board
+  is not evidence about visual regression. Only a local guarded run is.
 - Clean `git archive` build, checked with the manual: **1 NOTE, 0 WARNING,
   0 ERROR**, 3:12 wall. The NOTE is the maintainer-cadence incoming-feasibility
   one. Tarball gate: only `ggRandomForests/.Rinstignore` matches `/\.[^/]+`,


### PR DESCRIPTION
A precision fix to the RC2 verification evidence, prompted by a reviewer catch.

## The problem

The evidence block reads:

> All 58 vdiffr baselines present before and after; the working tree was byte-identical, so nothing was pruned.

That sentence is **true**, but it evidences only that nothing was **pruned**. It says nothing about whether any SVG actually matched. Sitting in a gate-evidence block next to check results, it invites the stronger reading.

## What the evidence actually is

The comparisons **did** run. The guarded suite used `VDIFFR_RUN_TESTS=true`, so the visual comparisons are inside the **1,975 pass count**. That is the number that evidences visual regression, not the baseline count.

## Why CI cannot supply it

All three workflows set the guard off:

```
.github/workflows/R-CMD-check.yaml:53:      VDIFFR_RUN_TESTS: "false"
.github/workflows/test-coverage.yaml:33:   VDIFFR_RUN_TESTS: "false"
.github/workflows/check-manual.yaml:33:    VDIFFR_RUN_TESTS: "false"
```

**No CI job ever compares an SVG**, so a green board is not evidence about visual regression. Only a local guarded run is.

This is the same point `AGENTS.md` now makes about the cross-branch baseline hazard ([#256](https://github.com/ehrlinger/ggRandomForests/pull/256), [#258](https://github.com/ehrlinger/ggRandomForests/pull/258)): a stale baseline leaves `main` *quietly wrong* rather than red, precisely because nothing in CI looks at it. Worth stating once in the release record too, since that record is what a future release reads back.

Documentation only; `release-checklist-v4.0.0.md` is `.Rbuildignore`d and absent from the tarball.

🤖 Generated with [Claude Code](https://claude.com/claude-code)