### PR TITLE
test: zero-diagonal sdependent mock for varPro 3.2.1

### DIFF
--- a/tests/testthat/test_gg_sdependent.R
+++ b/tests/testthat/test_gg_sdependent.R
@@ -5,13 +5,15 @@
 # tests run on CRAN with skip_if_not_installed("varPro"); only the live
 # uvarpro() grow is skip_on_cran().
 
-# A get.beta.entropy()-shaped matrix: square, named, NA diagonal.
+# A get.beta.entropy()-shaped matrix: square, named, zero diagonal.
+# varPro >= 3.2.1 sdependent() rejects non-finite entries, and live
+# get.beta.entropy() output carries 0 (not NA) for self-links.
 .mock_entropy_sq <- function() {
   v <- c("a", "b", "c", "d")
-  matrix(c(NA, .6, .1, .7,
-           .5, NA, .2, .8,
-           .1, .3, NA, .2,
-           .6, .7, .1, NA),
+  matrix(c(0, .6, .1, .7,
+           .5, 0, .2, .8,
+           .1, .3, 0, .2,
+           .6, .7, .1, 0),
          nrow = 4, byrow = TRUE, dimnames = list(v, v))
 }
 .stub_uvarpro <- function(ntree = 50L) {


### PR DESCRIPTION
## Summary

The varPro 3.2.1 candidate on `kogalur/varPro@develop` (`6ff9099`) adds input validation to `sdependent()`: `'I' must contain finite, nonnegative values.` The `.mock_entropy_sq()` fixture in `test_gg_sdependent.R` used an `NA` diagonal, so 10 tests in that file errored against the candidate. Udaya Kogalur flagged the incompatibility ahead of the varPro release.

Live `get.beta.entropy()` output carries `0`, not `NA`, for self-links (checked on both 3.2.0 and 3.2.1), so the mock now uses a zero diagonal. It is a test-only change, and `R/` is untouched: `gg_sdependent()` on a real `uvarpro` fit already works on 3.2.1.

## Verification

| | varPro 3.2.0 (CRAN) | varPro 3.2.1 (develop) |
|---|---|---|
| `test_gg_sdependent.R` before | pass | **10 errors** |
| `test_gg_sdependent.R` after | pass (34) | pass (34) |
| varPro-related set, 14 files plus snapshots | 0 fail, 22 warn, 2 skip | 0 fail, 22 warn, 2 skip |

- On both versions the mock returns identical `imp.score` and `signal.vars` with a zero diagonal and with an `NA` diagonal (3.2.0 only for NA), so the test expectations still mean the same thing.
- The warnings are identical on both versions: loess near-singularity messages that were already there.
- `lintr::lint_package()` reports 0 lints. `git status` was clean after every run and no vdiffr baselines were touched.
- 3.2.1 was built into a scratch library, so the installed 3.2.0 was left alone.

No version bump. This changes a test only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)