### PR TITLE
feat: add scale = "prob_typical" to gg_partial_varpro()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,24 @@ Version: 4.0.0
 
 ggRandomForests v4.0.0 (development)
 ====================================
+* `gg_partial_varpro()` gains `scale = "prob_typical"`. `partialpro()` returns
+  per-subject log-odds, and collapsing them to a curve takes an average and a
+  back-transform; the ORDER is a modelling choice. `"prob"` (unchanged, still
+  the classification default) transforms per observation then averages, giving
+  the mean predicted probability -- the expected proportion of the cohort.
+  `"prob_typical"` averages on the log-odds scale then transforms once, giving
+  the probability for a subject at the mean log-odds.
+
+  They are different estimands and they disagree. The inverse logit is concave
+  above zero and convex below it, so by Jensen `"prob"` is pulled toward 0.5 at
+  both ends, by more the more heterogeneous the cohort. Where the per-subject
+  log-odds carry an SD near 4.5, a point reading 0.96 under `"prob_typical"`
+  reads 0.74 under `"prob"` -- large enough to change how a figure is read, so
+  the choice should be deliberate. A figure captioned as a percentage of
+  patients wants `"prob"`. `?gg_partial_varpro` sets out both.
+
+  The distinction applies only to the `continuous` frame; the `categorical`
+  frame keeps values unaveraged, so both scales return the same numbers there.
 * `plot.gg_partial_varpro()` gains `ylim`, pinning the shared y range across
   panels. It could not be set from outside: on the `panels` route a
   `coord_cartesian()` added with `&` replaces the per-panel coordinate system

--- a/R/gg_partial_varpro.R
+++ b/R/gg_partial_varpro.R
@@ -87,7 +87,8 @@
 #'   \code{varPro::partialpro(object)} for you.  Required when
 #'   \code{scale \%in\% c("surv","chf")}.
 #' @param scale Character; the y-axis scale.  One of \code{"auto"} (default),
-#'   the classification scales \code{"prob"} / \code{"odds"} / \code{"logodds"},
+#'   the classification scales \code{"prob"} / \code{"prob_typical"} /
+#'   \code{"odds"} / \code{"logodds"},
 #'   or the survival scales \code{"rmst"} / \code{"surv"} / \code{"mortality"} /
 #'   \code{"chf"}.  With \code{"auto"}: classification fits resolve to
 #'   \code{"prob"} (probability of the target class) and survival fits to
@@ -252,6 +253,45 @@
 #' \code{causal} contrast is shown only on \code{"logodds"} (see
 #' \code{\link{plot.gg_partial_varpro}}).
 #'
+#' **Two probability scales, and why they disagree (scale = "prob" vs
+#' "prob_typical"):** \code{partialpro} returns a matrix of per-subject
+#' log-odds, one row per observation and one column per grid point. Collapsing
+#' it to a curve takes an average and a back-transform, and the \emph{order}
+#' of those two steps is a modelling choice, not a detail:
+#'
+#' \deqn{\mathrm{prob}(x) = \frac{1}{n}\sum_i \mathrm{logit}^{-1}(z_i(x))
+#'   \qquad
+#'   \mathrm{prob\_typical}(x) = \mathrm{logit}^{-1}\!\left(
+#'   \frac{1}{n}\sum_i z_i(x)\right)}
+#'
+#' \code{"prob"} (the classification default) transforms per observation and
+#' then averages, so the curve is the \strong{mean predicted probability} --
+#' the expected proportion of this cohort, and the standard partial dependence
+#' quantity on a probability scale. \code{"prob_typical"} averages on the
+#' log-odds scale and then transforms once, giving the probability for a
+#' \strong{subject sitting at the mean log-odds}.
+#'
+#' These are different estimands and they do not agree.
+#' \eqn{\mathrm{logit}^{-1}} is concave above zero and convex below it, so by
+#' Jensen's inequality \code{"prob"} is pulled toward \eqn{0.5} relative to
+#' \code{"prob_typical"}, at both ends of the curve. The gap widens with the
+#' spread of per-subject log-odds, and on a heterogeneous cohort it is not
+#' small: where the per-subject log-odds carry an SD near 4.5, a point reading
+#' \eqn{0.96} under \code{"prob_typical"} reads \eqn{0.74} under
+#' \code{"prob"}.
+#'
+#' Which to report is a question about the claim, not about the code. If the
+#' sentence is "what fraction of these patients would wean", that is
+#' \code{"prob"}. If it is "what would we predict for a typical patient", that
+#' is \code{"prob_typical"} -- while remembering that the mean-log-odds
+#' subject need not resemble anyone in the data. A figure captioned as a
+#' percentage of patients wants \code{"prob"}.
+#'
+#' The distinction applies only to the \code{continuous} frame. The
+#' \code{categorical} frame keeps its values unaveraged so the plot method can
+#' draw boxplots, so there is no averaging order to choose and the two scales
+#' return the same numbers there.
+#'
 #' **Survival probability (scale = "surv"):** \code{scale = "surv"} (the
 #' survival default) computes \eqn{S(\tau \mid x)} through \code{partialpro}
 #' (the same UVT engine as mortality and RMST), bounded in \eqn{[0, 1]}.  When
@@ -325,6 +365,13 @@
 #'     yhat.causal = matrix(rnorm(n_obs * 2), nrow = n_obs)
 #'   )
 #' )
+#' ## The two probability scales differ by the ORDER of averaging and
+#' ## back-transform, and disagree whenever subjects are heterogeneous.
+#' pa <- gg_partial_varpro(mock_data, scale = "prob")
+#' pt <- gg_partial_varpro(mock_data, scale = "prob_typical")
+#' head(data.frame(prob = pa$continuous$parametric,
+#'                 prob_typical = pt$continuous$parametric))
+#'
 #' result <- gg_partial_varpro(mock_data, scale = "logodds")
 #' head(result$continuous)
 #' head(result$categorical)
@@ -363,7 +410,8 @@
 #' @export
 gg_partial_varpro <- function(part_dta  = NULL,
                                object    = NULL,
-                               scale     = c("auto", "prob", "odds", "logodds",
+                               scale     = c("auto", "prob", "prob_typical",
+                                             "odds", "logodds",
                                              "rmst", "surv", "mortality", "chf"),
                                time      = NULL,
                                nvars     = NULL,
@@ -754,10 +802,8 @@ gg_partial_varpro <- function(part_dta  = NULL,
     if (length(feat$xvirtual) > cat_limit) {
       plt.df <- dplyr::bind_cols(
         variable      = feat$xvirtual,
-        parametric    = colMeans(.scale_transform(feat$yhat.par,    scale),
-                                 na.rm = TRUE),
-        nonparametric = colMeans(.scale_transform(feat$yhat.nonpar, scale),
-                                 na.rm = TRUE),
+        parametric    = .varpro_column_summary(feat$yhat.par,    scale),
+        nonparametric = .varpro_column_summary(feat$yhat.nonpar, scale),
         # `causal` is a centered contrast: not shown on bounded scales
         causal        = if (bounded) NA_real_ else
           colMeans(feat$yhat.causal, na.rm = TRUE)
@@ -808,6 +854,11 @@ gg_partial_varpro <- function(part_dta  = NULL,
 .scale_transform <- function(z, scale) {
   switch(scale,
     prob = stats::plogis(z),
+    ## Elementwise only. On the categorical frame the values stay unaveraged,
+    ## so "average first" has nothing to bite on and this matches `prob`; the
+    ## two scales differ only on the continuous frame. See
+    ## .varpro_column_summary().
+    prob_typical = stats::plogis(z),
     odds = exp(z),
     z)
 }
@@ -817,7 +868,7 @@ gg_partial_varpro <- function(part_dta  = NULL,
 ## contrast is not shown (it cannot share the axis).
 #' @keywords internal
 .is_bounded_scale <- function(scale) {
-  scale %in% c("prob", "odds", "surv")
+  scale %in% c("prob", "prob_typical", "odds", "surv")
 }
 
 #' @keywords internal
@@ -913,4 +964,28 @@ gg_partial_varpro <- function(part_dta  = NULL,
     path       = "C"
   )
   pd
+}
+
+## Collapse one partialpro matrix (observations x grid points) to one value per
+## grid point.  The ORDER matters and is the whole difference between "prob"
+## and "prob_typical".
+##
+##   prob          mean_i(plogis(z_i))   the mean predicted probability -- the
+##                                       expected proportion of this cohort,
+##                                       and the standard partial dependence
+##                                       quantity on a probability scale.
+##   prob_typical  plogis(mean_i(z_i))   the probability for a subject sitting
+##                                       at the mean log-odds.
+##
+## plogis is concave above 0 and convex below it, so by Jensen these are not
+## the same curve: "prob" is pulled toward 0.5 relative to "prob_typical", and
+## the gap widens with the spread of per-subject log-odds.  On a heterogeneous
+## cohort it is large -- a point where "prob_typical" reads 0.96 can read 0.74
+## under "prob" when the per-subject log-odds carry an SD near 4.5.
+#' @keywords internal
+.varpro_column_summary <- function(mat, scale) {
+  if (identical(scale, "prob_typical")) {
+    return(stats::plogis(colMeans(mat, na.rm = TRUE)))
+  }
+  colMeans(.scale_transform(mat, scale), na.rm = TRUE)
 }

--- a/R/gg_partialpro.R
+++ b/R/gg_partialpro.R
@@ -19,7 +19,12 @@
 #' @export
 gg_partialpro <- function(part_dta,
                           object    = NULL,
-                          scale     = c("auto", "prob", "odds", "logodds",
+                          ## Must stay in step with gg_partial_varpro()'s own
+                          ## choices: this default vector is forwarded whole,
+                          ## and match.arg() there errors on any vector that is
+                          ## not exactly that formal's default.
+                          scale     = c("auto", "prob", "prob_typical",
+                                        "odds", "logodds",
                                         "rmst", "surv", "mortality", "chf"),
                           time      = NULL,
                           nvars     = NULL,

--- a/R/plot.gg_partial_varpro.R
+++ b/R/plot.gg_partial_varpro.R
@@ -533,6 +533,13 @@ plot.gg_partial_varpro <- function(x, # nolint: cyclocomp_linter
   has_tgt <- !is.null(tgt) && !is.na(tgt)
   switch(scale,
     prob      = if (has_tgt) sprintf("P(Y = %s)", tgt) else "Probability",
+    ## Named on the axis, because the difference from "prob" is invisible in
+    ## the curve itself and a reader cannot be expected to infer it.
+    prob_typical = if (has_tgt) {
+      sprintf("P(Y = %s), typical subject", tgt)
+    } else {
+      "Probability, typical subject"
+    },
     odds      = if (has_tgt) sprintf("Odds(Y = %s)", tgt) else "Odds",
     logodds   = if (has_tgt) sprintf("Log-odds(Y = %s)", tgt) else "Log-odds",
     mortality = "Ensemble mortality (expected events)",
@@ -586,7 +593,7 @@ plot.gg_partial_varpro <- function(x, # nolint: cyclocomp_linter
     return(invisible(NULL))
   }
   scale <- if (is.null(prov)) "generic" else (prov$scale %||% "generic")
-  if (!scale %in% c("prob", "surv")) {
+  if (!scale %in% c("prob", "prob_typical", "surv")) {
     stop("plot.gg_partial_varpro: 'complement' needs a probability scale, ",
          "but this object is on the '", scale, "' scale. Re-extract with ",
          "gg_partial_varpro(scale = \"prob\") for a classification fit, or ",

--- a/R/plot.gg_partial_varpro.R
+++ b/R/plot.gg_partial_varpro.R
@@ -594,10 +594,15 @@ plot.gg_partial_varpro <- function(x, # nolint: cyclocomp_linter
   }
   scale <- if (is.null(prov)) "generic" else (prov$scale %||% "generic")
   if (!scale %in% c("prob", "prob_typical", "surv")) {
+    ## Name every scale the guard above accepts.  A message that lists a
+    ## subset sends the caller to the wrong estimand, which on these two is
+    ## not a cosmetic difference.
     stop("plot.gg_partial_varpro: 'complement' needs a probability scale, ",
          "but this object is on the '", scale, "' scale. Re-extract with ",
-         "gg_partial_varpro(scale = \"prob\") for a classification fit, or ",
-         "scale = \"surv\" for a survival fit.", call. = FALSE)
+         "gg_partial_varpro(scale = \"prob\") for the mean predicted ",
+         "probability across subjects, scale = \"prob_typical\" for the ",
+         "probability at the mean log-odds, or scale = \"surv\" for a ",
+         "survival fit.", call. = FALSE)
   }
   invisible(NULL)
 }

--- a/man/gg_partial_varpro.Rd
+++ b/man/gg_partial_varpro.Rd
@@ -8,7 +8,8 @@
 gg_partial_varpro(
   part_dta = NULL,
   object = NULL,
-  scale = c("auto", "prob", "odds", "logodds", "rmst", "surv", "mortality", "chf"),
+  scale = c("auto", "prob", "prob_typical", "odds", "logodds", "rmst", "surv",
+    "mortality", "chf"),
   time = NULL,
   nvars = NULL,
   cat_limit = 10,
@@ -19,7 +20,8 @@ gg_partial_varpro(
 gg_partialpro(
   part_dta,
   object = NULL,
-  scale = c("auto", "prob", "odds", "logodds", "rmst", "surv", "mortality", "chf"),
+  scale = c("auto", "prob", "prob_typical", "odds", "logodds", "rmst", "surv",
+    "mortality", "chf"),
   time = NULL,
   nvars = NULL,
   cat_limit = 10,
@@ -40,7 +42,8 @@ came from.  When supplied it provides the provenance metadata, and when
 \code{scale \%in\% c("surv","chf")}.}
 
 \item{scale}{Character; the y-axis scale.  One of \code{"auto"} (default),
-the classification scales \code{"prob"} / \code{"odds"} / \code{"logodds"},
+the classification scales \code{"prob"} / \code{"prob_typical"} /
+\code{"odds"} / \code{"logodds"},
 or the survival scales \code{"rmst"} / \code{"surv"} / \code{"mortality"} /
 \code{"chf"}.  With \code{"auto"}: classification fits resolve to
 \code{"prob"} (probability of the target class) and survival fits to
@@ -237,6 +240,45 @@ predicted probability, not the probability of the mean log-odds.  The
 \code{causal} contrast is shown only on \code{"logodds"} (see
 \code{\link{plot.gg_partial_varpro}}).
 
+\strong{Two probability scales, and why they disagree (scale = "prob" vs
+"prob_typical"):} \code{partialpro} returns a matrix of per-subject
+log-odds, one row per observation and one column per grid point. Collapsing
+it to a curve takes an average and a back-transform, and the \emph{order}
+of those two steps is a modelling choice, not a detail:
+
+\deqn{\mathrm{prob}(x) = \frac{1}{n}\sum_i \mathrm{logit}^{-1}(z_i(x))
+  \qquad
+  \mathrm{prob\_typical}(x) = \mathrm{logit}^{-1}\!\left(
+  \frac{1}{n}\sum_i z_i(x)\right)}
+
+\code{"prob"} (the classification default) transforms per observation and
+then averages, so the curve is the \strong{mean predicted probability} --
+the expected proportion of this cohort, and the standard partial dependence
+quantity on a probability scale. \code{"prob_typical"} averages on the
+log-odds scale and then transforms once, giving the probability for a
+\strong{subject sitting at the mean log-odds}.
+
+These are different estimands and they do not agree.
+\eqn{\mathrm{logit}^{-1}} is concave above zero and convex below it, so by
+Jensen's inequality \code{"prob"} is pulled toward \eqn{0.5} relative to
+\code{"prob_typical"}, at both ends of the curve. The gap widens with the
+spread of per-subject log-odds, and on a heterogeneous cohort it is not
+small: where the per-subject log-odds carry an SD near 4.5, a point reading
+\eqn{0.96} under \code{"prob_typical"} reads \eqn{0.74} under
+\code{"prob"}.
+
+Which to report is a question about the claim, not about the code. If the
+sentence is "what fraction of these patients would wean", that is
+\code{"prob"}. If it is "what would we predict for a typical patient", that
+is \code{"prob_typical"} -- while remembering that the mean-log-odds
+subject need not resemble anyone in the data. A figure captioned as a
+percentage of patients wants \code{"prob"}.
+
+The distinction applies only to the \code{continuous} frame. The
+\code{categorical} frame keeps its values unaveraged so the plot method can
+draw boxplots, so there is no averaging order to choose and the two scales
+return the same numbers there.
+
 \strong{Survival probability (scale = "surv"):} \code{scale = "surv"} (the
 survival default) computes \eqn{S(\tau \mid x)} through \code{partialpro}
 (the same UVT engine as mortality and RMST), bounded in \eqn{[0, 1]}.  When
@@ -358,6 +400,13 @@ mock_data <- list(
     yhat.causal = matrix(rnorm(n_obs * 2), nrow = n_obs)
   )
 )
+## The two probability scales differ by the ORDER of averaging and
+## back-transform, and disagree whenever subjects are heterogeneous.
+pa <- gg_partial_varpro(mock_data, scale = "prob")
+pt <- gg_partial_varpro(mock_data, scale = "prob_typical")
+head(data.frame(prob = pa$continuous$parametric,
+                prob_typical = pt$continuous$parametric))
+
 result <- gg_partial_varpro(mock_data, scale = "logodds")
 head(result$continuous)
 head(result$categorical)

--- a/tests/testthat/test_gg_partial_varpro.R
+++ b/tests/testthat/test_gg_partial_varpro.R
@@ -1260,3 +1260,55 @@ test_that("plot.gg_partial_varpro: non-numeric scale column → stop", {
   expect_error(plot(pp, type = "parametric", panels = spec),
                regexp = "must be numeric")
 })
+
+## ── scale = "prob_typical": averaging order ─────────────────────────────────
+test_that("gg_partial_varpro: prob_typical is plogis(mean), prob is mean(plogis)", {
+  set.seed(5)
+  n <- 200
+  np <- 12
+  grid <- seq(25, 85, length.out = np)
+  ## Wide per-subject spread, so Jensen has something to bite on.
+  z <- sapply(grid, function(x) rnorm(n, mean = -2 + 0.06 * x, sd = 4.5))
+  md <- list(bpd = list(xvirtual = grid, xorg = runif(n, 25, 85),
+                        yhat.par = z, yhat.nonpar = z,
+                        yhat.causal = matrix(rnorm(n * np), nrow = n)))
+
+  a <- suppressWarnings(gg_partial_varpro(md, scale = "prob"))$continuous
+  b <- suppressWarnings(gg_partial_varpro(md, scale = "prob_typical"))$continuous
+
+  expect_equal(a$parametric, as.numeric(colMeans(stats::plogis(z))))
+  expect_equal(b$parametric, as.numeric(stats::plogis(colMeans(z))))
+
+  ## Jensen: prob is pulled TOWARD 0.5 relative to prob_typical, both ends.
+  hi <- b$parametric > 0.5
+  expect_true(all(a$parametric[hi] < b$parametric[hi]))
+  expect_true(all(a$parametric[!hi] > b$parametric[!hi]))
+
+  ## Both stay in [0, 1].
+  expect_true(all(a$parametric >= 0 & a$parametric <= 1))
+  expect_true(all(b$parametric >= 0 & b$parametric <= 1))
+})
+
+test_that("gg_partial_varpro: prob_typical is bounded, and drops causal", {
+  o <- suppressWarnings(gg_partial_varpro(make_mock_vpro_two_cont(),
+                                          scale = "prob_typical"))
+  expect_true(all(is.na(o$continuous$causal)))
+  expect_equal(attr(o, "provenance")$scale, "prob_typical")
+})
+
+test_that("gg_partial_varpro: the two scales agree on the categorical frame", {
+  ## No averaging happens there, so there is no order to choose.
+  md <- make_mock_vpro_data()
+  a <- suppressWarnings(gg_partial_varpro(md, scale = "prob"))$categorical
+  b <- suppressWarnings(gg_partial_varpro(md, scale = "prob_typical"))$categorical
+  expect_equal(a$parametric, b$parametric)
+})
+
+test_that("plot.gg_partial_varpro: prob_typical labels the axis and takes complement", {
+  o <- suppressWarnings(gg_partial_varpro(make_mock_vpro_two_cont(),
+                                          scale = "prob_typical"))
+  p <- plot(o, which = "continuous", type = "parametric")
+  expect_match(p$labels$y, "typical subject")
+  q <- plot(o, which = "continuous", type = "parametric", complement = TRUE)
+  expect_match(q$labels$y, "^1 - ")
+})

--- a/tests/testthat/test_gg_partial_varpro.R
+++ b/tests/testthat/test_gg_partial_varpro.R
@@ -1312,3 +1312,15 @@ test_that("plot.gg_partial_varpro: prob_typical labels the axis and takes comple
   q <- plot(o, which = "continuous", type = "parametric", complement = TRUE)
   expect_match(q$labels$y, "^1 - ")
 })
+
+test_that("plot.gg_partial_varpro: complement error names every valid scale", {
+  o <- suppressWarnings(gg_partial_varpro(make_mock_vpro_two_cont(),
+                                          scale = "logodds"))
+  msg <- tryCatch(plot(o, complement = TRUE),
+                  error = function(e) conditionMessage(e))
+  ## The guard accepts three scales; a message listing a subset sends the
+  ## caller to the wrong estimand.
+  for (sc in c("prob", "prob_typical", "surv")) {
+    expect_match(msg, sc, fixed = TRUE)
+  }
+})


### PR DESCRIPTION
## Problem

`partialpro()` returns per-subject log-odds — one row per observation, one column per grid point. Collapsing that to a curve takes an average and a back-transform, and the **order** of the two is a modelling choice, not a detail:

```
prob          mean_i(plogis(z_i))    transform per subject, then average
prob_typical  plogis(mean_i(z_i))    average log-odds, then transform once
```

Only `"prob"` existed. A caller wanting the second had to leave the package and hand-roll `mutate(odds = exp(parametric), prob = odds / (1 + odds))` on the averaged column — which is exactly what the manuscript figure that prompted this did, for years, without anyone noticing the two were different.

## They disagree, and not slightly

`plogis` is concave above 0 and convex below it, so by Jensen's inequality `"prob"` is pulled **toward 0.5 at both ends**, by more the wider the per-subject spread.

Measured on the real fit that surfaced this, switching a figure from the hand-rolled `prob_typical` arithmetic to `scale = "prob"`:

| | prob_typical | prob |
|---|---|---|
| Diastolic BP @ 85 | 0.96 | 0.74 |
| VIS @ 46 | 0.28 | 0.40 |

Every panel moved toward the middle. The implied per-subject log-odds SD is about 4.5 — a cohort that splits hard at the extremes. That is large enough to change how a clinician reads the figure, so `?gg_partial_varpro` now sets out both estimands and says which claim each supports: a figure captioned as a percentage of patients wants `"prob"`; a "typical patient" curve wants `"prob_typical"`, while remembering the mean-log-odds subject need not resemble anyone in the data.

## Implementation

This is an averaging **order**, not another transform function, so it gets its own summary path in `.varpro_column_summary()` rather than another branch of `.scale_transform()`. The elementwise branch still exists because the `categorical` frame keeps values unaveraged for boxplots — there the two scales necessarily agree, and a test pins that.

`prob_typical` is a bounded scale, so it suppresses the `causal` contrast like `prob` does, and `plot(complement = TRUE)` accepts it.

## One break the suite caught that review would not have

`gg_partialpro()`, the deprecated shim, carries **its own copy** of the `scale` choices vector and forwards it whole. `match.arg()` in the callee errors on any vector that is not exactly that formal's default, so the shim broke the instant the callee gained a choice:

```
Error in `match.arg(scale)`: 'arg' must be of length 1
```

Synced, with a comment marking the coupling so the next person adding a scale sees it.

## Verification

- `devtools::document()`, `lintr::lint_package()` → **0 lints**
- `NOT_CRAN=true VDIFFR_RUN_TESTS=true devtools::test()` → **2079 pass, 0 fail** (2068 on `main`)
- 60 vdiffr baselines intact, none deleted
- Four new tests: the two identities checked directly against `colMeans(plogis(z))` and `plogis(colMeans(z))`; the Jensen direction asserted at both ends; the categorical frames asserted equal; the axis label and `complement` on the new scale

`R CMD check --as-cran` is running from a clean `git archive` export; I will post the result.

## Compatibility

Additive. `"prob"` is unchanged and remains the classification default, so no existing call moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)