### PR TITLE
docs: crps_integrated is the raw Brier integral, not a 0-0.25 score

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -85,7 +85,7 @@ ggRandomForests v4.0.0 (development)
   dropped without a warning, so the facet strips rendered as bare "1" and "3"
   instead of the intended "1 Year" and "3 Years". Corrected; the figure now
   carries the labels its code always asked for.
-* The survival vignette described `attr(gg_brier(), "crps_integrated")` as a
+* The survival vignette described `attr(gg_brier(rf), "crps_integrated")` as a
   time-normalised score on the 0 to 0.25 Brier scale, then printed 1.44. The
   attribute is `get.brier.survival()$crps`, the raw area under the Brier
   curve in time units, and always has been. The vignette now says so and shows

--- a/NEWS.md
+++ b/NEWS.md
@@ -85,6 +85,12 @@ ggRandomForests v4.0.0 (development)
   dropped without a warning, so the facet strips rendered as bare "1" and "3"
   instead of the intended "1 Year" and "3 Years". Corrected; the figure now
   carries the labels its code always asked for.
+* The survival vignette described `attr(gg_brier(), "crps_integrated")` as a
+  time-normalised score on the 0 to 0.25 Brier scale, then printed 1.44. The
+  attribute is `get.brier.survival()$crps`, the raw area under the Brier
+  curve in time units, and always has been. The vignette now says so and shows
+  the normalised value (`crps.std`, and the right edge of the running CRPS
+  curve); the `gg_brier()` help says the same. No change to any returned value.
 * Development line opened after the v3.2.0 CRAN release (forward-merged the
   v3.2.0 RMST/varPro fixes onto the dev line).
 * Begin the v4.0.0 development line: a Random Hazard Forests (RHF)

--- a/R/gg_brier.R
+++ b/R/gg_brier.R
@@ -72,7 +72,7 @@
 #'   The integrated CRPS is attached as \code{attr(., "crps_integrated")}.
 #'   It is \code{get.brier.survival()$crps}, the raw area under the Brier
 #'   curve, not normalized by time, so it is in the units of the time axis
-#'   and grows with follow-up. Divide by \code{max(time)} for
+#'   and grows with follow-up. Divide by \code{max(.$time)} for
 #'   \code{get.brier.survival()$crps.std}; the last value of the \code{crps}
 #'   column instead divides by the time elapsed since the first event time.
 #'

--- a/R/gg_brier.R
+++ b/R/gg_brier.R
@@ -69,9 +69,12 @@
 #'     \item{crps.lower, crps.upper}{running CRPS of the 15th / 85th
 #'       per-subject Brier percentile, normalized by elapsed time.}
 #'   }
-#'   The integrated CRPS (a single scalar matching
-#'   \code{get.brier.survival()$crps}) is attached as
-#'   \code{attr(., "crps_integrated")}.
+#'   The integrated CRPS is attached as \code{attr(., "crps_integrated")}.
+#'   It is \code{get.brier.survival()$crps}, the raw area under the Brier
+#'   curve, not normalized by time, so it is in the units of the time axis
+#'   and grows with follow-up. Divide by \code{max(time)} for
+#'   \code{get.brier.survival()$crps.std}; the last value of the \code{crps}
+#'   column instead divides by the time elapsed since the first event time.
 #'
 #' @seealso \code{\link{plot.gg_brier}},
 #'   \code{\link[randomForestSRC]{get.brier.survival}},

--- a/man/gg_brier.Rd
+++ b/man/gg_brier.Rd
@@ -33,7 +33,7 @@ per-subject Brier percentile, normalized by elapsed time.}
 The integrated CRPS is attached as \code{attr(., "crps_integrated")}.
 It is \code{get.brier.survival()$crps}, the raw area under the Brier
 curve, not normalized by time, so it is in the units of the time axis
-and grows with follow-up. Divide by \code{max(time)} for
+and grows with follow-up. Divide by \code{max(.$time)} for
 \code{get.brier.survival()$crps.std}; the last value of the \code{crps}
 column instead divides by the time elapsed since the first event time.
 }

--- a/man/gg_brier.Rd
+++ b/man/gg_brier.Rd
@@ -30,9 +30,12 @@ each mortality-risk quartile.}
 \item{crps.lower, crps.upper}{running CRPS of the 15th / 85th
 per-subject Brier percentile, normalized by elapsed time.}
 }
-The integrated CRPS (a single scalar matching
-\code{get.brier.survival()$crps}) is attached as
-\code{attr(., "crps_integrated")}.
+The integrated CRPS is attached as \code{attr(., "crps_integrated")}.
+It is \code{get.brier.survival()$crps}, the raw area under the Brier
+curve, not normalized by time, so it is in the units of the time axis
+and grows with follow-up. Divide by \code{max(time)} for
+\code{get.brier.survival()$crps.std}; the last value of the \code{crps}
+column instead divides by the time elapsed since the first event time.
 }
 \description{
 The Brier score asks a familiar question of any probabilistic forecast:

--- a/vignettes/ggRandomForests-survival.qmd
+++ b/vignettes/ggRandomForests-survival.qmd
@@ -648,7 +648,8 @@ attribute. Be careful with it. That number is the raw area under the Brier
 curve, *not* divided by elapsed time, so it carries the units of the time axis
 (years here) and grows with the length of follow-up. It is not on the 0 to 0.25
 scale, and you cannot compare it across studies with different follow-up.
-Divide it by the follow-up time to put it back on the Brier scale:
+Divide it by the largest event time, `max(gg_bs$time)`, to put it back on the
+Brier scale:
 
 ```{r brier-crps-scalar}
 crps_raw <- attr(gg_bs, "crps_integrated")

--- a/vignettes/ggRandomForests-survival.qmd
+++ b/vignettes/ggRandomForests-survival.qmd
@@ -629,24 +629,36 @@ wide one means the predicted risks are pulling apart.
 plot(gg_bs, envelope = TRUE)
 ```
 
-The running CRPS (continuous ranked probability score) is the Brier score
-integrated over time and divided by elapsed time — the time-average of the
-curve above. It collapses the whole trajectory into one running number, which
-is handy when you want a single calibration figure rather than a curve to read.
-Like the Brier score, a CRPS near 0 is good and a value near 0.25 is the
-uninformative ceiling (the same constant-predictor reference as above). The final (integrated) value at the right edge of the
-plot is the one most often reported.
+The running CRPS (continuous ranked probability score) integrates the Brier
+score over time and divides by the time elapsed since the first event, so each
+point on the curve is the average of the Brier curve up to that time. It
+collapses the whole trajectory into one running number, which is handy when
+you want a single calibration figure rather than a curve to read. Because it is
+an average of Brier scores it reads on the same scale: near 0 is good, and 0.25
+is the constant-predictor reference from above. The value at the right edge of
+the plot, the average over the whole follow-up, is the one to report.
 
 ```{r brier-crps, fig.width=7, fig.height=3.5, fig.cap="Running CRPS for the PBC survival forest."}
 plot(gg_bs, type = "crps")
 ```
 
-The integrated CRPS --- a scalar summary of overall calibration --- is stored
-as an attribute and can be retrieved with:
+`gg_brier()` also keeps the integrated CRPS that
+`randomForestSRC::get.brier.survival()` returns, as the `crps_integrated`
+attribute. Be careful with it. That number is the raw area under the Brier
+curve, *not* divided by elapsed time, so it carries the units of the time axis
+(years here) and grows with the length of follow-up. It is not on the 0 to 0.25
+scale, and you cannot compare it across studies with different follow-up.
+Divide it by the follow-up time to put it back on the Brier scale:
 
 ```{r brier-crps-scalar}
-attr(gg_bs, "crps_integrated")
+crps_raw <- attr(gg_bs, "crps_integrated")
+crps_raw                     # area under the Brier curve, in years
+crps_raw / max(gg_bs$time)   # get.brier.survival()'s crps.std
+tail(gg_bs$crps, 1)          # right edge of the running CRPS plot
 ```
+
+The last two differ slightly. `crps.std` divides by the largest event time,
+while the running curve divides by the time elapsed since the first one.
 
 # Conclusion
 


### PR DESCRIPTION
## What was wrong

The survival vignette's Brier/CRPS section said the CRPS is "divided by elapsed time", that 0.25 is the "uninformative ceiling", and that the right-edge value is the one to report. Then it printed `attr(gg_bs, "crps_integrated")`, which renders as ~1.42 (1.44 in a seeded build). That isn't on a 0-0.25 scale.

## What the attribute actually is

`gg_brier.rfsrc()` sets `attr(., "crps_integrated") <- brier_obj$crps`. Upstream, `randomForestSRC:::.surv.brier` computes

```r
crps     <- trapz(times, point)   # raw area under the Brier curve
crps.std <- crps / time.max
```

So the attribute is the **raw integral, in time units**. It has always been that, and `test_extractor_contracts.R` pins it to `get.brier.survival()$crps`. The prose was wrong, not the code.

Three quantities are in play, measured on the vignette's forest (years):

| quantity | value | denominator |
|---|---|---|
| `attr(gg_bs, "crps_integrated")` = upstream `crps` | 1.423 | none |
| upstream `crps.std` = `crps / max(time)` | 0.1240 | `max(time)` |
| `tail(gg_bs$crps, 1)` (right edge of `plot(type = "crps")`) | 0.1253 | `max(time) - min(time)` |

The same holds on a days-scale fit, where the attribute is 536.8 (days) against a right edge of 0.129.

## Change (docs only)

- **Vignette:** describes the running CRPS correctly (divided by time since the first event), and flags that `crps_integrated` is the raw integral that grows with follow-up. The scalar chunk now prints the raw value, `crps_raw / max(gg_bs$time)` (= `crps.std`), and the right edge, then explains why the last two differ.
- **`gg_brier()` @return:** says the attribute is the un-normalised `crps` in time units and names both normalised routes.
- **NEWS:** one bullet under 4.0.0. No version bump.

No returned value, class or column changed. Whether `crps_integrated` should itself be normalised is a separate question, and a behaviour change on a CRAN package, so it's left for the maintainer.

## Checks

- `devtools::document()`: regenerates `man/gg_brier.Rd` only
- `lintr::lint_package()`: 0 lints
- `NOT_CRAN=true VDIFFR_RUN_TESTS=true devtools::test()`: `[ FAIL 0 | WARN 58 | SKIP 6 | PASS 2169 ]`, 0 snapshot deletions
- The vignette code through the CRPS chunk ran cleanly in a scratch copy; its values are in the table above
- `R CMD check --as-cran` not run (docs-only; left for CI / the release gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
