### PR TITLE
chore: keep vdiffr baselines out of the CRAN source tarball

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -80,3 +80,9 @@ Rplots\.pdf$
 (^|/)\.remember$
 (^|/)\.Rhistory$
 (^|/)\.DS_Store$
+
+# vdiffr baselines. They are visual-regression fixtures for local and CI runs,
+# never read on CRAN: R CMD check runs with NOT_CRAN false and test_snapshots.R
+# registers nothing unless VDIFFR_RUN_TESTS is "true", which no check sets. They
+# stay in git; only the built tarball loses them.
+^tests/testthat/_snaps$


### PR DESCRIPTION
One line in `.Rbuildignore`. **The measured saving is 0.43 MB, not the ~3 MB the uncompressed figures suggest** — SVG is text and compresses about 7×. Worth reading that before deciding this is worth a rule.

## Premise, verified rather than assumed

The 63 SVGs under `tests/testthat/_snaps` are 3.05 MB uncompressed and are never compared on CRAN:

- `test_snapshots.R:19` wraps **all 61** `test_that` blocks in `identical(Sys.getenv("VDIFFR_RUN_TESTS"), "true")`, so when it is unset they are never *registered* — they do not even appear as skips.
- `R CMD check` runs with `NOT_CRAN` false, and the three CI check workflows set `VDIFFR_RUN_TESTS: "false"` deliberately.
- The as-cran check log confirms it empirically: `test_snapshots.R` is absent from the executed files, `FAIL 0 | WARN 8 | SKIP 153 | PASS 1603` against `PASS 2068` locally with the guard on.

The check that could have killed this: `.Renviron` inverts the unset default to `"true"`. Had it shipped, the snapshots would run during check and the baselines would be genuinely needed. It is `.Rbuildignore`'d and absent from the tarball, and there is no `~/.Renviron` entry.

## Measured

Both builds from a clean `git archive` export, per `AGENTS.md`.

| | tarball | check |
|---|---|---|
| `main` (88893fb7) | 4.02 MB | Status: 1 NOTE |
| this branch | 3.59 MB | Status: 1 NOTE |
| | **−0.43 MB (−11%)** | unchanged |

Against CRAN's 5 MB limit that moves headroom from 0.98 MB to 1.41 MB, a 44% increase, and the tree grows with every new plot method — 58 to 60 baselines in the last week alone.

## The property that has to hold

`.Rbuildignore` acts at `R CMD build`, not at `git archive`, so all 63 SVGs stay in the repo and remain available to local and CI runs. Verified with a full local suite on this branch: **60 baselines before and after, 2068 pass, 0 fail, no deletions in `git status`**.

## One behaviour change, and it is the correct one

The preservation test at `test_snapshots.R:638` — which announces each baseline so testthat's cleanup does not orphan them — now skips under check with `no vdiffr baselines present to preserve`. There are none in the tarball to protect, so there is nothing for it to do. It still runs locally and in CI where the tree exists. This is the `SKIP 153 → 154` in the check log.

## Not changed

`gg-rfsrc-survival-no-ci.svg` is 1024 KB because `gg_rfsrc(rfsrc_pbc)` draws one survival curve per subject — 322 polylines, 75,837 coordinate pairs. That is intrinsic to the plot; shrinking it would mean testing a smaller plot than the one users get.

## Judgement call

11% is real but modest, and it buys a `.Rbuildignore` rule someone has to understand later. The comment in the file explains why the tree is excluded and that it stays in git. Reasonable to decline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)