### PR TITLE
Adopt randomForestRHF 2.0.3 cumulative-hazard semantics

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -49,7 +49,7 @@ Suggests:
     pkgload,
     quarto,
     ragg,
-    randomForestRHF (>= 2.0.0),
+    randomForestRHF (>= 2.0.3),
     RColorBrewer,
     rmarkdown,
     testthat,

--- a/NEWS.md
+++ b/NEWS.md
@@ -103,22 +103,25 @@ ggRandomForests v4.0.0 (development)
   `treesize / metric / value / se / selected`; the plot marks the selected
   size and draws an iAUC standard-error ribbon only when finite supplied iAUC
   standard errors are available. `gg_tune_rhf()` never recalculates tuning.
-* Require `randomForestRHF (>= 2.0.0)` in Suggests, and adopt its revised
+* Require `randomForestRHF (>= 2.0.3)` in Suggests, and adopt its revised
   hazard semantics. From 2.0.0 the pointwise hazard is defined only where a
   grid point falls inside one of the case's supplied `(start, stop]`
-  intervals, and is `NA` in gaps and after the final stop; the cumulative
-  hazard is unaffected, because it accumulates the exact interval overlap and
-  stays flat across those regions. `auct.rhf()` can likewise return an `NA`
-  AUC at the final grid time, where the censoring-weight denominator is
-  undefined once the control set is nearly exhausted. `gg_rhf()` passes the
-  mask through unchanged, so `hazard` may be `NA` where it previously was not;
-  `plot.gg_rhf()` and `plot.gg_auct()` drop those cells before drawing, so a
-  hazard curve now ends with its case's follow-up instead of reporting removed
-  missing values on every plot. 2.0.0 also changes the default hazard
-  aggregation (`adaptive = TRUE`), which shifts fitted values; four RHF vdiffr
-  baselines and the precomputed vignette analysis were regenerated against it.
-  This resolves issue #229, where the earlier reading (a small negative hazard,
-  specific to the macOS arm64 binary) was wrong on both counts.
+  intervals, and is `NA` in gaps and after the final stop. 2.0.0 left the
+  cumulative hazard unmasked; 2.0.3 masks it as well, on its own rule, setting
+  it to `NA` after each case's final stop while still holding it flat through
+  an internal gap. The two masks therefore coincide on a fit whose cases carry
+  a single interval each, and come apart only with time-dependent covariates.
+  `auct.rhf()` can likewise return an `NA` AUC at the final grid time, where
+  the censoring-weight denominator is undefined once the control set is nearly
+  exhausted. `gg_rhf()` passes both masks through unchanged, so `hazard` and
+  `chf` may be `NA` where they previously were not; `plot.gg_rhf()` and
+  `plot.gg_auct()` drop those cells before drawing, so a curve now ends with
+  its case's follow-up instead of reporting removed missing values on every
+  plot. 2.0.0 also changes the default hazard aggregation (`adaptive = TRUE`),
+  which shifts fitted values; four RHF vdiffr baselines and the precomputed
+  vignette analysis were regenerated against it. This resolves issue #229,
+  where the earlier reading (a small negative hazard, specific to the macOS
+  arm64 binary) was wrong on both counts.
 * The RHF vignette drops its cumulative/dynamic AUC section for now and keeps
   the incident/dynamic one. Holding the in-sample cumulative hazard flat after
   follow-up makes it track observation length as well as risk, which pushes

--- a/R/gg_auct.R
+++ b/R/gg_auct.R
@@ -33,7 +33,7 @@
 #' arXiv:2608.21597. \doi{10.48550/arXiv.2608.21597}.
 #'
 #' Ishwaran H, Kogalur UB (2026). \emph{randomForestRHF: Random Hazard
-#' Forests}. R package version 2.0.0.
+#' Forests}. R package version 2.0.3.
 #' \url{https://CRAN.R-project.org/package=randomForestRHF}.
 #'
 #' @note

--- a/R/gg_rhf.R
+++ b/R/gg_rhf.R
@@ -15,21 +15,25 @@
 #'   `id`, `time`, `hazard`, `chf`, `source`, an integer `ntime` attribute
 #'   (number of grid points), and a `provenance` attribute.
 #'
-#'   The frame always has `ntime` rows per case. `hazard` may be `NA`: from
-#'   \pkg{randomForestRHF} 2.0.0 the pointwise hazard is defined only where a
-#'   grid point falls inside one of the case's supplied `(start, stop]`
-#'   intervals, and is `NA` in gaps and after the final stop time. `chf` is not
-#'   masked. It accumulates the exact interval overlap, so it stays flat across
-#'   those regions. The values are passed through unchanged; use
-#'   `na.rm = TRUE` when summarising `hazard`, or see [plot.gg_rhf()], which
-#'   drops the masked cells before drawing.
+#'   The frame always has `ntime` rows per case. Both `hazard` and `chf` may be
+#'   `NA`, and they are masked on different rules. From \pkg{randomForestRHF}
+#'   2.0.0 the pointwise hazard is defined only where a grid point falls inside
+#'   one of the case's supplied `(start, stop]` intervals, and is `NA` in gaps
+#'   and after the final stop time. From 2.0.3 the cumulative hazard is `NA`
+#'   after each case's final stop, but stays flat through an internal gap
+#'   rather than going missing there. So on a fit whose cases each have a
+#'   single interval the two masks look the same, and with time-dependent
+#'   covariates they do not. Earlier versions carried `chf` across the whole
+#'   grid. The values are passed through unchanged; use `na.rm = TRUE` when
+#'   summarising either column, or see [plot.gg_rhf()], which drops the masked
+#'   cells before drawing.
 #'
 #' @references
 #' Ishwaran H, Hsich EM, Kogalur UB, Lee DKK (2026). Random Hazard Forests.
 #' arXiv:2608.21597. \doi{10.48550/arXiv.2608.21597}.
 #'
 #' Ishwaran H, Kogalur UB (2026). \emph{randomForestRHF: Random Hazard
-#' Forests}. R package version 2.0.0.
+#' Forests}. R package version 2.0.3.
 #' \url{https://CRAN.R-project.org/package=randomForestRHF}.
 #'
 #' @seealso [plot.gg_rhf()], [randomForestRHF::rhf()]

--- a/R/gg_rhf_importance.R
+++ b/R/gg_rhf_importance.R
@@ -54,7 +54,7 @@
 #' arXiv:2608.21597. \doi{10.48550/arXiv.2608.21597}.
 #'
 #' Ishwaran H, Kogalur UB (2026). \emph{randomForestRHF: Random Hazard
-#' Forests}. R package version 2.0.0.
+#' Forests}. R package version 2.0.3.
 #' \url{https://CRAN.R-project.org/package=randomForestRHF}.
 #'
 #' @seealso [plot.gg_rhf_importance()], [randomForestRHF::importance.rhf()]

--- a/R/gg_tune_rhf.R
+++ b/R/gg_tune_rhf.R
@@ -39,7 +39,7 @@
 #' arXiv:2608.21597. \doi{10.48550/arXiv.2608.21597}.
 #'
 #' Ishwaran H, Kogalur UB (2026). \emph{randomForestRHF: Random Hazard
-#' Forests}. R package version 2.0.0.
+#' Forests}. R package version 2.0.3.
 #' \url{https://CRAN.R-project.org/package=randomForestRHF}.
 #'
 #' @seealso [plot()],

--- a/R/help.R
+++ b/R/help.R
@@ -148,7 +148,7 @@
 #' arXiv:2608.21597. \doi{10.48550/arXiv.2608.21597}.
 #'
 #' Ishwaran H, Kogalur UB (2026). \emph{randomForestRHF: Random Hazard
-#' Forests}. R package version 2.0.0.
+#' Forests}. R package version 2.0.3.
 #' \url{https://CRAN.R-project.org/package=randomForestRHF}
 #'
 #' Wickham, H. ggplot2: elegant graphics for data analysis. Springer New York,

--- a/R/plot.gg_rhf.R
+++ b/R/plot.gg_rhf.R
@@ -8,8 +8,11 @@
 #' \pkg{randomForestRHF} 2.0.0 the hazard is `NA` outside each case's observed
 #' `(start, stop]` path, so a hazard curve simply ends with that case's
 #' follow-up, and a case whose hazard is masked throughout is left out of the
-#' legend rather than shown as an empty one. Cumulative hazard carries no such
-#' mask, so `hazard.only = FALSE` draws every grid point.
+#' legend rather than shown as an empty one. From 2.0.3 the cumulative hazard
+#' is masked too, though on a different rule: it is `NA` after each case's
+#' final stop, and stays flat through an internal gap. So `hazard.only = FALSE`
+#' also ends each curve with that case's follow-up, but it keeps the grid
+#' points a gap would have cost the hazard panel.
 #'
 #' @param x A `gg_rhf` object from [gg_rhf()].
 #' @param idx Integer vector of case ids (matched against the `id` column) to
@@ -61,8 +64,10 @@ plot.gg_rhf <- function(x, idx = NULL, hazard.only = TRUE, ...) {
   # values it reports as removed rows on every hazard plot: the curve is
   # identical either way, it simply ends with the case's follow-up. Filtering
   # before factor() also keeps a case whose hazard is entirely masked out of
-  # the legend instead of leaving it there as an empty level. chf carries no
-  # mask, so this is a no-op when hazard.only = FALSE.
+  # the legend instead of leaving it there as an empty level. Since 2.0.3 chf
+  # is masked as well (NA after each case's final stop, flat through internal
+  # gaps), so this filter applies to both columns; it is not a no-op when
+  # hazard.only = FALSE, and it drops fewer rows there on a fit with gaps.
   dropped <- !is.finite(dta[[yvar]])
   if (all(dropped)) {
     warning("no finite ", yvar, " values remain for the requested idx.",

--- a/man/ggRandomForests-package.Rd
+++ b/man/ggRandomForests-package.Rd
@@ -136,7 +136,7 @@ Ishwaran H, Hsich EM, Kogalur UB, Lee DKK (2026). Random Hazard Forests.
 arXiv:2608.21597. \doi{10.48550/arXiv.2608.21597}.
 
 Ishwaran H, Kogalur UB (2026). \emph{randomForestRHF: Random Hazard
-Forests}. R package version 2.0.0.
+Forests}. R package version 2.0.3.
 \url{https://CRAN.R-project.org/package=randomForestRHF}
 
 Wickham, H. ggplot2: elegant graphics for data analysis. Springer New York,

--- a/man/gg_auct.Rd
+++ b/man/gg_auct.Rd
@@ -84,7 +84,7 @@ Ishwaran H, Hsich EM, Kogalur UB, Lee DKK (2026). Random Hazard Forests.
 arXiv:2608.21597. \doi{10.48550/arXiv.2608.21597}.
 
 Ishwaran H, Kogalur UB (2026). \emph{randomForestRHF: Random Hazard
-Forests}. R package version 2.0.0.
+Forests}. R package version 2.0.3.
 \url{https://CRAN.R-project.org/package=randomForestRHF}.
 }
 \seealso{

--- a/man/gg_rhf.Rd
+++ b/man/gg_rhf.Rd
@@ -23,14 +23,18 @@ A \code{data.frame} of class \code{c("gg_rhf", "data.frame")} with columns
 \code{id}, \code{time}, \code{hazard}, \code{chf}, \code{source}, an integer \code{ntime} attribute
 (number of grid points), and a \code{provenance} attribute.
 
-The frame always has \code{ntime} rows per case. \code{hazard} may be \code{NA}: from
-\pkg{randomForestRHF} 2.0.0 the pointwise hazard is defined only where a
-grid point falls inside one of the case's supplied \verb{(start, stop]}
-intervals, and is \code{NA} in gaps and after the final stop time. \code{chf} is not
-masked. It accumulates the exact interval overlap, so it stays flat across
-those regions. The values are passed through unchanged; use
-\code{na.rm = TRUE} when summarising \code{hazard}, or see \code{\link[=plot.gg_rhf]{plot.gg_rhf()}}, which
-drops the masked cells before drawing.
+The frame always has \code{ntime} rows per case. Both \code{hazard} and \code{chf} may be
+\code{NA}, and they are masked on different rules. From \pkg{randomForestRHF}
+2.0.0 the pointwise hazard is defined only where a grid point falls inside
+one of the case's supplied \verb{(start, stop]} intervals, and is \code{NA} in gaps
+and after the final stop time. From 2.0.3 the cumulative hazard is \code{NA}
+after each case's final stop, but stays flat through an internal gap
+rather than going missing there. So on a fit whose cases each have a
+single interval the two masks look the same, and with time-dependent
+covariates they do not. Earlier versions carried \code{chf} across the whole
+grid. The values are passed through unchanged; use \code{na.rm = TRUE} when
+summarising either column, or see \code{\link[=plot.gg_rhf]{plot.gg_rhf()}}, which drops the masked
+cells before drawing.
 }
 \description{
 Extracts case-specific ensemble hazard and cumulative-hazard estimates from
@@ -55,7 +59,7 @@ Ishwaran H, Hsich EM, Kogalur UB, Lee DKK (2026). Random Hazard Forests.
 arXiv:2608.21597. \doi{10.48550/arXiv.2608.21597}.
 
 Ishwaran H, Kogalur UB (2026). \emph{randomForestRHF: Random Hazard
-Forests}. R package version 2.0.0.
+Forests}. R package version 2.0.3.
 \url{https://CRAN.R-project.org/package=randomForestRHF}.
 }
 \seealso{

--- a/man/gg_rhf_importance.Rd
+++ b/man/gg_rhf_importance.Rd
@@ -91,7 +91,7 @@ Ishwaran H, Hsich EM, Kogalur UB, Lee DKK (2026). Random Hazard Forests.
 arXiv:2608.21597. \doi{10.48550/arXiv.2608.21597}.
 
 Ishwaran H, Kogalur UB (2026). \emph{randomForestRHF: Random Hazard
-Forests}. R package version 2.0.0.
+Forests}. R package version 2.0.3.
 \url{https://CRAN.R-project.org/package=randomForestRHF}.
 }
 \seealso{

--- a/man/gg_tune_rhf.Rd
+++ b/man/gg_tune_rhf.Rd
@@ -72,7 +72,7 @@ Ishwaran H, Hsich EM, Kogalur UB, Lee DKK (2026). Random Hazard Forests.
 arXiv:2608.21597. \doi{10.48550/arXiv.2608.21597}.
 
 Ishwaran H, Kogalur UB (2026). \emph{randomForestRHF: Random Hazard
-Forests}. R package version 2.0.0.
+Forests}. R package version 2.0.3.
 \url{https://CRAN.R-project.org/package=randomForestRHF}.
 }
 \seealso{

--- a/man/plot.gg_rhf.Rd
+++ b/man/plot.gg_rhf.Rd
@@ -29,8 +29,11 @@ Cells the forest left undefined are dropped before drawing. From
 \pkg{randomForestRHF} 2.0.0 the hazard is \code{NA} outside each case's observed
 \verb{(start, stop]} path, so a hazard curve simply ends with that case's
 follow-up, and a case whose hazard is masked throughout is left out of the
-legend rather than shown as an empty one. Cumulative hazard carries no such
-mask, so \code{hazard.only = FALSE} draws every grid point.
+legend rather than shown as an empty one. From 2.0.3 the cumulative hazard
+is masked too, though on a different rule: it is \code{NA} after each case's
+final stop, and stays flat through an internal gap. So \code{hazard.only = FALSE}
+also ends each curve with that case's follow-up, but it keeps the grid
+points a gap would have cost the hazard panel.
 }
 \examples{
 \donttest{

--- a/tests/testthat/_snaps/snapshots/gg-auct-chf.svg
+++ b/tests/testthat/_snaps/snapshots/gg-auct-chf.svg
@@ -27,33 +27,43 @@
 </defs>
 <g clip-path='url(#cpMzUuMjR8NzE0LjUyfDIyLjc4fDUzMS43NQ==)'>
 <rect x='35.24' y='22.78' width='679.28' height='508.97' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<polyline points='35.24,486.60 714.52,486.60 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='35.24,350.56 714.52,350.56 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='35.24,214.53 714.52,214.53 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='35.24,78.49 714.52,78.49 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='35.24,460.18 714.52,460.18 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='35.24,363.31 714.52,363.31 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='35.24,266.45 714.52,266.45 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='35.24,169.58 714.52,169.58 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='35.24,72.71 714.52,72.71 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='127.85,531.75 127.85,22.78 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='327.63,531.75 327.63,22.78 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='527.41,531.75 527.41,22.78 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='35.24,418.58 714.52,418.58 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='35.24,282.55 714.52,282.55 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='35.24,146.51 714.52,146.51 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='35.24,508.62 714.52,508.62 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='35.24,411.75 714.52,411.75 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='35.24,314.88 714.52,314.88 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='35.24,218.01 714.52,218.01 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='35.24,121.15 714.52,121.15 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='35.24,24.28 714.52,24.28 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='227.74,531.75 227.74,22.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='427.52,531.75 427.52,22.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='627.31,531.75 627.31,22.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polygon points='66.11,45.92 105.47,93.88 174.40,149.58 199.57,167.43 243.72,174.70 298.86,182.63 363.99,216.82 448.50,272.00 544.00,347.09 683.64,414.81 683.64,508.62 544.00,455.61 448.50,382.22 363.99,297.37 298.86,288.05 243.72,295.04 199.57,266.21 174.40,236.92 105.47,203.92 66.11,154.54 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #333333; fill-opacity: 0.20;' />
-<polyline points='66.11,45.92 105.47,93.88 174.40,149.58 199.57,167.43 243.72,174.70 298.86,182.63 363.99,216.82 448.50,272.00 544.00,347.09 683.64,414.81 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
-<polyline points='683.64,508.62 544.00,455.61 448.50,382.22 363.99,297.37 298.86,288.05 243.72,295.04 199.57,266.21 174.40,236.92 105.47,203.92 66.11,154.54 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
-<polyline points='66.11,100.23 105.47,148.90 174.40,193.25 199.57,216.82 243.72,234.87 298.86,235.34 363.99,257.10 448.50,327.11 544.00,401.35 683.64,461.71 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
-<line x1='35.24' y1='350.56' x2='714.52' y2='350.56' style='stroke-width: 1.07; stroke: #7F7F7F; stroke-dasharray: 5.69,5.69; stroke-linecap: butt;' />
+<polygon points='66.11,45.92 105.47,46.52 174.40,69.47 199.57,102.49 243.72,113.94 298.86,86.79 363.99,98.81 448.50,123.65 544.00,146.67 683.64,162.68 683.64,283.74 544.00,264.10 448.50,221.98 363.99,171.34 298.86,175.46 243.72,189.00 199.57,200.45 174.40,215.17 105.47,198.80 66.11,144.66 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #333333; fill-opacity: 0.20;' />
+<polyline points='66.11,45.92 105.47,46.52 174.40,69.47 199.57,102.49 243.72,113.94 298.86,86.79 363.99,98.81 448.50,123.65 544.00,146.67 683.64,162.68 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<polyline points='683.64,283.74 544.00,264.10 448.50,221.98 363.99,171.34 298.86,175.46 243.72,189.00 199.57,200.45 174.40,215.17 105.47,198.80 66.11,144.66 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<polyline points='66.11,95.29 105.47,122.66 174.40,142.32 199.57,151.47 243.72,151.47 298.86,131.13 363.99,135.08 448.50,172.81 544.00,205.38 683.64,223.21 ' style='stroke-width: 1.07; stroke-linecap: butt;' />
+<line x1='35.24' y1='508.62' x2='714.52' y2='508.62' style='stroke-width: 1.07; stroke: #7F7F7F; stroke-dasharray: 5.69,5.69; stroke-linecap: butt;' />
 <rect x='35.24' y='22.78' width='679.28' height='508.97' style='stroke-width: 1.07; stroke: #333333;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
-<text x='30.31' y='421.61' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.4</text>
-<text x='30.31' y='285.57' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.6</text>
-<text x='30.31' y='149.54' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.8</text>
-<polyline points='32.50,418.58 35.24,418.58 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='32.50,282.55 35.24,282.55 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='32.50,146.51 35.24,146.51 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='30.31' y='511.64' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<text x='30.31' y='414.78' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.6</text>
+<text x='30.31' y='317.91' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.7</text>
+<text x='30.31' y='221.04' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.8</text>
+<text x='30.31' y='124.17' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.9</text>
+<text x='30.31' y='27.31' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<polyline points='32.50,508.62 35.24,508.62 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='32.50,411.75 35.24,411.75 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='32.50,314.88 35.24,314.88 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='32.50,218.01 35.24,218.01 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='32.50,121.15 35.24,121.15 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='32.50,24.28 35.24,24.28 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
 <polyline points='227.74,534.49 227.74,531.75 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
 <polyline points='427.52,534.49 427.52,531.75 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
 <polyline points='627.31,534.49 627.31,531.75 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
@@ -63,6 +73,6 @@
 <text x='374.88' y='554.87' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='24.45px' lengthAdjust='spacingAndGlyphs'>Time</text>
 <text transform='translate(13.05,277.27) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='33.61px' lengthAdjust='spacingAndGlyphs'>AUC(t)</text>
 <text x='35.24' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='166.53px' lengthAdjust='spacingAndGlyphs'>Time-varying AUC (cumhaz)</text>
-<text x='714.52' y='568.69' text-anchor='end' style='font-size: 8.80px; font-family: sans;' textLength='200.41px' lengthAdjust='spacingAndGlyphs'>iAUC (Uno) = 0.431  |  iAUC (standardized) = 0.452</text>
+<text x='714.52' y='568.69' text-anchor='end' style='font-size: 8.80px; font-family: sans;' textLength='200.41px' lengthAdjust='spacingAndGlyphs'>iAUC (Uno) = 0.818  |  iAUC (standardized) = 0.661</text>
 </g>
 </svg>

--- a/tests/testthat/_snaps/snapshots/gg-rhf-chf.svg
+++ b/tests/testthat/_snaps/snapshots/gg-rhf-chf.svg
@@ -27,50 +27,39 @@
 </defs>
 <g clip-path='url(#cpMzUuMjR8NjYwLjA1fDIyLjc4fDU0NS4xMQ==)'>
 <rect x='35.24' y='22.78' width='624.82' height='522.33' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<polyline points='35.24,470.36 660.05,470.36 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='35.24,356.67 660.05,356.67 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='35.24,242.99 660.05,242.99 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='35.24,129.31 660.05,129.31 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='107.52,545.11 107.52,22.78 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='249.52,545.11 249.52,22.78 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='391.53,545.11 391.53,22.78 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='533.53,545.11 533.53,22.78 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='35.24,527.20 660.05,527.20 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='35.24,413.51 660.05,413.51 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='35.24,299.83 660.05,299.83 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='35.24,186.15 660.05,186.15 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='35.24,72.47 660.05,72.47 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='36.52,545.11 36.52,22.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='178.52,545.11 178.52,22.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='320.52,545.11 320.52,22.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='462.53,545.11 462.53,22.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='604.53,545.11 604.53,22.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='63.64,357.94 91.61,154.78 140.60,149.90 158.50,149.90 189.88,149.90 229.07,149.90 275.37,149.90 335.43,149.90 403.31,149.90 502.57,149.90 631.65,149.90 ' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt;' />
-<polyline points='63.64,521.37 91.61,493.35 140.60,467.80 158.50,418.60 189.88,351.69 229.07,308.96 275.37,266.70 335.43,266.70 403.31,266.70 502.57,266.70 631.65,266.70 ' style='stroke-width: 1.07; stroke: #00BA38; stroke-linecap: butt;' />
-<polyline points='63.64,520.18 91.61,501.30 140.60,484.13 158.50,477.79 189.88,468.44 229.07,460.06 275.37,441.62 335.43,413.64 403.31,382.15 502.57,187.48 631.65,46.53 ' style='stroke-width: 1.07; stroke: #619CFF; stroke-linecap: butt;' />
+<polyline points='35.24,455.29 660.05,455.29 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='35.24,308.04 660.05,308.04 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='35.24,160.79 660.05,160.79 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='120.42,545.11 120.42,22.78 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='304.19,545.11 304.19,22.78 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='487.95,545.11 487.95,22.78 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='35.24,528.92 660.05,528.92 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='35.24,381.67 660.05,381.67 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='35.24,234.42 660.05,234.42 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='35.24,87.17 660.05,87.17 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='212.30,545.11 212.30,22.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='396.07,545.11 396.07,22.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='579.83,545.11 579.83,22.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='63.64,309.68 99.84,46.53 ' style='stroke-width: 1.07; stroke: #F8766D; stroke-linecap: butt;' />
+<polyline points='63.64,521.37 99.84,485.08 163.24,451.99 186.39,388.25 227.01,301.59 277.72,246.23 ' style='stroke-width: 1.07; stroke: #00BA38; stroke-linecap: butt;' />
+<polyline points='63.64,519.83 99.84,495.37 163.24,473.13 186.39,464.92 227.01,452.81 277.72,441.96 337.63,418.07 415.36,381.83 503.20,341.03 631.65,88.89 ' style='stroke-width: 1.07; stroke: #619CFF; stroke-linecap: butt;' />
 <rect x='35.24' y='22.78' width='624.82' height='522.33' style='stroke-width: 1.07; stroke: #333333;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
-<text x='30.31' y='530.22' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.0</text>
-<text x='30.31' y='416.54' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.2</text>
-<text x='30.31' y='302.86' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.4</text>
-<text x='30.31' y='189.18' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.6</text>
-<text x='30.31' y='75.50' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.8</text>
-<polyline points='32.50,527.20 35.24,527.20 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='32.50,413.51 35.24,413.51 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='32.50,299.83 35.24,299.83 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='32.50,186.15 35.24,186.15 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='32.50,72.47 35.24,72.47 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='36.52,547.85 36.52,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='178.52,547.85 178.52,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='320.52,547.85 320.52,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='462.53,547.85 462.53,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='604.53,547.85 604.53,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
-<text x='36.52' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>0</text>
-<text x='178.52' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='19.58px' lengthAdjust='spacingAndGlyphs'>1000</text>
-<text x='320.52' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='19.58px' lengthAdjust='spacingAndGlyphs'>2000</text>
-<text x='462.53' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='19.58px' lengthAdjust='spacingAndGlyphs'>3000</text>
-<text x='604.53' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='19.58px' lengthAdjust='spacingAndGlyphs'>4000</text>
+<text x='30.31' y='531.94' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.0</text>
+<text x='30.31' y='384.69' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.2</text>
+<text x='30.31' y='237.44' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.4</text>
+<text x='30.31' y='90.19' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.6</text>
+<polyline points='32.50,528.92 35.24,528.92 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='32.50,381.67 35.24,381.67 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='32.50,234.42 35.24,234.42 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='32.50,87.17 35.24,87.17 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='212.30,547.85 212.30,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='396.07,547.85 396.07,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='579.83,547.85 579.83,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='212.30' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='19.58px' lengthAdjust='spacingAndGlyphs'>1000</text>
+<text x='396.07' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='19.58px' lengthAdjust='spacingAndGlyphs'>2000</text>
+<text x='579.83' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='19.58px' lengthAdjust='spacingAndGlyphs'>3000</text>
 <text x='347.65' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='24.45px' lengthAdjust='spacingAndGlyphs'>Time</text>
 <text transform='translate(13.05,283.95) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='91.73px' lengthAdjust='spacingAndGlyphs'>Cumulative hazard</text>
 <rect x='671.01' y='244.88' width='43.51' height='78.13' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />

--- a/tests/testthat/test_gg_rhf.R
+++ b/tests/testthat/test_gg_rhf.R
@@ -18,21 +18,26 @@ test_that("gg_rhf.rhf returns a tidy long frame over time.interest", {
   expect_setequal(unique(gg$time), o$time.interest)
   expect_equal(unique(gg$source), "oob")
   expect_true(all(gg$hazard >= 0, na.rm = TRUE))
-  expect_true(all(is.finite(gg$chf) & gg$chf >= 0))
+  expect_true(all(gg$chf >= 0, na.rm = TRUE))
+  expect_true(all(is.finite(gg$chf[!is.na(gg$chf)])))
 })
 
-test_that("gg_rhf carries the rhf hazard NA mask through unchanged", {
+test_that("gg_rhf carries both rhf NA masks through unchanged", {
   o  <- .rhf_pbc()
   gg <- gg_rhf(o)
   # randomForestRHF >= 2.0.0 defines the pointwise hazard only where the grid
   # point falls inside one of the case's supplied (start, stop] intervals, and
-  # returns NA in gaps and after the final stop. chf is unaffected: it
-  # accumulates the exact interval overlap, so it stays flat across those
-  # regions rather than going NA. gg_rhf is a passthrough, so the mask has to
-  # arrive in the frame unrepaired, undropped and in column-major order.
+  # returns NA in gaps and after the final stop. From 2.0.3 chf is masked too,
+  # but on its own rule: NA after each case's final stop, flat through internal
+  # gaps. The two masks coincide on this fixture, whose cases each carry a
+  # single interval, and would differ on a fit with real time-dependent
+  # covariates. So assert each against its own source matrix rather than
+  # against the other. gg_rhf is a passthrough, so both masks have to arrive in
+  # the frame unrepaired, undropped and in column-major order.
   expect_identical(is.na(gg$hazard), as.vector(is.na(o$hazard.oob)))
+  expect_identical(is.na(gg$chf), as.vector(is.na(o$chf.oob)))
   expect_true(all(is.finite(gg$hazard[!is.na(gg$hazard)])))
-  expect_false(anyNA(gg$chf))
+  expect_true(all(is.finite(gg$chf[!is.na(gg$chf)])))
 })
 
 test_that("gg_rhf source='inbag' selects the inbag matrices", {

--- a/tests/testthat/test_plot_gg_rhf.R
+++ b/tests/testthat/test_plot_gg_rhf.R
@@ -42,11 +42,33 @@ test_that("plot.gg_rhf drops the NA hazard cells instead of warning", {
   expect_false(anyNA(ld$y))
 })
 
-test_that("plot.gg_rhf hazard.only = FALSE keeps every chf row", {
-  # chf carries no NA mask, so the cumulative-hazard panel must not lose rows
-  # to the hazard-side filter.
-  gg <- gg_rhf(.rhf_pbc())
-  p  <- plot(gg, idx = c(1, 5, 10), hazard.only = FALSE)
-  ld <- ggplot2::layer_data(p)
-  expect_equal(nrow(ld), 3L * attr(gg, "ntime"))
+test_that("plot.gg_rhf hazard.only = FALSE keeps every unmasked chf row", {
+  # From randomForestRHF 2.0.3 chf is NA after each case's final stop, so the
+  # cumulative-hazard panel loses those cells and no others.
+  idx <- c(1, 5, 10)
+  gg  <- gg_rhf(.rhf_pbc())
+  p   <- plot(gg, idx = idx, hazard.only = FALSE)
+  ld  <- ggplot2::layer_data(p)
+  expect_equal(nrow(ld), sum(!is.na(gg$chf[gg$id %in% idx])))
+  expect_false(anyNA(ld$y))
+})
+
+test_that("plot.gg_rhf filters on the column it draws, not on hazard", {
+  # The two masks coincide on the .rhf_pbc() fixture, whose cases each carry a
+  # single interval, so it cannot catch a panel filtered by the wrong column.
+  # With time-dependent covariates they come apart: randomForestRHF 2.0.3 holds
+  # chf flat through an internal gap while the hazard goes NA there. Build that
+  # shape directly rather than fitting a forest to reach it.
+  gg <- data.frame(
+    id     = rep(1L, 4L),
+    time   = c(1, 2, 3, 4),
+    hazard = c(0.1, NA, 0.3, NA),   # NA in an internal gap and after the stop
+    chf    = c(0.1, 0.1, 0.4, NA),  # flat through the gap, NA after the stop
+    source = "oob"
+  )
+  attr(gg, "ntime") <- 4L
+  class(gg) <- c("gg_rhf", "data.frame")
+
+  expect_equal(nrow(ggplot2::layer_data(plot(gg))), 2L)
+  expect_equal(nrow(ggplot2::layer_data(plot(gg, hazard.only = FALSE))), 3L)
 })

--- a/vignettes/rhf.qmd
+++ b/vignettes/rhf.qmd
@@ -289,10 +289,15 @@ grid. `gg_rhf()` passes those `NA` values through unchanged, and `plot()` drops
 them before drawing, so a curve covers the range the forest was asked about and
 no more.
 
-Cumulative hazard is not masked this way. It accumulates the exact overlap
-between the working grid and the supplied records, so it stays flat through a
-gap rather than going missing, and the panel below draws every grid point. If
-you summarize `hazard` yourself, remember to pass `na.rm = TRUE`.
+Cumulative hazard is masked too, but on a different rule, and version 2.0.3
+changed it. It accumulates the exact overlap between the working grid and the
+supplied records, so it stays flat through a gap between two records rather
+than going missing there. After a subject's final stop, though, there is no
+more overlap to accumulate, and from 2.0.3 the value is `NA` instead of the
+last level carried forward. So the cumulative-hazard panel below ends each
+curve where the hazard panel does, and the difference between the two masks
+only shows up on a fit with time-dependent covariates, where the gaps are real.
+If you summarize either column yourself, remember to pass `na.rm = TRUE`.
 
 ### Cumulative hazard adds the local rates
 


### PR DESCRIPTION
`randomForestRHF` 2.0.3 reached CRAN on 2026-09-01 and changed what `chf` contains. Three tests encoded the 2.0.0 invariant and now fail on every CI platform. This adopts the new semantics.

## What broke, and why it is not #267

[#267](https://github.com/ehrlinger/ggRandomForests/pull/267) adds three files under `.github/ISSUE_TEMPLATE/` and nothing else, yet five R CMD check jobs went red on it. It was simply the first build after the upstream release. `main` was last green on 2026-08-31 against 2.0.0, so `main` carries the same latent failure and has not run since.

From the 2.0.3 NEWS:

> counting-process fits keep hazards NA outside supplied paths, keep CHF flat through internal gaps, and set CHF to NA after each subject's final stop.

2.0.0 masked only `hazard`. 2.0.3 masks `chf` as well, on its own rule.

| Test | Asserted | Under 2.0.3 |
|---|---|---|
| `test_gg_rhf.R:21` | `all(is.finite(chf) & chf >= 0)` | FALSE, trailing NAs |
| `test_gg_rhf.R:35` | `expect_false(anyNA(chf))` | NAs present |
| `test_plot_gg_rhf.R:51` | `nrow(ld) == 3 * ntime` | 18, not 33 |

## No behaviour change here

`gg_rhf()` is a passthrough, and `plot.gg_rhf()` already filters on `dta[[yvar]]`, the column it is about to draw. Both were correct before and after. What was wrong was the documented contract: the roxygen, the vignette and the tests all asserted that `chf` carries no mask.

## Two choices worth a look

**Each mask is asserted against its own source matrix, not against the other.** `.rhf_pbc()` converts static-covariate pbc to counting-process form, so every case carries exactly one interval and has no internal gaps. The hazard mask and the chf mask are therefore byte-identical on this fixture. `expect_identical(is.na(chf), is.na(hazard))` would pass forever while pinning an artifact of the fixture rather than the upstream rule.

**A second plot test builds the gap case as a literal 4-row frame.** The bug class worth guarding is a panel filtered by the wrong column's mask, and the fixture cannot detect it for the reason above. With time-dependent covariates the masks come apart, so that shape is constructed directly rather than chased through a forest fit that would cost seconds and still might not produce a gap.

## Also regenerated: `gg-auct-chf`

Not anticipated. 2.0.3 also corrects cumulative/dynamic `auct.rhf()`, so the AUC values moved. They now span 0.79 to 0.93 with nothing below the chance line, which is the inversion reported as kogalur/randomForestRHF#1 being fixed upstream.

The vignette's deferred cumulative/dynamic AUC section is therefore un-blockable, but that is **not** in this PR. It needs its own verification and possibly a regenerated precomputed analysis. Filed separately.

## Verification

Run in the order `AGENTS.md` sets out:

- `devtools::document()` clean.
- `lintr::lint_package()` reports **0 lints**.
- `NOT_CRAN=true VDIFFR_RUN_TESTS=true devtools::test()` gives **FAIL 0 | WARN 58 | SKIP 6 | PASS 2087**, from FAIL 3 | PASS 2011.
- All **60 vdiffr baselines intact**, zero deletions. Two modified, both accounted for above.
- `R CMD check --as-cran` with the manual, built from a clean `git archive` export: **1 NOTE**, the standard incoming-feasibility maintainer note (8 updates in 6 months). 154s of timed steps, top costs vignette rebuild 45s and `--run-donttest` 33s.
- Tarball gate: only `ggRandomForests/.Rinstignore` matches the hidden-file grep, `cran-comments` count 0, 3.6M.

No version bump. v4.0.0 is unreleased, so the NEWS bullet lands under the existing heading, and rather than adding a second bullet contradicting the first, the existing `randomForestRHF` bullet was revised to describe the end state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)