### PR TITLE
RC3 release prep: Date bump and carried-forward UBSAN evidence

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: ggRandomForests
 Type: Package
 Title: Visually Exploring Random Forests
 Version: 4.0.0
-Date: 2026-08-30
+Date: 2026-08-31
 Authors@R: person("John", "Ehrlinger",
   role = c("aut", "cre"),
   email = "john.ehrlinger@gmail.com",

--- a/release-checklist-v4.0.0.md
+++ b/release-checklist-v4.0.0.md
@@ -111,6 +111,37 @@ unsupervised variable priority where that method is discussed.
   This tooling follow-up does not replace or advance any ggRandomForests CRAN
   release gate.
 
+## Verification evidence: 2026-08-31 (internal RC3)
+
+- `main` after [#260](https://github.com/ehrlinger/ggRandomForests/pull/260), zero
+  open pull requests, and **zero open issues**: #229 was closed as already fixed
+  by #231, and #251 closed by #260.
+- `DESCRIPTION` `Date:` bumped `2026-08-30` to `2026-08-31`. Version stays `4.0.0`.
+- `devtools::document()`, `lintr::lint_package()` and
+  `NOT_CRAN=true VDIFFR_RUN_TESTS=true devtools::test()` run in that order.
+  Results recorded at the foot of this section.
+- ⚠️ **The UBSAN gate result is CARRIED FORWARD from RC2, not re-run.** Maintainer
+  decision, 2026-08-31. Recording it as carried forward rather than as a fresh
+  pass, because gate 81's text says "run on the release candidate" and RC3 is a
+  different candidate.
+
+  **Justification.** #260 changes only R code (`R/plot.gg_variable.R`,
+  `R/utils.R`). ggRandomForests has no `src/`, no `LinkingTo` and no
+  `NeedsCompilation`, so it contributes no compiled code at all, and the
+  sanitizer's targets are the `rfsrc`, `varpro` and RHF C paths that this change
+  does not alter.
+
+  ⚠️ **This is an argument about an invariant, not a measurement.** It is weaker
+  evidence than the RC2 carry-forward across `6630516e` to `bf663c51`, where
+  `AGENTS.md` is `.Rbuildignore`d and `git diff` excluding markdown was empty, so
+  the tarball was provably byte-identical. Here the tarball genuinely differs. A
+  future reader should not mistake the two for the same standard.
+
+  The carried result is [run 33288367135](https://github.com/ehrlinger/ggRandomForests/actions/runs/33288367135):
+  calibration observed `entry.c:184`, and the supported paths enumerated exactly
+  one diagnostic, `varPro` `shared/stackAuxiliaryInfo.c:165`
+  ([kogalur/varPro#6](https://github.com/kogalur/varPro/issues/6)).
+
 ## Verification evidence: 2026-08-30 (internal RC2)
 
 - `main` @ `0f0335fe`, zero open pull requests, 110 commits ahead of


### PR DESCRIPTION
Prepares `v4.0.0-rc3`. **Release status stays `HOLD`** — the three remaining gates are all CRAN steps.

## Changes

- **`DESCRIPTION` `Date:`** `2026-08-30` → `2026-08-31`. Version stays `4.0.0`: RC3 is a candidate *of* that version, not a new one. Verified inside the built tarball, not just the working tree.
- **RC3 verification evidence** added to `release-checklist-v4.0.0.md`.

## Gate, run on this branch

Run against `8366488d`, the exact tree this PR merges, rather than against `main`, so the tagged tree is the gated tree.

| Check | Result |
|---|---|
| `devtools::document()` | no drift |
| `lintr::lint_package()` | 0 lints |
| `NOT_CRAN=true VDIFFR_RUN_TESTS=true devtools::test()` | **0 failures, 2,008 pass**, 6 skips |
| vdiffr baselines | 58 → 58, tree byte-identical, no pruning |
| Tarball gate | only `.Rinstignore`; no `cran-comments`; 4.0 MB; `Date: 2026-08-31` |
| `R CMD check --as-cran` with the manual, clean `git archive` | **1 NOTE, 0 WARNING, 0 ERROR**, 3:23 |

## ⚠️ The UBSAN result is carried forward, not re-run

Maintainer decision, 2026-08-31. Recorded in the checklist as **carried forward** rather than as a fresh pass, because gate 81's text says "run on the release candidate" and RC3 is a different candidate.

**Justification.** [#260](https://github.com/ehrlinger/ggRandomForests/pull/260) changes only R code. ggRandomForests has no `src/`, no `LinkingTo` and no `NeedsCompilation`, so it contributes no compiled code, and the sanitizer's targets are the `rfsrc`/`varpro`/RHF C paths this change does not alter.

**Its weakness is recorded alongside it.** This is an argument about an invariant, not a measurement. It is weaker than the RC2 carry-forward across `6630516e`..`bf663c51`, where `AGENTS.md` is `.Rbuildignore`d and `git diff` excluding markdown was empty, so the tarball was *provably* byte-identical. Here the tarball genuinely differs. A future release should not read the two as the same standard of evidence.

Carried result: [run 33288367135](https://github.com/ehrlinger/ggRandomForests/actions/runs/33288367135) — calibration observed `entry.c:184`, supported paths enumerated exactly one diagnostic ([kogalur/varPro#6](https://github.com/kogalur/varPro/issues/6)).

## What RC3 adds over RC2

[#260](https://github.com/ehrlinger/ggRandomForests/pull/260): `plot.gg_variable()`'s dead `time` / `time_labels` formals retired with a guard that redirects to `gg_variable()`, and `time_units` sanity-checked against the data it describes.

**ggRandomForests now has zero open issues.** #229 closed as already fixed by #231; #251 closed by #260.

🤖 Generated with [Claude Code](https://claude.com/claude-code)