### PR TITLE
Guard cumulative/dynamic AUC against randomForestRHF < 2.0.3

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -124,6 +124,16 @@ ggRandomForests v4.0.0 (development)
   resolves issue #229, where the earlier reading (a small negative hazard,
   specific to the macOS arm64 binary) was wrong on both counts, and
   kogalur/randomForestRHF#1, the inverted cumulative/dynamic AUC.
+* `gg_auct()` now errors rather than compute a cumulative/dynamic AUC it knows
+  to be wrong. `DESCRIPTION` asks for `randomForestRHF (>= 2.0.3)`, but R does
+  not enforce a `Suggests` version at run time, so a session still carrying
+  2.0.0 previously got the inverted curve with no warning. The check is
+  deliberately narrow: it applies only to `method = "cumulative"`, since the
+  incident definition never inherited the problem, and only when `gg_auct()`
+  does the computation. A supplied `auct_fit` is taken as given, because an
+  `auct.rhf` object records no version and may have been read from a file
+  built elsewhere. The message names the installed version and points at
+  `method = "incident"` as the alternative.
 * `gg_auct()` gains a `method` argument and now forwards `...` to
   `randomForestRHF::auct.rhf()`. `auct.rhf()` defaults `method` to
   `"cumulative"`, and `gg_auct()` previously passed only `marker`, so the

--- a/R/gg_auct.R
+++ b/R/gg_auct.R
@@ -47,13 +47,14 @@
 #'
 #' Cumulative/dynamic AUC was unreliable under \pkg{randomForestRHF} 2.0.0,
 #' which could push the curve below the 0.5 chance line on data the forest
-#' fits well. That was an upstream problem, fixed in 2.0.3. `DESCRIPTION` asks
-#' for 2.0.3 in `Suggests`, but R does not enforce a `Suggests` version at run
-#' time, and `gg_auct()` checks only that the package is installed. A session
-#' that still has 2.0.0 will return the old inverted curve with no warning, so
-#' check `packageVersion("randomForestRHF")` before trusting a
-#' cumulative/dynamic result. `gg_auct()` passes the values through unchanged
-#' in every case.
+#' fits well. That was an upstream problem, fixed in 2.0.3. R does not enforce
+#' a `Suggests` version at run time, so `gg_auct()` checks the installed
+#' version itself and errors rather than compute a cumulative/dynamic curve it
+#' knows to be wrong. The check applies only when `gg_auct()` does the
+#' computation: `method = "incident"` is unaffected by the upstream problem and
+#' is never gated, and a supplied `auct_fit` is taken as given, since an
+#' `auct.rhf` object records no version and may have been read from a file.
+#' `gg_auct()` passes the values through unchanged in every case.
 #'
 #' @seealso [plot.gg_auct()], [randomForestRHF::auct.rhf()]
 #'
@@ -73,6 +74,33 @@ gg_auct <- function(object, ...) {
   UseMethod("gg_auct", object)
 }
 
+# Cumulative/dynamic AUC is wrong before randomForestRHF 2.0.3: that release
+# corrected auct.rhf() to reconstruct common-time markers from the retained
+# tree-level arrays. Before it, the in-sample cumulative hazard was held flat
+# after follow-up, so the marker tracked observation length as well as risk and
+# the curve could sit below the chance line on data the forest fits well.
+#
+# DESCRIPTION asks for >= 2.0.3 in Suggests, but R does not enforce a Suggests
+# version at run time, so a session carrying an older build would otherwise get
+# the inverted curve with no warning.
+#
+# Only the cumulative definition is gated. Incident/dynamic compares subjects
+# within a risk set at t, before any has left follow-up, and is unaffected
+# (measured identical at 0.531 across 2.0.0 and 2.0.3).
+#
+# `version` is a parameter rather than read here so the guard is testable
+# without a downgraded install.
+.stop_if_auct_cumulative_unsupported <- function(method, version) {
+  if (identical(method, "cumulative") &&
+        version < package_version("2.0.3")) {
+    stop("gg_auct(method = \"cumulative\") needs randomForestRHF >= 2.0.3. ",
+         "Version ", version, " is installed, and returns an inverted ",
+         "cumulative/dynamic AUC. Update randomForestRHF, or use ",
+         "method = \"incident\", which is unaffected.", call. = FALSE)
+  }
+  invisible(NULL)
+}
+
 #' @rdname gg_auct
 #' @export
 gg_auct.rhf <- function(object, marker = c("chf", "haz"), auct_fit = NULL,
@@ -85,6 +113,9 @@ gg_auct.rhf <- function(object, marker = c("chf", "haz"), auct_fit = NULL,
       stop("Install the 'randomForestRHF' package to use gg_auct(): ",
            "install.packages('randomForestRHF')", call. = FALSE)
     }
+    .stop_if_auct_cumulative_unsupported(
+      method, utils::packageVersion("randomForestRHF")
+    )
     auct_fit <- randomForestRHF::auct.rhf(object, marker = marker,
                                           method = method, ...)
   }

--- a/man/gg_auct.Rd
+++ b/man/gg_auct.Rd
@@ -60,13 +60,14 @@ rather than as a check on each other.
 
 Cumulative/dynamic AUC was unreliable under \pkg{randomForestRHF} 2.0.0,
 which could push the curve below the 0.5 chance line on data the forest
-fits well. That was an upstream problem, fixed in 2.0.3. \code{DESCRIPTION} asks
-for 2.0.3 in \code{Suggests}, but R does not enforce a \code{Suggests} version at run
-time, and \code{gg_auct()} checks only that the package is installed. A session
-that still has 2.0.0 will return the old inverted curve with no warning, so
-check \code{packageVersion("randomForestRHF")} before trusting a
-cumulative/dynamic result. \code{gg_auct()} passes the values through unchanged
-in every case.
+fits well. That was an upstream problem, fixed in 2.0.3. R does not enforce
+a \code{Suggests} version at run time, so \code{gg_auct()} checks the installed
+version itself and errors rather than compute a cumulative/dynamic curve it
+knows to be wrong. The check applies only when \code{gg_auct()} does the
+computation: \code{method = "incident"} is unaffected by the upstream problem and
+is never gated, and a supplied \code{auct_fit} is taken as given, since an
+\code{auct.rhf} object records no version and may have been read from a file.
+\code{gg_auct()} passes the values through unchanged in every case.
 }
 \examples{
 \donttest{

--- a/tests/testthat/test_gg_auct.R
+++ b/tests/testthat/test_gg_auct.R
@@ -76,3 +76,58 @@ test_that("gg_auct ignores method and ... when auct_fit is supplied", {
   gg <- gg_auct(o, marker = "chf", method = "incident", auct_fit = fit)
   expect_equal(attr(gg, "iauc")$uno, fit$iAUC.uno)
 })
+
+test_that("the cumulative/dynamic version guard gates only what it should", {
+  # randomForestRHF < 2.0.3 returns an inverted cumulative/dynamic AUC, and a
+  # Suggests version is not enforced at run time, so gg_auct() checks it. The
+  # guard takes the version as an argument precisely so this can be exercised
+  # without a downgraded install.
+  guard <- ggRandomForests:::.stop_if_auct_cumulative_unsupported
+
+  # Gated: the affected definition on an affected version.
+  for (v in c("1.0.1", "2.0.0", "2.0.2")) {
+    expect_error(
+      guard("cumulative", package_version(v)),
+      "needs randomForestRHF >= 2.0.3"
+    )
+  }
+
+  # Not gated: fixed versions, including a later one.
+  for (v in c("2.0.3", "2.1.0", "3.0.0")) {
+    expect_silent(guard("cumulative", package_version(v)))
+    expect_null(guard("cumulative", package_version(v)))
+  }
+
+  # Not gated: the incident definition never inherited the problem, so gating
+  # it would break working code.
+  for (v in c("2.0.0", "2.0.3")) {
+    expect_silent(guard("incident", package_version(v)))
+  }
+})
+
+test_that("the version guard names the installed version and a way out", {
+  guard <- ggRandomForests:::.stop_if_auct_cumulative_unsupported
+  msg <- tryCatch(
+    guard("cumulative", package_version("2.0.0")),
+    error = function(e) conditionMessage(e)
+  )
+  expect_match(msg, "2.0.0", fixed = TRUE)
+  expect_match(msg, "method = \"incident\"", fixed = TRUE)
+})
+
+test_that("gg_auct.rhf still calls the version guard on the compute path", {
+  # The guard's logic is tested directly above, which would keep passing if the
+  # call site were dropped in a refactor. Pin that it is still wired in, and
+  # still inside the branch that computes rather than the one that accepts a
+  # supplied auct_fit.
+  txt <- paste(
+    deparse(body(ggRandomForests:::gg_auct.rhf)), collapse = "\n"
+  )
+  expect_match(txt, ".stop_if_auct_cumulative_unsupported", fixed = TRUE)
+  compute_branch <- sub(
+    ".*is\\.null\\(auct_fit\\)", "", sub("inherits\\(auct_fit.*", "", txt)
+  )
+  expect_match(
+    compute_branch, ".stop_if_auct_cumulative_unsupported", fixed = TRUE
+  )
+})


### PR DESCRIPTION
Follow-up to [#269](https://github.com/ehrlinger/ggRandomForests/pull/269), where Copilot pointed out that `?gg_auct` claimed a version requirement nothing enforced. Deferred from that PR because it changes the behaviour of an exported function.

## The gap

`DESCRIPTION` asks for `randomForestRHF (>= 2.0.3)` in `Suggests`, but R does not enforce a `Suggests` version at run time, and `gg_auct.rhf()` checked only that the package was installed. A session still carrying 2.0.0 got the inverted cumulative/dynamic curve with no warning. The docs described the hazard; nothing prevented it.

```r
gg_auct(fit, marker = "chf", method = "cumulative")
#> Error: gg_auct(method = "cumulative") needs randomForestRHF >= 2.0.3.
#>   Version 2.0.0 is installed, and returns an inverted cumulative/dynamic
#>   AUC. Update randomForestRHF, or use method = "incident", which is
#>   unaffected.
```

## Three deliberate limits

Each of these would otherwise be a false alarm that breaks working code:

| Path | Gated | Why |
|---|---|---|
| compute + `method = "cumulative"` | **yes** | the affected case |
| compute + `method = "incident"` | no | never inherited the problem, measured identical at 0.531 across 2.0.0 and 2.0.3 |
| supplied `auct_fit` | no | an `auct.rhf` object records no version and may have been read from a file built elsewhere, so the installed version says nothing about it |

That last row matters concretely: the RHF vignette supplies `auct_fit` from a saved `.rds`, so a guard on that path would fire on provenance it cannot actually see.

## Errors rather than warns

The failure mode is a silently inverted scientific result, which is worse than a stop, and the remedy is one line and named in the message. `DESCRIPTION` already declares the floor; this makes the declared contract real. Because the gate is narrow, it cannot break incident users or anyone supplying a precomputed fit.

## Making a version check testable

Reading `packageVersion()` inline would have made this untestable without a downgraded install, and mocking another package's function is not workable on testthat edition 2, which this package uses. The check therefore takes the version as an argument, so the logic is a pure function that can be hit with fabricated versions.

That split has a cost: the logic tests would keep passing if a refactor dropped the call site. So the coverage is in two halves.

- **Logic**, over gated versions (1.0.1, 2.0.0, 2.0.2), ungated ones (2.0.3, 2.1.0, 3.0.0), that `"incident"` is never gated, and that the message names both the installed version and the way out.
- **Call site**, pinned structurally inside the compute branch, in the same spirit as `test_determinism.R` parsing the suite. **Mutation-tested**: removing the call gives FAIL 2, restoring it gives FAIL 0. A structural test that cannot fail is worse than none.

I also verified the wiring directly by rebinding the guard in the namespace to an always-error stub: reached on both compute paths, not reached when `auct_fit` is supplied.

## Verification

- `devtools::document()` clean; `lintr::lint_package()` **0 lints**.
- `NOT_CRAN=true VDIFFR_RUN_TESTS=true devtools::test()` gives **FAIL 0 | WARN 58 | SKIP 6 | PASS 2102**, up from 2087.
- **60 vdiffr baselines intact, 0 deletions, 0 modifications.**
- `R CMD check --as-cran` with the manual, from a clean `git archive` export of this exact commit: **1 NOTE**, the standard incoming-feasibility maintainer note. 158s of timed steps.
- Tarball: only `ggRandomForests/.Rinstignore` matches the hidden-file grep.

`?gg_auct` is updated, since its previous note said the check did not exist. No version bump: v4.0.0 is unreleased, so the NEWS bullet lands under the existing heading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)