### PR TITLE
Retire plot.gg_variable()'s dead time formals, guard what replaces them

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -114,6 +114,22 @@ ggRandomForests v4.0.0 (development)
   matches on raw variable names, so the label is display only and passing a
   label where a variable name belongs is still an error. As with the varPro
   methods above, `labels` was previously accepted and discarded in silence.
+* `plot.gg_variable()` no longer declares `time` and `time_labels`, two formals
+  its body never read. They are parameters of `gg_variable()`, the extractor,
+  which bakes the horizon into the object before `plot()` runs, so the man page
+  had been promising a horizon selection the method never performed. Supplying
+  either now warns and names the call that works. ⚠️ `time_units` moved to
+  **after** `...` in the signature as part of this: R partial-matches argument
+  names only before `...`, so with `time_units` ahead of it a caller writing
+  `time = 1191` bound silently to `time_units` and died on its type check.
+  Past the dots, matching is exact. `time_units` always had to be named, so no
+  working call changes.
+* `time_units` is now sanity-checked against the data it describes. A year-like
+  unit supplied against values above 150 warns, because that is almost always a
+  forest fit on a smaller unit and produces an axis title wrong by a factor of
+  365. It warns rather than errors, and only in that one direction: small values
+  labelled `"days"` is ordinary, so there is no signal to check. The package
+  still cannot derive the unit and does not try to.
 * `plot.gg_variable()`, `plot.gg_udependent()` and `plot.gg_sdependent()` gain
   `labels`, which completes the argument across every plot method in the
   package that renders variable names. `plot.gg_variable()` labels the facet strips in its panel

--- a/NEWS.md
+++ b/NEWS.md
@@ -124,12 +124,16 @@ ggRandomForests v4.0.0 (development)
   `time = 1191` bound silently to `time_units` and died on its type check.
   Past the dots, matching is exact. `time_units` always had to be named, so no
   working call changes.
-* `time_units` is now sanity-checked against the data it describes. A year-like
+* `plot.gg_variable()` sanity-checks `time_units` against the data it describes. A year-like
   unit supplied against values above 150 warns, because that is almost always a
   forest fit on a smaller unit and produces an axis title wrong by a factor of
   365. It warns rather than errors, and only in that one direction: small values
   labelled `"days"` is ordinary, so there is no signal to check. The package
-  still cannot derive the unit and does not try to.
+  still cannot derive the unit and does not try to. Scoped to
+  `plot.gg_variable()` for now: `plot.gg_rfsrc()` also takes `time_units`, but a
+  `gg_rfsrc` object has no `time` column (its time points live in `variable`,
+  which holds class names for a classification fit), so there is no unambiguous
+  column to check and extending it is not a one-line change.
 * `plot.gg_variable()`, `plot.gg_udependent()` and `plot.gg_sdependent()` gain
   `labels`, which completes the argument across every plot method in the
   package that renders variable names. `plot.gg_variable()` labels the facet strips in its panel

--- a/R/plot.gg_variable.R
+++ b/R/plot.gg_variable.R
@@ -18,8 +18,6 @@
 #' @param x \code{\link{gg_variable}} object created from a
 #' \code{\link[randomForestSRC]{rfsrc}} object
 #' @param xvar variable (or list of variables) of interest.
-#' @param time For survival, one or more times of interest
-#' @param time_labels string labels for times
 #' @param panel Should plots be faceted along multiple xvar?
 #' @param oob oob estimates (boolean)
 #' @param points plot the raw data points (boolean)
@@ -141,17 +139,24 @@
 #' @export
 plot.gg_variable <- function(x, # nolint: cyclocomp_linter
                              xvar,
-                             time,
-                             time_labels,
                              panel = FALSE,
                              oob = TRUE,
                              points = TRUE,
                              smooth = TRUE,
                              labels = NULL,
-                             time_units = NULL,
-                             ...) {
+                             ...,
+                             ## AFTER the dots deliberately.  R partial-matches
+                             ## argument names only BEFORE ..., so with
+                             ## time_units ahead of it a caller writing
+                             ## time = 1191 (the retired argument) silently bound
+                             ## to time_units and died on its type check, and
+                             ## .check_retired_time_args() never saw the name.
+                             ## Past the dots, matching is exact and 'time' falls
+                             ## into ... where the guard can report it.
+                             time_units = NULL) {
   gg_dta <- x
-  time_units <- .check_time_units(time_units)
+  .check_retired_time_args(...)
+  time_units <- .check_time_units(time_units, gg_dta[["time"]])
 
   ## Resolve the label lookup ONCE.  .forest_strip_labeller() would resolve it
   ## again internally, and a lookup that matches nothing warns on every

--- a/R/plot.gg_variable.R
+++ b/R/plot.gg_variable.R
@@ -154,8 +154,22 @@ plot.gg_variable <- function(x, # nolint: cyclocomp_linter
                              ## Past the dots, matching is exact and 'time' falls
                              ## into ... where the guard can report it.
                              time_units = NULL) {
+  ## Coerce FIRST.  plot.gg_variable() also accepts a raw rfsrc and forwards ...
+  ## to gg_variable(), where 'time' and 'time_labels' are real, working
+  ## parameters.  Guarding before this point warned that they were ignored on
+  ## the one path where they are honoured, and left the plausibility check
+  ## reading gg_dta[["time"]] off an rfsrc rather than off the extracted frame.
   gg_dta <- x
-  .check_retired_time_args(...)
+  from_rfsrc <- inherits(x, "rfsrc")
+  if (from_rfsrc) {
+    gg_dta <- gg_variable(x, ...)
+  }
+
+  ## Only meaningful for an already-extracted gg_variable object: that is the
+  ## call where the horizon is already baked in and the argument really is dead.
+  if (!from_rfsrc) {
+    .check_retired_time_args(...)
+  }
   time_units <- .check_time_units(time_units, gg_dta[["time"]])
 
   ## Resolve the label lookup ONCE.  .forest_strip_labeller() would resolve it
@@ -166,11 +180,6 @@ plot.gg_variable <- function(x, # nolint: cyclocomp_linter
   strip_labeller <- ggplot2::as_labeller(
     function(v) .apply_forest_labels(v, lab_lookup)
   )
-
-  # I don't think this will work with latest S3 models.
-  if (inherits(x, "rfsrc")) {
-    gg_dta <- gg_variable(x, ...)
-  }
 
   ## ---- Detect forest family from gg_variable class attributes ----------
   # Default to classification; override if survival or regression flags found

--- a/R/utils.R
+++ b/R/utils.R
@@ -228,7 +228,7 @@ shift <- function(x, shift_by = 1) {
 # cannot derive the unit and must not assert one.  The default prints no unit,
 # which is always correct; a caller who knows the unit supplies it.
 #' @keywords internal
-.check_time_units <- function(time_units) {
+.check_time_units <- function(time_units, time_values = NULL) {
   if (is.null(time_units)) {
     return(NULL)
   }
@@ -237,7 +237,68 @@ shift <- function(x, shift_by = 1) {
     stop("'time_units' must be NULL or a single non-empty character string.",
          call. = FALSE)
   }
+  .warn_implausible_time_units(time_units, time_values)
   time_units
+}
+
+## One-directional plausibility check on a SUPPLIED unit.  The package cannot
+## derive the unit (randomForestSRC stores none), so this never errors and never
+## guesses: it flags only the case that actually occurred, a day-scale horizon
+## labelled in years, which renders "Survival at 1191 years" and is wrong by a
+## factor of 365.
+##
+## Deliberately not checked in reverse.  Small values with "days" is ordinary
+## (a five-day ICU study), so there is no signal there and a check would be noise.
+##
+## The check is opportunistic: 'time_values' is absent for regression and
+## classification, because plot.gg_variable() resolves units before it branches
+## on family.  A missing, empty or non-numeric column simply skips the check.
+#' @keywords internal
+.warn_implausible_time_units <- function(time_units, time_values) {
+  if (is.null(time_values) || !length(time_values)) {
+    return(invisible(NULL))
+  }
+  if (!grepl("^(year|years|yr|yrs)$", time_units, ignore.case = TRUE)) {
+    return(invisible(NULL))
+  }
+  ## gg_dta$time is a FACTOR whose integer codes are not its labels, so compare
+  ## through as.character() or this silently tests the wrong numbers.
+  num <- suppressWarnings(as.numeric(as.character(time_values)))
+  num <- num[is.finite(num)]
+  if (!length(num) || max(num) <= 150) {
+    return(invisible(NULL))
+  }
+  warning("time_units = \"", time_units, "\" against time values up to ",
+          format(max(num)), ". That is implausible for years and usually means ",
+          "the forest was fit on a smaller unit, such as days. The axis title ",
+          "is taken from 'time_units' as supplied and is not derived from the ",
+          "data.", call. = FALSE)
+  invisible(NULL)
+}
+
+## plot.gg_variable() once declared 'time' and 'time_labels' as formals it never
+## read.  They are parameters of gg_variable(), the extractor, which bakes the
+## horizon into gg_dta$time before plot() ever runs.  Removing them alone would
+## let the names fall into ... and trip ggplot2's generic "Ignoring unknown
+## parameters", which points at a geom rather than at the call that works, so
+## catch them here and name the right one.
+##
+## MUST NOT consume anything from ...: plot.gg_variable() forwards ... to ggplot2
+## layers, and swallowing an argument meant to be relayed would reintroduce the
+## defect this replaced.
+#' @keywords internal
+.check_retired_time_args <- function(...) {
+  supplied <- names(list(...))
+  if (is.null(supplied)) {
+    return(invisible(NULL))
+  }
+  hit <- intersect(c("time", "time_labels"), supplied)
+  for (arg in hit) {
+    warning("plot.gg_variable(): '", arg, "' selects a horizon at extraction ",
+            "time, not at plot time, and is ignored here. Use ",
+            "gg_variable(rf, ", arg, " = ...) instead.", call. = FALSE)
+  }
+  invisible(NULL)
 }
 
 # Survival y-axis title: "Survival at 1191" / "Survival at 1191 days".

--- a/dev/specs/2026-08-31-plot-gg-variable-time-args-design.md
+++ b/dev/specs/2026-08-31-plot-gg-variable-time-args-design.md
@@ -1,0 +1,186 @@
+# Design: retire `plot.gg_variable()`'s dead time formals, guard what replaces them
+
+**Date:** 2026-08-31
+**Issue:** [#251](https://github.com/ehrlinger/ggRandomForests/issues/251)
+**Status:** design approved, not yet implemented
+**Target version:** 4.0.0 (unreleased development line)
+
+## Problem
+
+`plot.gg_variable()` declares and documents two formals its body never reads:
+
+```r
+plot.gg_variable <- function(x, xvar, time, time_labels, panel = FALSE,
+                             oob = TRUE, points = TRUE, smooth = TRUE,
+                             labels = NULL, time_units = NULL, ...)
+```
+
+`time` and `time_labels` are real parameters of `gg_variable()`, the extractor,
+which reads them out of `...` and uses them to select the horizon and label the
+resulting `time` column. By the time `plot()` runs, the horizon is already baked
+into `gg_dta$time` and the method reads only that column. Searching the body for a
+bare `time` or `time_labels` returns nothing: every occurrence is `gg_dta$time`, a
+column-name string, `time_units`, or a comment.
+
+`man/plot.gg_variable.Rd` advertises both on the method, so `?plot.gg_variable`
+tells a user they can select a horizon at plot time. They cannot:
+
+```r
+gg_dta <- gg_variable(rf, time = 90)
+plot(gg_dta, xvar = "age", time = 1191)   # still the 90 plot, no error, no warning
+```
+
+The failure is silent because the arguments match named formals rather than
+falling into `...`, so neither R nor the method complains.
+
+A second, related gap arrived with [#250](https://github.com/ehrlinger/ggRandomForests/pull/250).
+`time_units` is validated only as "NULL or a single non-empty string"
+(`.check_time_units()`, `R/utils.R`), never against the data it describes, so a
+wrong unit produces a confidently wrong axis title:
+
+```r
+plot(gg_dta, xvar = "age", time_units = "years")  # "Survival at 1191 years"
+```
+
+Both are the same defect: an argument accepted, never validated against the data,
+and reported as neither applied nor rejected. The same class was fixed four times
+in this package during the week of 2026-08-29 (PRs 240, 242, 244) and is filed
+upstream as [kogalur/varPro#7](https://github.com/kogalur/varPro/issues/7).
+
+## Decisions
+
+Four maintainer decisions, 2026-08-31:
+
+1. **Horizon selection is the extractor's job, and only the extractor's.**
+   `plot()` renders whatever the object already contains. Wiring `plot()` up to
+   re-slice was rejected: it duplicates extractor logic in a plot method and lets
+   two places disagree about what a horizon means.
+2. **Remove the formals now, no deprecation cycle.** Not a breaking change to any
+   released version: 4.0.0 is unreleased, there are zero CRAN reverse dependencies,
+   and no caller in `R/`, `tests/` or `vignettes/` passes `time=` to `plot()`.
+3. **Catch the retired names in `...` and redirect.** Removal alone would let
+   `time=` fall into `...` and trip ggplot2's generic `Ignoring unknown parameters`,
+   which points at a geom rather than at the call that works.
+4. **Give `time_units` a narrow, one-directional plausibility check.** Only the
+   case that actually occurred.
+
+## Changes
+
+### 1. Remove `time` and `time_labels`
+
+Delete both formals from the signature and both `@param` entries from the roxygen
+block. Regenerate `man/plot.gg_variable.Rd`.
+
+### 2. Retired-name guard
+
+A new internal helper in `R/utils.R`, called once near the top of
+`plot.gg_variable()`:
+
+```r
+.check_retired_time_args(...)
+```
+
+It inspects `names(list(...))` for `time` and `time_labels` and warns, naming the
+call that works:
+
+> `plot.gg_variable(): 'time' selects a horizon at extraction time, not at plot`
+> `time. Use gg_variable(rf, time = ...) instead.`
+
+A **warning, not an error.** The plot is still correct for the horizon the object
+holds, so aborting would be worse than drawing it with a correction.
+
+The helper must not consume anything from `...`. `plot.gg_variable()` forwards
+`...` to ggplot2 layers, and swallowing an argument it was meant to relay would
+reintroduce the exact defect this change removes.
+
+### 3. `time_units` plausibility check
+
+`.check_time_units()` gains a second, **optional** argument carrying the time
+values:
+
+```r
+.check_time_units(time_units, time_values = NULL)
+```
+
+It warns when a year-like unit (`year`, `years`, `yr`, `yrs`, matched
+case-insensitively) is supplied against values exceeding **150**.
+
+Three details the design review surfaced, each of which would otherwise bite
+during implementation:
+
+- **There are two callers, not one.** `plot.gg_variable()` (`R/plot.gg_variable.R:154`)
+  and `plot.gg_rfsrc()` (`R/plot.gg_rfsrc.R:167`). The new argument defaults to
+  `NULL` so the existing type validation is unchanged for both and neither call
+  site is forced to change.
+- **The time column does not always exist.** `plot.gg_variable()` calls this
+  helper before it branches on family, and only the survival branch has a `time`
+  column. Pass `gg_dta[["time"]]`, which is `NULL` for regression and
+  classification, and skip the plausibility check whenever the values are absent,
+  empty, or not numeric-coercible. The check is opportunistic, never required.
+- **`gg_dta$time` is a factor.** `.survival_at_label()` already calls
+  `as.character()` on it precisely because the integer codes are not the labels.
+  Any magnitude comparison must go through
+  `suppressWarnings(as.numeric(as.character(x)))` and ignore `NA` results, or it
+  will compare factor codes and silently test the wrong thing.
+
+150 sits above any plausible human survival horizon measured in years, with
+margin. It fires on the observed case (a day-scale horizon labelled `"years"`) and
+stays silent on real clinical data.
+
+Warning, never an error: the package cannot know the unit, and a genuinely long
+horizon is conceivable.
+
+**The reverse direction is deliberately not checked.** Small values with `"days"`
+is normal, so there is no reliable signal and a check would be noise. Likewise no
+unit-to-magnitude table beyond the year case; that is speculative until a second
+case appears.
+
+## Testing
+
+Data-carrying assertions, per the repo convention. No `expect_s3_class(p, "ggplot")`
+as a substitute for checking behaviour.
+
+**Retired-name guard** (`tests/testthat/test_gg_variable.R`)
+
+- `plot(gg_dta, xvar = "age", time = 1191)` warns, and the message names `gg_variable(`
+- the same for `time_labels`
+- the returned object is still a valid plot: the warning corrects, it does not abort
+- **a normal call warns about neither.** A guard that fires on everything is as
+  useless as one that fires on nothing, and `...` is rarely empty in a plot method
+- **other `...` arguments still reach the geoms.** `alpha = 0.3` lands in
+  `aes_params`, proving the new inspection does not consume what it inspects
+
+**`time_units` plausibility** (`tests/testthat/test_utils.R`)
+
+- values around 1191 with `"years"` warns
+- values around 1191 with `"days"` is silent
+- values around 3 with `"years"` is silent, the reverse direction we do not check
+- `"Yrs"` and `"YEAR"` warn, confirming case-insensitive matching
+- `time_units = NULL` is silent and unchanged
+- the existing type validation still errors on `character(0)`, `NA` and `""`
+
+## Non-goals
+
+Stated so they do not creep in during implementation:
+
+- No re-slicing in `plot()`. Horizon stays extractor-only.
+- No reverse-direction unit check.
+- No unit-to-magnitude table beyond the year case.
+- `facet_wrap(~time)` and the `gg_dta$time` column are untouched. That facet faces
+  time rather than variables and is not part of this change.
+
+## Definition of done
+
+The repo's standard gate, in order:
+
+```bash
+Rscript -e 'devtools::document()'
+Rscript -e 'lintr::lint_package()'                                  # 0 lints
+NOT_CRAN=true VDIFFR_RUN_TESTS=true Rscript -e 'devtools::test()'    # 0 failures
+```
+
+Then `R CMD check --as-cran` with the manual, from a clean `git archive` export,
+once per PR.
+
+No version bump. 4.0.0 is an unreleased line, so these land as bullets under its
+open NEWS section.

--- a/dev/specs/2026-08-31-plot-gg-variable-time-args-design.md
+++ b/dev/specs/2026-08-31-plot-gg-variable-time-args-design.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-08-31
 **Issue:** [#251](https://github.com/ehrlinger/ggRandomForests/issues/251)
-**Status:** design approved, not yet implemented
+**Status:** implemented in [#260](https://github.com/ehrlinger/ggRandomForests/pull/260)
 **Target version:** 4.0.0 (unreleased development line)
 
 ## Problem

--- a/man/plot.gg_variable.Rd
+++ b/man/plot.gg_variable.Rd
@@ -7,15 +7,13 @@
 \method{plot}{gg_variable}(
   x,
   xvar,
-  time,
-  time_labels,
   panel = FALSE,
   oob = TRUE,
   points = TRUE,
   smooth = TRUE,
   labels = NULL,
-  time_units = NULL,
-  ...
+  ...,
+  time_units = NULL
 )
 }
 \arguments{
@@ -23,10 +21,6 @@
 \code{\link[randomForestSRC]{rfsrc}} object}
 
 \item{xvar}{variable (or list of variables) of interest.}
-
-\item{time}{For survival, one or more times of interest}
-
-\item{time_labels}{string labels for times}
 
 \item{panel}{Should plots be faceted along multiple xvar?}
 
@@ -43,6 +37,8 @@
 name. Applied to the facet strips in the panel plot and to the x axis title
 in the individual plot. Defaults to \code{NULL} (raw names).}
 
+\item{...}{arguments passed to the \code{ggplot2} functions.}
+
 \item{time_units}{Optional name of the time unit the forest was fit in, used
 only in the survival y axis title. The horizon is chosen at
 \code{gg_variable(rf, time = 1191)}; \code{plot(gg_dta)} then titles the
@@ -51,8 +47,6 @@ axis \code{"Survival at 1191"}, and \code{time_units = "days"} makes that
 \code{\link[randomForestSRC]{rfsrc}} object records the unit, so the
 package cannot infer it. Defaults to \code{NULL} (no unit printed). Not
 printed when multiple times are faceted.}
-
-\item{...}{arguments passed to the \code{ggplot2} functions.}
 }
 \value{
 A single \code{ggplot} object when \code{length(xvar) == 1} or

--- a/tests/testthat/test_gg_variable.R
+++ b/tests/testthat/test_gg_variable.R
@@ -832,3 +832,76 @@ test_that("plot.gg_variable regression y label is untouched by the units change"
   gg_plt <- plot(gg_dta, xvar = "Temp")
   expect_false(grepl("Survival at", gg_plt$labels$y, fixed = TRUE))
 })
+
+## ---- retired time / time_labels formals (issue #251) -----------------------
+
+test_that("plot.gg_variable warns and redirects when given the retired time arg", {
+  skip_on_cran()
+  set.seed(42)
+  data(veteran, package = "randomForestSRC")
+  rf <- randomForestSRC::rfsrc(Surv(time, status) ~ ., data = veteran,
+                               ntree = 50, nsplit = 5)
+  gg_dta <- gg_variable(rf, time = 90)
+
+  expect_warning(plot(gg_dta, xvar = "age", time = 1191),
+                 "gg_variable\\(rf, time =")
+  expect_warning(plot(gg_dta, xvar = "age", time_labels = "x"),
+                 "gg_variable\\(rf, time_labels =")
+})
+
+test_that("plot.gg_variable still returns a usable plot after the warning", {
+  skip_on_cran()
+  set.seed(42)
+  data(veteran, package = "randomForestSRC")
+  rf <- randomForestSRC::rfsrc(Surv(time, status) ~ ., data = veteran,
+                               ntree = 50, nsplit = 5)
+  gg_dta <- gg_variable(rf, time = 90)
+
+  # The warning corrects; it must not abort. The plot is still right for the
+  # horizon the object actually holds.
+  p <- suppressWarnings(plot(gg_dta, xvar = "age", time = 1191))
+  expect_s3_class(p, "ggplot")
+})
+
+test_that("plot.gg_variable warns about neither on a normal call", {
+  skip_on_cran()
+  set.seed(20260817L)
+  rf <- randomForestSRC::rfsrc(mpg ~ ., data = mtcars, ntree = 50)
+  gg_dta <- gg_variable(rf)
+
+  expect_warning(suppressMessages(ggplot2::ggplot_build(
+    plot(gg_dta, xvar = "wt"))), regexp = NA)
+})
+
+test_that("plot.gg_variable still forwards other ... arguments to the geoms", {
+  skip_on_cran()
+  set.seed(20260817L)
+  rf <- randomForestSRC::rfsrc(mpg ~ ., data = mtcars, ntree = 50)
+  gg_dta <- gg_variable(rf)
+
+  # Inspecting ... must not consume it: this method relays ... to ggplot2.
+  p <- plot(gg_dta, xvar = "wt", alpha = 0.3)
+  alphas <- vapply(p$layers, function(l) {
+    a <- l$aes_params$alpha
+    if (is.null(a)) NA_real_ else as.numeric(a)
+  }, numeric(1))
+  expect_true(any(!is.na(alphas) & alphas == 0.3))
+})
+
+test_that("plot.gg_variable: 'time' does not partial-match 'time_units'", {
+  skip_on_cran()
+  set.seed(42)
+  data(veteran, package = "randomForestSRC")
+  rf <- randomForestSRC::rfsrc(Surv(time, status) ~ ., data = veteran,
+                               ntree = 50, nsplit = 5)
+  gg_dta <- gg_variable(rf, time = 90)
+
+  # Regression test. With time_units declared BEFORE ..., R matched the retired
+  # 'time' as a prefix of 'time_units', so the call died on time_units' type
+  # check instead of reaching the guard. time_units now sits after ..., where
+  # matching is exact.
+  w <- tryCatch(plot(gg_dta, xvar = "age", time = 1191),
+                warning = function(w) conditionMessage(w))
+  expect_match(w, "selects a horizon at extraction")
+  expect_false(grepl("single non-empty character string", w))
+})

--- a/tests/testthat/test_gg_variable.R
+++ b/tests/testthat/test_gg_variable.R
@@ -905,3 +905,40 @@ test_that("plot.gg_variable: 'time' does not partial-match 'time_units'", {
   expect_match(w, "selects a horizon at extraction")
   expect_false(grepl("single non-empty character string", w))
 })
+
+test_that("plot.gg_variable does not warn 'ignored' on the rfsrc path, where time IS used", {
+  skip_on_cran()
+  set.seed(42)
+  data(veteran, package = "randomForestSRC")
+  rf <- randomForestSRC::rfsrc(Surv(time, status) ~ ., data = veteran,
+                               ntree = 50, nsplit = 5)
+
+  # plot.gg_variable() also accepts a raw rfsrc and forwards ... to
+  # gg_variable(), where 'time' is a real, working parameter. The retired-arg
+  # guard must not fire there: it would report as dead the one path that
+  # honours the argument. Found in review of #260.
+  msgs <- character(0)
+  p <- withCallingHandlers(
+    plot.gg_variable(rf, xvar = "age", time = 90),
+    warning = function(w) {
+      msgs <<- c(msgs, conditionMessage(w))
+      invokeRestart("muffleWarning")
+    }
+  )
+  expect_false(any(grepl("selects a horizon at extraction", msgs)))
+  expect_true(inherits(p, "ggplot") || inherits(p, "patchwork"))
+})
+
+test_that("plot.gg_variable still warns on an already-extracted object", {
+  skip_on_cran()
+  set.seed(42)
+  data(veteran, package = "randomForestSRC")
+  rf <- randomForestSRC::rfsrc(Surv(time, status) ~ ., data = veteran,
+                               ntree = 50, nsplit = 5)
+  gg_dta <- gg_variable(rf, time = 90)
+
+  # The complement of the test above: once extracted, the horizon is baked in
+  # and the argument really is dead, so the guard must still fire.
+  expect_warning(plot(gg_dta, xvar = "age", time = 1191),
+                 "selects a horizon at extraction")
+})

--- a/tests/testthat/test_utils.R
+++ b/tests/testthat/test_utils.R
@@ -21,3 +21,63 @@ test_that(".time_axis_label omits the unit unless one is given", {
   expect_identical(.time_axis_label(NULL), "time")
   expect_identical(.time_axis_label("days"), "time (days)")
 })
+
+## ---- time_units plausibility (issue #251) ----------------------------------
+
+test_that(".check_time_units warns on a year-like unit against day-scale values", {
+  expect_warning(.check_time_units("years", c(30, 90, 1191)), "implausible for years")
+  expect_warning(.check_time_units("yr", c(1191)), "implausible for years")
+})
+
+test_that(".check_time_units matches year-like units case-insensitively", {
+  expect_warning(.check_time_units("Yrs", 1191), "implausible for years")
+  expect_warning(.check_time_units("YEAR", 1191), "implausible for years")
+})
+
+test_that(".check_time_units is silent in the direction we deliberately skip", {
+  # Small values with "days" is ordinary; there is no signal, so no check.
+  expect_silent(.check_time_units("days", c(1, 3, 5)))
+  # Day-scale values labelled days is correct.
+  expect_silent(.check_time_units("days", c(30, 90, 1191)))
+  # Year-scale values labelled years is correct.
+  expect_silent(.check_time_units("years", c(1, 3, 5)))
+})
+
+test_that(".check_time_units compares factor LABELS, not integer codes", {
+  # gg_dta$time is a factor. A single 1191 level has integer code 1, so a naive
+  # comparison would test 1 > 150 and never fire on the case that motivated this.
+  f <- factor(1191)
+  expect_equal(as.integer(f), 1L)                      # the trap
+  expect_warning(.check_time_units("years", f), "implausible for years")
+})
+
+test_that(".check_time_units skips the check when values are absent or unusable", {
+  expect_silent(.check_time_units("years"))            # no values supplied
+  expect_silent(.check_time_units("years", NULL))
+  expect_silent(.check_time_units("years", numeric(0)))
+  expect_silent(.check_time_units("years", factor(c("a", "b"))))  # non-numeric
+})
+
+test_that(".check_time_units keeps its existing type validation", {
+  expect_null(.check_time_units(NULL))
+  expect_equal(.check_time_units("days"), "days")
+  expect_error(.check_time_units(character(0)), "single non-empty")
+  expect_error(.check_time_units(NA_character_), "single non-empty")
+  expect_error(.check_time_units(""), "single non-empty")
+})
+
+## ---- retired time args (issue #251) ----------------------------------------
+
+test_that(".check_retired_time_args warns and names the call that works", {
+  expect_warning(.check_retired_time_args(time = 1191), "gg_variable\\(rf, time =")
+  expect_warning(.check_retired_time_args(time_labels = "a"),
+                 "gg_variable\\(rf, time_labels =")
+})
+
+test_that(".check_retired_time_args is silent on everything else", {
+  # A guard that fires on everything is as useless as one that fires on nothing,
+  # and ... is rarely empty in a plot method.
+  expect_silent(.check_retired_time_args())
+  expect_silent(.check_retired_time_args(alpha = 0.3))
+  expect_silent(.check_retired_time_args(alpha = 0.3, size = 2))
+})


### PR DESCRIPTION
Closes #251. Implements [`dev/specs/2026-08-31-plot-gg-variable-time-args-design.md`](dev/specs/2026-08-31-plot-gg-variable-time-args-design.md), included in this PR.

## What was wrong

`plot.gg_variable()` declared and documented `time` and `time_labels` as formals its body never read. They belong to `gg_variable()`, the extractor, which bakes the horizon into `gg_dta$time` before `plot()` runs. So `?plot.gg_variable` promised a horizon selection the method never performed, and the call was accepted in silence:

```r
gg_dta <- gg_variable(rf, time = 90)
plot(gg_dta, xvar = "age", time = 1191)   # still the 90 plot, no error, no warning
```

## Decisions (maintainer, 2026-08-31)

1. **Horizon selection is the extractor's job, and only the extractor's.** Wiring `plot()` up to re-slice was rejected: it duplicates extractor logic and lets two places disagree about what a horizon means.
2. **Remove now, no deprecation cycle.** Not a breaking change to any released version: `4.0.0` is unreleased, **zero CRAN reverse dependencies**, and no caller in `R/`, `tests/` or `vignettes/` passes `time=` to `plot()`.
3. **Catch the retired names in `...` and redirect**, rather than leaving ggplot2 to emit a generic `Ignoring unknown parameters` that points at a geom.
4. **Give `time_units` a narrow, one-directional plausibility check.**

## Two traps the implementation surfaced

Both are now pinned by tests, and both would have shipped silently.

### Removing `time` did **not** send it to `...`

R partial-matches argument names **only before `...`**, and `time_units` sat ahead of the dots. So `time` matched it as a unique prefix, bound `1191` to `time_units`, and died on its type check:

```
Error: 'time_units' must be NULL or a single non-empty character string.
```

The guard never saw the name. `time_units` now sits **after `...`**, where matching is exact. It always had to be named, so no working call changes.

### `gg_dta$time` is a factor whose integer codes are not its labels

`.survival_at_label()` already calls `as.character()` on it for exactly this reason. A magnitude comparison written the obvious way compares codes, so a single `1191` level reads as `1` and **never fires on the case that motivated the check**. It would have passed its own tests on multi-level data. The comparison goes through `as.character()`, and a test asserts the trap directly:

```r
f <- factor(1191)
expect_equal(as.integer(f), 1L)                      # the trap
expect_warning(.check_time_units("years", f), "implausible for years")
```

## The `time_units` check

Warns when a year-like unit (`year`/`years`/`yr`/`yrs`, case-insensitive) is supplied against values above **150**, which sits above any plausible human survival horizon in years with margin.

**Warning, never an error** — the package cannot know the unit and a long horizon is conceivable. **One direction only**: small values with `"days"` is ordinary, so there is no signal and a check would be noise. **Opportunistic**: the helper is called before the method branches on family, so `gg_dta[["time"]]` is `NULL` for regression and classification and the check simply skips.

## Tests

The two negative cases matter most, because a guard that fires on everything is as useless as one that fires on nothing:

- **a normal call warns about neither**
- **other `...` arguments still reach the geoms** (`alpha = 0.3` lands in `aes_params`) — inspecting `...` must not consume it, since this method relays `...` to ggplot2 layers, and swallowing a relayed argument would reintroduce the exact defect being removed

## Definition of done

| Gate | Result |
|---|---|
| `devtools::document()` | `man/plot.gg_variable.Rd` regenerated, no longer documents the dead args |
| `lintr::lint_package()` | 0 lints |
| Guarded suite | **0 failures, 2,005 pass** (was 1,975) |
| vdiffr baselines | 58 → 58, tree byte-identical |
| `R CMD check --as-cran` with the manual, clean `git archive` | **1 NOTE, 0 WARNING, 0 ERROR**, 3:22 |

No version bump: `4.0.0` is an unreleased line, so these land under its open NEWS section.

⚠️ **Not in `v4.0.0-rc2`.** That tag is on `bf663c51` and published; rolling this in would mean force-moving it to a different tree, so two people could hold the same tag name and different code. Needs an RC3 or the next RC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)