### PR TITLE
docs(agents): submit the checked tarball, not devtools::submit_cran()

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -286,7 +286,8 @@ project context. Read it before writing user-facing text.
   tar xzf ggRandomForests_<version>.tar.gz -O ggRandomForests/DESCRIPTION | sed -n '4,5p'
   tar tzf ggRandomForests_<version>.tar.gz | grep -c cran-comments   # expect 0
   ```
-- A working-tree `R CMD build .` is **not** a reason to rebuild on its own. Measured
+- A working-tree `R CMD build .` does not leak **files**. Its **vignette output** is a
+  different matter; see the next bullet. Measured
   2026-08-20 at `26416c6c`: a build from the full working tree (71 MB of untracked
   `.Rcheck`, `docs/`, `.claude/`, `.remember/`, `.Rproj.user/`) and a build from a clean
   `git archive` export produced tarballs with an identical 247-entry file list, no
@@ -295,3 +296,21 @@ project context. Read it before writing user-facing text.
   `R CMD build` prunes matched *directories* wholesale, so `.claude/settings.local.json` and
   the `.Rcheck` tree are never walked. Testing an ignore pattern against a full file path
   wrongly reports those two as leaks. Run the `tar tzf` check above instead of predicting.
+- **Do not submit with `devtools::submit_cran()`. Upload the checked tarball.**
+  `submit_cran()` does not send the tarball you checked. It rebuilds from the working tree
+  (`pkgbuild::build(pkg$path, tempdir())`), and the vignettes in that build render against
+  whatever git-ignored knitr caches are lying in `vignettes/`. Measured 2026-09-10 on 3.5.3 at
+  `e7a9a092`, with caches from 2026-08-25: the file list and the vignette text were identical
+  to the `git archive` build, but `inst/doc/varpro.html` had **2 figures instead of 13** and
+  `uvarpro.html` **0 instead of 3**. `R CMD check --as-cran` on that tarball was still 0/0/1
+  NOTE, because the check re-renders the vignettes in its own tree and never inspects the
+  shipped HTML, so nothing flags it. CRAN would have published the figure-less pages.
+  `submit_cran()` also sends **all** of `cran-comments.md` as the comment, every past
+  version's section included. Submit the gate-checked `git archive` tarball through
+  <https://cran.r-project.org/submit.html> instead, paste only the current version's section,
+  and update `CRAN-SUBMISSION` by hand afterwards. To compare two tarballs' vignettes:
+
+  ```bash
+  tar xzf ggRandomForests_<version>.tar.gz -O ggRandomForests/inst/doc/varpro.html |
+    grep -o 'data:image/png;base64' | wc -l
+  ```


### PR DESCRIPTION
## Summary

This forward-ports the `AGENTS.md` release gotcha from #279, which is on `maint/v3`, to `main`, so the v4 release gets it too. The commit was cherry-picked with `-x` from `a592f059`.

`devtools::submit_cran()` doesn't upload the tarball you checked. It rebuilds from the working tree, and the vignettes in that build render against whatever git-ignored knitr caches sit in `vignettes/`. On 3.5.3, with caches from 2026-08-25, that build had the same file list and the same vignette text as the `git archive` build. But `varpro.html` shipped **2 of 13 figures** and `uvarpro.html` **0 of 3**, while `R CMD check --as-cran` still reported 0 errors, 0 warnings and 1 NOTE. `submit_cran()` also sends all of `cran-comments.md` as the submission comment.

Changes:
- A new Gotchas bullet: submit the gate-checked `git archive` tarball through the CRAN web form, paste only the current version's section, and update `CRAN-SUBMISSION` by hand. It includes a one-line command that counts the figures in a vignette.
- A qualification to the bullet above it. "A working-tree build is not a reason to rebuild" is now limited to the file list, so the two bullets don't contradict each other.

This changes documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)