### PR TITLE
docs: seed the survival vignette so builds are reproducible

### DIFF
--- a/vignettes/ggRandomForests-survival.qmd
+++ b/vignettes/ggRandomForests-survival.qmd
@@ -374,9 +374,9 @@ plot(gg_vimp(rfsrc_pbc), labels = st_labs) +
   labs(fill = "VIMP > 0")
 ```
 
-Bilirubin ranks highest, followed by copper, prothrombin time, albumin, and age
---- closely matching the variables selected in the @fleming:1991 proportional
-hazards model.
+Bilirubin ranks highest, followed by edema, ascites, albumin, copper, age, and
+prothrombin time --- closely matching the variables selected in the
+@fleming:1991 proportional hazards model.
 
 ## Minimal depth
 
@@ -392,9 +392,10 @@ The `max.subtree()` function computes minimal depth for each variable. The
 threshold is `r round(md_pbc$threshold, 2)`, selecting
 `r length(md_pbc$topvars)` variables: `r paste(md_pbc$topvars, collapse = ", ")`.
 
-Both selection methods agree on the key predictors: `bili`, `albumin`, `copper`,
-`prothrombin`, and `age`. We add `edema` (selected by the @fleming:1991 model)
-for the remainder of the analysis.
+Both selection methods agree on the key continuous predictors: `bili`,
+`albumin`, `copper`, `prothrombin`, and `age`. Both also rank the categorical
+`edema` and `ascites` highly; we carry `edema` (selected by the @fleming:1991
+model) forward for the remainder of the analysis.
 
 ```{r select-vars}
 xvar     <- c("bili", "albumin", "copper", "prothrombin", "age")
@@ -658,8 +659,9 @@ We have walked a full random survival forest analysis with
   the PBC trial, the same conclusion reached in @fleming:1991.
 - `gg_error()` showed the OOB error settling quickly as trees were added.
 - VIMP (`gg_vimp()`) and minimal depth (`max.subtree()`) landed on the same
-  five predictors (bilirubin, albumin, copper, prothrombin, and age),
-  which is also where the proportional hazards model landed.
+  five continuous predictors (bilirubin, albumin, copper, prothrombin, and
+  age), plus edema and ascites, largely where the proportional hazards model
+  landed.
 - `gg_variable()` exposed non-proportional hazards for bilirubin and copper,
   where the gap between time horizons widens.
 - Partial dependence from `gg_partial_rfsrc()` gave the risk-adjusted version

--- a/vignettes/ggRandomForests-survival.qmd
+++ b/vignettes/ggRandomForests-survival.qmd
@@ -276,6 +276,7 @@ complete imputed data. This keeps the fitted forest object free of imputation
 state, which is required for `partial.rfsrc()` to work correctly.
 
 ```{r rfsrc-fit}
+set.seed(42)
 # Step 1: impute missing values via random forest proximity
 pbc_imputed <- impute.rfsrc(Surv(years, status) ~ .,
                              data    = pbc_trial,


### PR DESCRIPTION
## Why

`ggRandomForests-survival.qmd` was the only vignette with no `set.seed()`. Its forests grew from an unseeded RNG, so two builds of identical source rendered different text (on 2026-09-10 the `max.subtree()` threshold came out as 5.9/8 vars in one build and 5.97/7 vars in the other, and the printed CRPS as 1.419 vs 1.404). Each build was internally consistent; the problem was reproducibility and noisy tarball diffs.

## What

- `set.seed(42)` as the first line of the `rfsrc-fit` chunk, the same pattern as the classification and regression vignettes (one seed before the fit, no `seed =` to `rfsrc()`). That chunk is the first RNG consumer (`impute.rfsrc()` then `rfsrc()`), and knitr runs chunks in order, so the downstream `predict(na.action = "na.impute")` is also fixed.
- Three prose passages quoted results literally rather than interpolating them, and they did not match the seeded fit:
  - VIMP order: now bili, edema, ascites, albumin, copper, age, prothrombin (the old text had copper and prothrombin second and third).
  - The minimal-depth follow-up and the conclusion now name edema and ascites alongside the five continuous predictors, since both methods rank those two highly. The analysis code (`xvar`, `xvar_cat`) is unchanged.

## Verification

- Two independent `R CMD build`s from `git archive` exports: the survival vignette's rendered text is **identical**. The HTML is byte-identical once base64 image payloads are masked. The remaining byte differences are inside the PNGs and show up in **every** vignette, including the six that already seed, so it's PNG encoding, not RNG. `DESCRIPTION` differs only by `Packaged:`.
- The seeded values (threshold 5.81; topvars age, ascites, edema, bili, chol, albumin, copper, prothrombin; CRPS 1.440241) come from the build and were reproduced by a standalone replay of the chunks.
- `devtools::document()`: no changes. `lintr::lint_package()`: 0 lints.
- `NOT_CRAN=true VDIFFR_RUN_TESTS=true devtools::test()`: 0 failed, 0 errors, 2169 passed, 6 skipped. All 6 skips are deliberate and predate this change. `git status` was clean before and after (no baseline pruning).
- `R CMD check --as-cran` (with the manual) from a clean export: 0 errors, 0 warnings, 1 NOTE. The NOTE is the incoming-feasibility "8 updates in past 6 months". Vignette rebuild 44s, tests 18s, `--run-donttest` examples 32s. Seeding adds no computation.

No version bump. v4 line only; not backported to `maint/v3`.

## Not in this PR

The vignette prints an integrated CRPS of ~1.44 right after prose saying 0.25 is the uninformative CRPS ceiling. That's a separate problem (either the attribute is the un-normalised integral or the prose is wrong), so I've left it for its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)