### PR TITLE
docs(cran): 3.5.3 win-builder results

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -274,7 +274,8 @@ project context. Read it before writing user-facing text.
   tar xzf ggRandomForests_<version>.tar.gz -O ggRandomForests/DESCRIPTION | sed -n '4,5p'
   tar tzf ggRandomForests_<version>.tar.gz | grep -c cran-comments   # expect 0
   ```
-- A working-tree `R CMD build .` is **not** a reason to rebuild on its own. Measured
+- A working-tree `R CMD build .` does not leak **files**. Its **vignette output** is a
+  different matter; see the next bullet. Measured
   2026-08-20 at `26416c6c`: a build from the full working tree (71 MB of untracked
   `.Rcheck`, `docs/`, `.claude/`, `.remember/`, `.Rproj.user/`) and a build from a clean
   `git archive` export produced tarballs with an identical 247-entry file list, no
@@ -283,3 +284,21 @@ project context. Read it before writing user-facing text.
   `R CMD build` prunes matched *directories* wholesale, so `.claude/settings.local.json` and
   the `.Rcheck` tree are never walked. Testing an ignore pattern against a full file path
   wrongly reports those two as leaks. Run the `tar tzf` check above instead of predicting.
+- **Do not submit with `devtools::submit_cran()`. Upload the checked tarball.**
+  `submit_cran()` does not send the tarball you checked. It rebuilds from the working tree
+  (`pkgbuild::build(pkg$path, tempdir())`), and the vignettes in that build render against
+  whatever git-ignored knitr caches are lying in `vignettes/`. Measured 2026-09-10 on 3.5.3 at
+  `e7a9a092`, with caches from 2026-08-25: the file list and the vignette text were identical
+  to the `git archive` build, but `inst/doc/varpro.html` had **2 figures instead of 13** and
+  `uvarpro.html` **0 instead of 3**. `R CMD check --as-cran` on that tarball was still 0/0/1
+  NOTE, because the check re-renders the vignettes in its own tree and never inspects the
+  shipped HTML, so nothing flags it. CRAN would have published the figure-less pages.
+  `submit_cran()` also sends **all** of `cran-comments.md` as the comment, every past
+  version's section included. Submit the gate-checked `git archive` tarball through
+  <https://cran.r-project.org/submit.html> instead, paste only the current version's section,
+  and update `CRAN-SUBMISSION` by hand afterwards. To compare two tarballs' vignettes:
+
+  ```bash
+  tar xzf ggRandomForests_<version>.tar.gz -O ggRandomForests/inst/doc/varpro.html |
+    grep -o 'data:image/png;base64' | wc -l
+  ```

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -8,24 +8,50 @@ varPro 3.2.1, and his reverse-dependency check would report it. Live
 `get.beta.entropy()` output puts `0` on that diagonal, and the mock now does
 too.
 
-The diff is that one test fixture plus the version metadata. No function,
+The diff is that one test fixture, five regenerated `vdiffr` survival
+baselines under `tests/testthat/_snaps/`, and the version metadata. The
+baselines follow a numerical change in `randomForestSRC` 3.7.0 and are compared
+only when `VDIFFR_RUN_TESTS` is set, which it is not on CRAN. No function,
 argument, example, vignette or returned object changed, and the mock gives
 identical results on the current CRAN varPro 3.2.0.
 
 ### Test environments
 
 * **Local:** macOS (aarch64-apple-darwin), R 4.6.1, `R CMD check --as-cran`
-  with the manual, built from a clean `git archive` export: **0 ERRORs,
-  0 WARNINGs, 1 NOTE**. The source tarball is 2.38 MB. Timed steps are
-  essentially unchanged from 3.5.2: examples 16s, examples with
-  `--run-donttest` 31s, tests 14s, vignette rebuild 38s.
+  with the manual, built from a clean `git archive` export of the submitted
+  commit: **0 ERRORs, 0 WARNINGs, 1 NOTE**. The source tarball is 2.37 MB.
+  Timed steps are essentially unchanged from 3.5.2: examples 15s, examples
+  with `--run-donttest` 35s, tests 17s, vignette rebuild 42s.
 * **Against varPro 3.2.1:** the test suite under CRAN skip semantics, run
   against the varPro 3.2.1 candidate from its development branch, passes with
   0 failures. Against 3.2.0 it passes as part of the check above.
 * **Reverse-dependency check:** 0 reverse dependencies on CRAN.
 * **URL check:** `urlchecker::url_check()` reports all URLs correct.
-* **win-builder:** PENDING. Fill in the R-devel, R-release and R-oldrelease
-  status and timed steps before submitting.
+
+**win-builder:** x86_64-w64-mingw32, Windows Server 2022, all three branches.
+Each returns **Status: 1 NOTE**, the same `Number of updates in past 6 months:
+8` reported locally, with no second NOTE and no ERRORs or WARNINGs.
+`checking for hidden files and directories` is OK on all three.
+
+| Step | R-devel (r90510) | R-release (4.6.1) | R-oldrelease (4.5.3) |
+|---|---|---|---|
+| CRAN incoming feasibility | | | 18s |
+| R code for possible problems | 23s | 21s | 25s |
+| examples | 36s | 33s | 37s |
+| tests | 37s | 38s | 43s |
+| re-building vignette outputs | 112s | 108s | 136s |
+| PDF version of manual | 15s | 15s | 14s |
+| HTML version of manual | | 14s | 13s |
+| **timed steps** | **223s** | **229s** | **286s** |
+
+The blank cells are steps that `00check.log` did not time on that branch. For
+3.5.2 the same branches came to 265s, 234s and 277s, so check time is unchanged
+within run-to-run noise.
+
+One caveat, so the record is exact. These runs used the tarball built before
+the five `vdiffr` baselines above were merged. The submitted tarball differs
+from it only in those five `.svg` files, which `R CMD check` does not compare
+on CRAN, and the local check above was run on the submitted tarball itself.
 
 ### NOTE disposition
 


### PR DESCRIPTION
## Summary

This fills in the line marked `PENDING` in the 3.5.3 section of `cran-comments.md` with the win-builder results. It also corrects two statements that #277 made out of date.

- **win-builder:** R-devel (r90510), R-release (4.6.1) and R-oldrelease (4.5.3) all return **Status: 1 NOTE**, the expected `Number of updates in past 6 months: 8`. Timed steps are 223s, 229s and 286s, against 265s, 234s and 277s for 3.5.2, so check time is unchanged within run-to-run noise.
- **Diff description:** the submitted tarball now includes the five survival vdiffr baselines regenerated for randomForestSRC 3.7.0 (#277). They are compared only when `VDIFFR_RUN_TESTS` is set, which it is not on CRAN.
- **Local check figures:** these now describe the submitted tarball, built from `e7a9a092`: 2.37 MB, 0 errors, 0 warnings, 1 NOTE.
- **Caveat, stated in the file:** win-builder ran on the build from `2c47e197`, which predates #277. That build differs from the submitted tarball only in those five `.svg` files.

- **`AGENTS.md` release gotcha:** do not submit with `devtools::submit_cran()`. It rebuilds from the working tree, where git-ignored knitr caches in `vignettes/` made `varpro.html` ship 2 of 13 figures and `uvarpro.html` 0 of 3, with `R CMD check --as-cran` still reporting 0 errors, 0 warnings and 1 NOTE. It also sends all of `cran-comments.md` as the submission comment. Instead, upload the checked `git archive` tarball through the web form. The earlier bullet saying a working-tree build is "not a reason to rebuild" is now limited to the file list.

This is documentation only. `cran-comments.md` is excluded from the tarball, so the file you submit is unchanged by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
