### PR TITLE
docs: correct content flagged in #282; fix plot.gg_vimp(relative)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -21,7 +21,10 @@ ggRandomForests v4.0.0 (development)
 * `plot.gg_vimp(relative = TRUE)` now plots relative VIMP: each variable's
   VIMP divided by the largest VIMP in its `set`, so the top variable reads 1
   (per class for classification). The argument was documented but never read,
-  so it silently plotted raw VIMP. It now defaults to `FALSE`.
+  so it silently plotted raw VIMP. It now defaults to `FALSE`. A set with no
+  positive VIMP is scaled by its largest absolute VIMP, never divided by zero.
+* `plot.gg_vimp(nvar = )` now keeps the top `nvar` variables rather than the
+  top `nvar` rows, so a classification plot no longer loses class panels.
 * `gg_partial_varpro()` gains `scale = "prob_typical"`. `partialpro()` returns
   per-subject log-odds, and collapsing them to a curve takes an average and a
   back-transform; the ORDER is a modelling choice. `"prob"` (unchanged, still

--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,10 @@ ggRandomForests v4.0.0 (development)
   `plot()` and `autoplot()` methods draw the first-order curves as lines and
   bars faceted by variable, matching `plot.gg_partial_rfsrc()`'s layout so the
   two can be read side by side, and the interaction surface as a heatmap.
+* `plot.gg_vimp(relative = TRUE)` now plots relative VIMP: each variable's
+  VIMP divided by the largest VIMP in its `set`, so the top variable reads 1
+  (per class for classification). The argument was documented but never read,
+  so it silently plotted raw VIMP. It now defaults to `FALSE`.
 * `gg_partial_varpro()` gains `scale = "prob_typical"`. `partialpro()` returns
   per-subject log-odds, and collapsing them to a curve takes an average and a
   back-transform; the ORDER is a modelling choice. `"prob"` (unchanged, still

--- a/R/gg_beta_varpro.R
+++ b/R/gg_beta_varpro.R
@@ -161,9 +161,9 @@
 #'   For a regression fit: one row per released variable, sorted by
 #'   `beta_mean` descending. For a classification fit: long-format with
 #'   an extra `class` column, one row per (variable, class) pair;
-#'   `variable` is a factor whose levels are set by
-#'   `mean(|sum-of-class-beta|)` descending so every facet / panel shares
-#'   the same row order. `which_class` (or the binary default
+#'   `variable` is a factor whose levels run in ascending
+#'   `mean(|sum-of-class-beta|)`, most important last, so every facet /
+#'   panel shares the same row order with the top variable at the top. `which_class` (or the binary default
 #'   last-factor-level) collapses the output to a single class.
 #'
 #' @seealso [gg_varpro()], [gg_vimp()], [plot.gg_beta_varpro()], [varPro::beta.varpro()].

--- a/R/gg_isopro.R
+++ b/R/gg_isopro.R
@@ -32,8 +32,10 @@
 #'     picks a variable at random and a split point uniformly at random
 #'     in the variable's range. Fast, no model, surprisingly effective.}
 #'   \item{\code{"unsupv"}}{Unsupervised splitting from
-#'     \code{randomForestSRC}: splits are chosen to separate the data
-#'     along the directions of highest variance. More structured than
+#'     \code{randomForestSRC}: at each split a random subset of the features
+#'     serves as pseudo-responses (\code{ytry} of them, about the square root
+#'     of the number of features by default) and the split is chosen to
+#'     separate those pseudo-responses. More structured than
 #'     \code{"rnd"}; sometimes more accurate, especially when the
 #'     anomalies follow a coherent direction.}
 #'   \item{\code{"auto"}}{An auto-encoder formulation that grows a

--- a/R/gg_ivarpro.R
+++ b/R/gg_ivarpro.R
@@ -51,7 +51,8 @@
 #' Long-format tidy frame. Regression has columns `obs`, `variable`,
 #' `local_imp`, `selected`. Classification adds a `class` column
 #' (factor in response-level order). `variable` is a factor whose
-#' levels are set by `mean(|local_imp|)` descending across all rows;
+#' levels run in ascending `mean(|local_imp|)` across all rows, so the
+#' most important variable is the last level and plots at the top;
 #' for classification that aggregate is across all (obs, class) so
 #' every facet / panel shows variables in the same row order. NA
 #' cells are filtered out; the source matrix is sparse, and the
@@ -133,8 +134,8 @@
 #' @return A `data.frame` of class `c("gg_ivarpro", "data.frame")`.
 #'   Regression: columns `obs / variable / local_imp / selected`.
 #'   Classification: long-format with an extra `class` column.
-#'   `variable` is a factor whose levels are set by
-#'   `mean(|local_imp|)` descending across all rows (the unified
+#'   `variable` is a factor whose levels run in ascending
+#'   `mean(|local_imp|)` across all rows, most important last (the unified
 #'   ranking axis shared across facets / panels).
 #'
 #' @seealso [gg_varpro()], [gg_vimp()], [gg_beta_varpro()], [varPro::ivarpro()].

--- a/R/gg_partialpro.R
+++ b/R/gg_partialpro.R
@@ -4,7 +4,7 @@
 #'
 #' \emph{Deprecated.} \code{gg_partialpro()} has been superseded by
 #' \code{\link{gg_partial_varpro}()} and is now a thin alias for it.  It will
-#' be removed in the release after \pkg{ggRandomForests} v3.0.0; use
+#' be removed in a future release; use
 #' \code{\link{gg_partial_varpro}()} directly.
 #'
 #' Arguments are documented on \code{\link{gg_partial_varpro}}; this alias

--- a/R/gg_survival.R
+++ b/R/gg_survival.R
@@ -15,10 +15,14 @@
 #' Nonparametric survival estimates.
 #'
 #' @details
-#' Comparing the forest's ensemble survival curve to the marginal
-#' Kaplan-Meier baseline is a quick sanity check: if they diverge the forest
-#' has found structure the predictors carry; if they track each other closely
-#' the predictors may add little.  \code{gg_survival} computes
+#' Placing the forest's ensemble survival curve over the marginal
+#' Kaplan-Meier baseline is a calibration check, not a test of signal. The
+#' ensemble curve averages the per-subject curves, so it should track the
+#' Kaplan-Meier estimate whether or not the predictors carry information; a
+#' forest grown on pure noise tracks it about as closely as one grown on real
+#' predictors. A clear gap points to miscalibration, most often at late times
+#' when few subjects remain at risk. To see what the predictors carry,
+#' stratify with \code{by} and compare the groups.  \code{gg_survival} computes
 #' the nonparametric baseline (the Kaplan-Meier or Nelson-Aalen estimate)
 #' so you can place it on the same canvas as the forest predictions from
 #' \code{\link{gg_rfsrc}}.

--- a/R/plot.gg_vimp.R
+++ b/R/plot.gg_vimp.R
@@ -30,7 +30,10 @@
 #'
 #' @param x \code{\link{gg_vimp}} object created from a
 #' \code{\link[randomForestSRC]{rfsrc}} object
-#' @param relative should we plot vimp or relative vimp. Defaults to vimp.
+#' @param relative If \code{TRUE}, plot relative VIMP: each variable's VIMP
+#'   divided by the largest VIMP in its \code{set}, so the top variable reads
+#'   1 (for classification, the top variable within each class).  Defaults to
+#'   \code{FALSE}, raw VIMP.
 #' @param lbls \emph{Deprecated} as of v4.0.0; use \code{labels}.  A named
 #'   character vector of alternative variable labels.
 #' @param labels Optional variable labels for the variable axis.  One of: a named
@@ -73,7 +76,7 @@
 #'
 #'
 #' @export
-plot.gg_vimp <- function(x, relative, lbls, labels = NULL, ...) {
+plot.gg_vimp <- function(x, relative = FALSE, lbls, labels = NULL, ...) {
   gg_dta <- x
 
   # Accept raw rfsrc / randomForest objects and compute VIMP on the fly
@@ -96,14 +99,30 @@ plot.gg_vimp <- function(x, relative, lbls, labels = NULL, ...) {
     }
   }
 
-  gg_plt <- ggplot2::ggplot(gg_dta)
-
   # Use "vimp" as the bar-height column when it exists; fall back to the
   # first column name for objects that store a renamed importance measure.
   msr <- "vimp"
   if (!msr %in% colnames(gg_dta)) {
     msr <- colnames(gg_dta)[1]
   }
+
+  # relative = TRUE rescales each bar to a fraction of the largest VIMP in its
+  # set (per class for multi-outcome fits). gg_vimp() does not return a
+  # relative column, so it is computed here.
+  if (isTRUE(relative)) {
+    grp <- if (is.null(gg_dta$set)) {
+      rep("all", nrow(gg_dta))
+    } else {
+      as.character(gg_dta$set)
+    }
+    top <- tapply(gg_dta[[msr]], grp, function(v) {
+      if (all(is.na(v))) NA_real_ else max(v, na.rm = TRUE)
+    })
+    gg_dta$rel_vimp <- gg_dta[[msr]] / unname(top[grp])
+    msr <- "rel_vimp"
+  }
+
+  gg_plt <- ggplot2::ggplot(gg_dta)
 
   # Always map both `fill` and `color` to `positive` -- this gives filled bars
   # (rather than hollow outlines) and ensures the function-level

--- a/R/plot.gg_vimp.R
+++ b/R/plot.gg_vimp.R
@@ -32,8 +32,9 @@
 #' \code{\link[randomForestSRC]{rfsrc}} object
 #' @param relative If \code{TRUE}, plot relative VIMP: each variable's VIMP
 #'   divided by the largest VIMP in its \code{set}, so the top variable reads
-#'   1 (for classification, the top variable within each class).  Defaults to
-#'   \code{FALSE}, raw VIMP.
+#'   1 (for classification, the top variable within each class).  A set with
+#'   no positive VIMP is divided by its largest absolute VIMP instead, and an
+#'   all-zero set stays at zero.  Defaults to \code{FALSE}, raw VIMP.
 #' @param lbls \emph{Deprecated} as of v4.0.0; use \code{labels}.  A named
 #'   character vector of alternative variable labels.
 #' @param labels Optional variable labels for the variable axis.  One of: a named
@@ -87,18 +88,6 @@ plot.gg_vimp <- function(x, relative = FALSE, lbls, labels = NULL, ...) {
   # Capture extra args so we can inspect nvar.
   arg_set <- list(...)
 
-  # Optionally restrict to the top-nvar most important variables (gg_vimp
-  # already sorts by descending VIMP, so we just trim the tail).
-  nvar <- nrow(gg_dta)
-  if (!is.null(arg_set$nvar)) {
-    if (is.numeric(arg_set$nvar) && arg_set$nvar > 1) {
-      if (arg_set$nvar < nrow(gg_dta)) {
-        nvar <- arg_set$nvar
-        gg_dta <- gg_dta[seq_len(nvar), ]
-      }
-    }
-  }
-
   # Use "vimp" as the bar-height column when it exists; fall back to the
   # first column name for objects that store a renamed importance measure.
   msr <- "vimp"
@@ -108,18 +97,40 @@ plot.gg_vimp <- function(x, relative = FALSE, lbls, labels = NULL, ...) {
 
   # relative = TRUE rescales each bar to a fraction of the largest VIMP in its
   # set (per class for multi-outcome fits). gg_vimp() does not return a
-  # relative column, so it is computed here.
+  # relative column, so it is computed here, before the nvar trim, so that a
+  # set's largest VIMP counts even when its variable is trimmed away.
   if (isTRUE(relative)) {
     grp <- if (is.null(gg_dta$set)) {
       rep("all", nrow(gg_dta))
     } else {
       as.character(gg_dta$set)
     }
+    # A set with no positive VIMP has no top variable to scale to: fall back
+    # to its largest magnitude so bars keep their sign, and leave an all-zero
+    # set at zero rather than divide by zero.
     top <- tapply(gg_dta[[msr]], grp, function(v) {
-      if (all(is.na(v))) NA_real_ else max(v, na.rm = TRUE)
+      v <- v[is.finite(v)]
+      if (length(v) == 0L) return(NA_real_)
+      top_v <- max(v)
+      if (top_v <= 0) top_v <- max(abs(v))
+      if (top_v == 0) 1 else top_v
     })
     gg_dta$rel_vimp <- gg_dta[[msr]] / unname(top[grp])
     msr <- "rel_vimp"
+  }
+
+  # Optionally restrict to the top-nvar most important variables. gg_vimp
+  # already sorts by descending VIMP, so keep the first nvar variables. Trim
+  # by variable, not by row: a multi-outcome frame has one row per variable
+  # and class, so a row trim would drop whole class panels.
+  if (!is.null(arg_set$nvar)) {
+    if (is.numeric(arg_set$nvar) && arg_set$nvar > 1) {
+      vars_ord <- unique(as.character(gg_dta$vars))
+      if (arg_set$nvar < length(vars_ord)) {
+        keep <- vars_ord[seq_len(arg_set$nvar)]
+        gg_dta <- gg_dta[as.character(gg_dta$vars) %in% keep, ]
+      }
+    }
   }
 
   gg_plt <- ggplot2::ggplot(gg_dta)

--- a/man/gg_beta_varpro.Rd
+++ b/man/gg_beta_varpro.Rd
@@ -33,9 +33,9 @@ A \code{data.frame} of class \code{c("gg_beta_varpro", "data.frame")}.
 For a regression fit: one row per released variable, sorted by
 \code{beta_mean} descending. For a classification fit: long-format with
 an extra \code{class} column, one row per (variable, class) pair;
-\code{variable} is a factor whose levels are set by
-\verb{mean(|sum-of-class-beta|)} descending so every facet / panel shares
-the same row order. \code{which_class} (or the binary default
+\code{variable} is a factor whose levels run in ascending
+\verb{mean(|sum-of-class-beta|)}, most important last, so every facet /
+panel shares the same row order with the top variable at the top. \code{which_class} (or the binary default
 last-factor-level) collapses the output to a single class.
 }
 \description{

--- a/man/gg_isopro.Rd
+++ b/man/gg_isopro.Rd
@@ -66,8 +66,10 @@ forest, which differ in how the splits are chosen:
 picks a variable at random and a split point uniformly at random
 in the variable's range. Fast, no model, surprisingly effective.}
 \item{\code{"unsupv"}}{Unsupervised splitting from
-\code{randomForestSRC}: splits are chosen to separate the data
-along the directions of highest variance. More structured than
+\code{randomForestSRC}: at each split a random subset of the features
+serves as pseudo-responses (\code{ytry} of them, about the square root
+of the number of features by default) and the split is chosen to
+separate those pseudo-responses. More structured than
 \code{"rnd"}; sometimes more accurate, especially when the
 anomalies follow a coherent direction.}
 \item{\code{"auto"}}{An auto-encoder formulation that grows a

--- a/man/gg_ivarpro.Rd
+++ b/man/gg_ivarpro.Rd
@@ -43,8 +43,8 @@ for the same \code{object}. Shape-validated.}
 A \code{data.frame} of class \code{c("gg_ivarpro", "data.frame")}.
 Regression: columns \code{obs / variable / local_imp / selected}.
 Classification: long-format with an extra \code{class} column.
-\code{variable} is a factor whose levels are set by
-\verb{mean(|local_imp|)} descending across all rows (the unified
+\code{variable} is a factor whose levels run in ascending
+\verb{mean(|local_imp|)} across all rows, most important last (the unified
 ranking axis shared across facets / panels).
 }
 \description{
@@ -107,7 +107,8 @@ low global) flags a regime-specific signal.
 Long-format tidy frame. Regression has columns \code{obs}, \code{variable},
 \code{local_imp}, \code{selected}. Classification adds a \code{class} column
 (factor in response-level order). \code{variable} is a factor whose
-levels are set by \verb{mean(|local_imp|)} descending across all rows;
+levels run in ascending \verb{mean(|local_imp|)} across all rows, so the
+most important variable is the last level and plots at the top;
 for classification that aggregate is across all (obs, class) so
 every facet / panel shows variables in the same row order. NA
 cells are filtered out; the source matrix is sparse, and the

--- a/man/gg_partial_varpro.Rd
+++ b/man/gg_partial_varpro.Rd
@@ -113,7 +113,7 @@ plot method will use.
 
 \emph{Deprecated.} \code{gg_partialpro()} has been superseded by
 \code{\link{gg_partial_varpro}()} and is now a thin alias for it.  It will
-be removed in the release after \pkg{ggRandomForests} v3.0.0; use
+be removed in a future release; use
 \code{\link{gg_partial_varpro}()} directly.
 }
 \details{

--- a/man/gg_survival.Rd
+++ b/man/gg_survival.Rd
@@ -70,10 +70,14 @@ and optionally \code{groups} when \code{by} is supplied.
 Nonparametric survival estimates.
 }
 \details{
-Comparing the forest's ensemble survival curve to the marginal
-Kaplan-Meier baseline is a quick sanity check: if they diverge the forest
-has found structure the predictors carry; if they track each other closely
-the predictors may add little.  \code{gg_survival} computes
+Placing the forest's ensemble survival curve over the marginal
+Kaplan-Meier baseline is a calibration check, not a test of signal. The
+ensemble curve averages the per-subject curves, so it should track the
+Kaplan-Meier estimate whether or not the predictors carry information; a
+forest grown on pure noise tracks it about as closely as one grown on real
+predictors. A clear gap points to miscalibration, most often at late times
+when few subjects remain at risk. To see what the predictors carry,
+stratify with \code{by} and compare the groups.  \code{gg_survival} computes
 the nonparametric baseline (the Kaplan-Meier or Nelson-Aalen estimate)
 so you can place it on the same canvas as the forest predictions from
 \code{\link{gg_rfsrc}}.

--- a/man/plot.gg_vimp.Rd
+++ b/man/plot.gg_vimp.Rd
@@ -5,13 +5,16 @@
 \title{Plot a \code{\link{gg_vimp}} object, extracted variable importance of a
 \code{\link[randomForestSRC]{rfsrc}} object}
 \usage{
-\method{plot}{gg_vimp}(x, relative, lbls, labels = NULL, ...)
+\method{plot}{gg_vimp}(x, relative = FALSE, lbls, labels = NULL, ...)
 }
 \arguments{
 \item{x}{\code{\link{gg_vimp}} object created from a
 \code{\link[randomForestSRC]{rfsrc}} object}
 
-\item{relative}{should we plot vimp or relative vimp. Defaults to vimp.}
+\item{relative}{If \code{TRUE}, plot relative VIMP: each variable's VIMP
+divided by the largest VIMP in its \code{set}, so the top variable reads
+1 (for classification, the top variable within each class).  Defaults to
+\code{FALSE}, raw VIMP.}
 
 \item{lbls}{\emph{Deprecated} as of v4.0.0; use \code{labels}.  A named
 character vector of alternative variable labels.}

--- a/man/plot.gg_vimp.Rd
+++ b/man/plot.gg_vimp.Rd
@@ -13,8 +13,9 @@
 
 \item{relative}{If \code{TRUE}, plot relative VIMP: each variable's VIMP
 divided by the largest VIMP in its \code{set}, so the top variable reads
-1 (for classification, the top variable within each class).  Defaults to
-\code{FALSE}, raw VIMP.}
+1 (for classification, the top variable within each class).  A set with
+no positive VIMP is divided by its largest absolute VIMP instead, and an
+all-zero set stays at zero.  Defaults to \code{FALSE}, raw VIMP.}
 
 \item{lbls}{\emph{Deprecated} as of v4.0.0; use \code{labels}.  A named
 character vector of alternative variable labels.}

--- a/tests/testthat/test_plot_layer_data.R
+++ b/tests/testthat/test_plot_layer_data.R
@@ -327,6 +327,38 @@ test_that("plot.gg_vimp produces a single merged 'VIMP > 0' legend", {
   expect_identical(p$labels$fill, p$labels$colour)
 })
 
+test_that("plot.gg_vimp(relative = TRUE) rescales to the largest VIMP", {
+  # Regression: `relative` was documented but never read, so relative = TRUE
+  # silently plotted raw VIMP.
+  gg <- structure(
+    data.frame(
+      vars     = factor(c("a", "b", "c"), levels = c("c", "b", "a")),
+      set      = "VIMP",
+      vimp     = c(0.30, 0.10, 0.05),
+      positive = c(TRUE, TRUE, TRUE)
+    ),
+    class = c("gg_vimp", "data.frame")
+  )
+  expect_equal(sort(ggplot2::layer_data(plot(gg), 1L)$y), sort(gg$vimp))
+
+  p_rel <- plot(gg, relative = TRUE)
+  expect_equal(sort(ggplot2::layer_data(p_rel, 1L)$y), sort(gg$vimp / 0.30))
+  expect_equal(p_rel$labels$y, "rel_vimp")
+
+  # Multi-outcome frames rescale within each set, so every class tops out at 1.
+  gg_cls <- structure(
+    data.frame(
+      vars     = factor(rep(c("a", "b"), 2), levels = c("b", "a")),
+      set      = rep(c("all", "setosa"), each = 2),
+      vimp     = c(0.40, 0.10, 0.08, 0.02),
+      positive = TRUE
+    ),
+    class = c("gg_vimp", "data.frame")
+  )
+  y <- ggplot2::layer_data(plot(gg_cls, relative = TRUE), 1L)$y
+  expect_equal(sort(y), sort(c(1, 0.25, 1, 0.25)))
+})
+
 test_that("plot.gg_vimp produces filled bars even when all VIMP are positive", {
   # Regression: previously the all-positive branch mapped only `color`,
   # leaving the bars hollow / outline-only and emitting "Ignoring unknown

--- a/tests/testthat/test_plot_layer_data.R
+++ b/tests/testthat/test_plot_layer_data.R
@@ -359,6 +359,50 @@ test_that("plot.gg_vimp(relative = TRUE) rescales to the largest VIMP", {
   expect_equal(sort(y), sort(c(1, 0.25, 1, 0.25)))
 })
 
+test_that("plot.gg_vimp(relative = TRUE) handles non-positive sets", {
+  # A set whose largest VIMP is zero or negative must not divide by zero:
+  # NaN / Inf bars are silently dropped by ggplot2.
+  gg <- structure(
+    data.frame(
+      vars     = factor(rep(c("a", "b"), 3), levels = c("b", "a")),
+      set      = rep(c("all", "zero", "neg"), each = 2),
+      vimp     = c(0.40, 0.10, 0, 0, -0.01, -0.04),
+      positive = c(TRUE, TRUE, FALSE, FALSE, FALSE, FALSE)
+    ),
+    class = c("gg_vimp", "data.frame")
+  )
+  # position_stack() leaves a negative bar's height in ymin, not y; one of
+  # ymin / ymax is always 0, so their sum is the signed bar height.
+  d <- ggplot2::layer_data(plot(gg, relative = TRUE), 1L)
+  h <- d$ymin + d$ymax
+  expect_true(all(is.finite(h)))
+  expect_equal(sort(h), sort(c(1, 0.25, 0, 0, -0.25, -1)))
+})
+
+test_that("plot.gg_vimp(nvar) trims variables, not rows of the long frame", {
+  # Sorted long frame, as gg_vimp() returns it. setosa's top variable, c,
+  # ranks third overall. A row trim to nvar = 2 kept only the two "all" rows
+  # and dropped the setosa panel.
+  gg_cls <- structure(
+    data.frame(
+      vars     = factor(c("a", "b", "c", "a", "b", "c"),
+                        levels = c("c", "b", "a")),
+      set      = c("all", "all", "setosa", "setosa", "setosa", "all"),
+      vimp     = c(0.40, 0.30, 0.20, 0.10, 0.05, 0.01),
+      positive = TRUE
+    ),
+    class = c("gg_vimp", "data.frame")
+  )
+  d <- ggplot2::layer_data(plot(gg_cls, nvar = 2), 1L)
+  expect_equal(nrow(d), 4L)
+  expect_equal(sort(d$y), sort(c(0.40, 0.30, 0.10, 0.05)))
+
+  # Relative scaling still divides setosa by its own maximum (c, 0.20), even
+  # though c is trimmed from the plot.
+  y <- ggplot2::layer_data(plot(gg_cls, nvar = 2, relative = TRUE), 1L)$y
+  expect_equal(sort(y), sort(c(1, 0.75, 0.5, 0.25)))
+})
+
 test_that("plot.gg_vimp produces filled bars even when all VIMP are positive", {
   # Regression: previously the all-positive branch mapped only `color`,
   # leaving the bars hollow / outline-only and emitting "Ignoring unknown

--- a/vignettes/explainability.qmd
+++ b/vignettes/explainability.qmd
@@ -69,8 +69,8 @@ different ways to answer it.
 
 That is a problem, because the five answers are not interchangeable. They
 estimate different things. Read one as though it were another and you will
-report a number that is off by a factor of two or three, with a figure that
-looks entirely reasonable.
+report a number that is off by as much as a factor of two or three, with a
+figure that looks entirely reasonable.
 
 This vignette puts them side by side on one forest. No one method wins; the
 point is to know which question you asked.
@@ -217,7 +217,8 @@ size of the effect, you are understating it.
 
 Two cautions before you conclude that ALE always wins. On `ptratio` the two
 methods agree closely, and on `lstat` partial dependence gives the *larger*
-range. The methods usually agree; knowing when they do not is the useful part.
+range. The gap usually runs one way but not always, so check both before you
+report the size of an effect.
 
 ## Where two variables act together
 

--- a/vignettes/ggRandomForests-regression.qmd
+++ b/vignettes/ggRandomForests-regression.qmd
@@ -422,8 +422,9 @@ plot(gg_v, xvar = "rm", alpha = 0.5) +
   facet_wrap(~lstat_grp)
 ```
 
-The `rm` effect is strongest in low-`lstat` tracts (bottom-left panels) and
-nearly flat in high-`lstat` tracts, confirming a meaningful interaction.
+The `rm` effect is strongest in low-`lstat` tracts (the top row of panels) and
+nearly flat in high-`lstat` tracts (the bottom row), confirming a meaningful
+interaction.
 
 # Partial Dependence Surface
 

--- a/vignettes/varpro.qmd
+++ b/vignettes/varpro.qmd
@@ -719,7 +719,9 @@ Across `gg_vimp()`, `gg_varpro()`, `gg_beta_varpro()` and `gg_ivarpro()`,
 rows come most-important-first, but the variable column (`vars` in
 `gg_vimp()`, `variable` elsewhere) is a factor whose levels run the other
 way: the most important variable is the *last* level. For classification
-the ranking uses importance aggregated across classes. After
+the three varPro extractors rank on importance aggregated across classes,
+while `gg_vimp()` ranks each variable by its largest VIMP over the `all`
+and per-class columns. After
 `coord_flip()` the last level sits at the top of the plot, and faceted
 views share one row order across panels. If you re-shape the frame
 downstream and want the order preserved, keep the variable column as a

--- a/vignettes/varpro.qmd
+++ b/vignettes/varpro.qmd
@@ -514,9 +514,10 @@ anomaly scoring on the predictor matrix. For many applied problems,
 those three views cover the questions you want to answer.
 
 The PBC (primary biliary cirrhosis) dataset from `randomForestSRC` has
-418 patients, seven predictors, and a Surv-encoded outcome of days to
-event (death or transplant, status ∈ {0, 1, 2}). We use a small
-seven-variable subset so the vignette fits quickly. For a full
+418 patients, 17 predictors, and a Surv-encoded outcome of days to
+death (`status` is 1 for death and 0 for censored; the 25 transplants are
+coded as censored). We use a five-predictor subset (`age`, `albumin`,
+`bili`, `edema`, `platelet`) so the vignette fits quickly. For a full
 analysis including time-dependent covariates, @Lee:2021 demonstrates the
 boosted nonparametric hazard framework that varPro's survival path draws
 on.
@@ -580,7 +581,8 @@ plot(gg_pd_pbc)
 ## Anomaly scoring: `gg_isopro()` on the X-matrix
 
 Because `isopro()` only sees the predictor matrix, it doesn't care
-about the family. The same call from section 3 works here.
+about the family. The same call from the Boston anomaly-scoring section
+works here.
 
 ```{r pbc-isopro, cache=TRUE}
 # Precomputed offline (see precompute_varpro.R); falls back to a live fit.
@@ -713,16 +715,15 @@ how much competes.
 
 ## Factor-level ordering
 
-Across `gg_beta_varpro()` and `gg_ivarpro()`, the `variable` column is
-stored as a factor whose levels are set by descending aggregate
-importance (`mean(|imp|)` summed across classes for classification).
-The default plot inherits that ordering, so faceted views show
-variables in the same row order across panels. If you re-shape the
-frame downstream and want the order preserved, keep `variable` as a
+Across `gg_vimp()`, `gg_varpro()`, `gg_beta_varpro()` and `gg_ivarpro()`,
+rows come most-important-first, but the variable column (`vars` in
+`gg_vimp()`, `variable` elsewhere) is a factor whose levels run the other
+way: the most important variable is the *last* level. For classification
+the ranking uses importance aggregated across classes. After
+`coord_flip()` the last level sits at the top of the plot, and faceted
+views share one row order across panels. If you re-shape the frame
+downstream and want the order preserved, keep the variable column as a
 factor rather than coercing to character.
-
-This convention will be propagated to `gg_vimp` and
-`plot.gg_varpro(conditional = TRUE)` in a follow-up release.
 
 ## Caching the expensive calls
 
@@ -730,11 +731,15 @@ This convention will be propagated to `gg_vimp` and
 calls. Both wrappers accept a pre-computed fit (`beta_fit`,
 `ivarpro_fit`) so you can iterate on selection, observation index, or
 cutoff without re-fitting the lasso or the local-importance machinery.
-The vignette uses this throughout: every section computes the heavy
-fit once in a `cache: true` chunk and re-uses it for every figure.
+The vignette uses this throughout: each heavy fit is computed once and
+passed in for every figure. To keep the `R CMD check` rebuild fast, those
+fits are precomputed by `precompute_varpro.R` and loaded from
+`varpro_precomputed.rds`; when the file is absent, each chunk fits live
+instead.
 
-Provenance carries `precomputed = TRUE` when the cached path was used,
-so downstream tooling can tell the two paths apart.
+Provenance carries `precomputed = TRUE` when a fit was passed in through
+`beta_fit` or `ivarpro_fit`, so downstream tooling can tell the two paths
+apart.
 
 ## Provenance shape
 


### PR DESCRIPTION
Follow-up to #282. This PR fixes the content items listed there under "Flagged for the author" that I could check against the code or against fitted output. It is **stacked on `docs/v4-no-ai-slop`** so the diff shows only this commit. When #282 merges, GitHub retargets this PR to `main`.

The #282 fixes are not repeated here: the "well before 500/200 trees" tree counts and the `gg_vimp.R` IncNodePurity/%IncMSE wording.

## Meaning-changing edits, with evidence

| Where | Was | Now | Evidence |
|---|---|---|---|
| `ggRandomForests-regression.qmd` L425 | `rm` effect strongest in low-`lstat` "(bottom-left panels)" | "(the top row of panels)", flat in "(the bottom row)" | I ran the vignette chunks up to `coplot-lstat` and read `ggplot_build()$layout`. `cut()` levels are ascending, so panels 1 to 3 (row 1) are `lstat` in (1.73, 5.68], (5.68, 8.26] and (8.26, 11.4]. A within-panel `lm(yhat ~ rm)` gives slopes 7.9, 6.5 and 5.1 on the top row and 0.5, -0.9 and 0.5 on the bottom row. |
| `R/gg_survival.R` @details | A forest-vs-KM gap means the forest "has found structure" | A calibration check, not a test of signal. A gap points to miscalibration, mostly at late times. Use `by` to compare groups | On PBC with `ntree = 200`, the largest gap between `colMeans(survival.oob)` and KM is **0.044 with the real predictors and 0.036 with two pure-noise predictors**, both at t = 4191. With `nodesize = 60` it is 0.016. A gap of that size shows up with or without signal. |
| `R/gg_isopro.R` `"unsupv"` | Splits "along the directions of highest variance" | At each split, a random subset of `ytry` features acts as pseudo-responses (about sqrt(p) by default), and the split separates them | The `varPro::isopro()` body (varPro 3.2.0) sets `ytry = min(ceiling(sqrt(ncol(data))), ncol(data) - 1)` and `mtry = Inf` and then calls `rfsrc(data = ...)` with no formula. `?rfsrc` says: "Random subsets of 'ytry' pseudo-responses are used for each 'mtry' variable." |
| `R/gg_partialpro.R` | Alias "removed in the release after v3.0.0" | "removed in a future release" | We are at 4.0.0 and the alias is still exported. I did not invent a date. |
| `varpro.qmd` PBC | "418 patients, seven predictors", outcome "death or transplant, status ∈ {0, 1, 2}", "seven-variable subset" | 418 patients and 17 predictors, `status` is 1 for death and 0 for censored, the 25 transplants are coded as censored, and a five-predictor subset (named) | `ncol(randomForestSRC::pbc)` is 19 (`days` + `status` + 17). `table(status)` is 0: 257 and 1: 161. `survival::pbc` is 232/25/161, and 257 = 232 + 25. The chunk selects `age`, `albumin`, `bili`, `edema` and `platelet`. |
| `varpro.qmd` isopro | "The same call from section 3" | "from the Boston anomaly-scoring section" | Headings are unnumbered. |
| `varpro.qmd` Caching | Every heavy fit is computed "in a `cache: true` chunk" | Fits are precomputed by `precompute_varpro.R` and loaded from `varpro_precomputed.rds`, with a live fit when the file is absent. `precomputed = TRUE` means a fit was passed via `beta_fit`/`ivarpro_fit` | The `precomputed` chunk plus `.vp$...` fallbacks in each heavy chunk. `gg_beta_varpro.R` L281/L446 and `gg_ivarpro.R` L402/485/513/521 set `precomputed = !is.null(<fit>)`. |
| `varpro.qmd` Factor-level ordering, plus `@section`/`@return` in `R/gg_ivarpro.R` and `@return` in `R/gg_beta_varpro.R` | Levels "set by descending aggregate importance"; convention "will be propagated to `gg_vimp` ... in a follow-up release" | Rows are most-important-first. Levels are **ascending**, with the most important variable **last**, so it plots at the top after `coord_flip()`. `gg_vimp()` (`vars`) and `gg_varpro()` already follow this. The follow-up-release sentence is dropped | `test_plot_conventions.R` L18/27/34/43 assert `tail(levels(...), 1)` is the top variable for `gg_vimp`, `gg_varpro`, `gg_beta_varpro` and `gg_ivarpro`, and L59 onward asserts rows are most-important-first. `gg_beta_varpro.R` L254 and L381 comment "REVERSED order used for the shared factor levels". This goes beyond the flagged line, but the roxygen stated the same wrong fact and would otherwise contradict the vignette. |
| `explainability.qmd` L72 | "off by a factor of two or three" | "off by **as much as** a factor of two or three" | See the next row. The worst ratios are 0.36 (`crim`, `nox`), which is about 2.8x. The median is about 1.7x. |
| `explainability.qmd` L220 | "The methods usually agree" | "The gap usually runs one way but not always, so check both before you report the size of an effect." | I replicated the prose's own claim. Across the 11 predictors that both methods treat as continuous (`rad` comes back categorical), with three forests (seeds 20260909, 1 and 2; `ntree = 500`; `n_eval = 25`) and the vignette's `compare()` metric, **ALE's range exceeds PD's in 9 of 11 and the median PD/ALE is 0.60**. Only `indus` (1.06) and `lstat` (1.12) exceed 1. So "nine of eleven, median near 0.6" holds, and "usually agree" contradicted it. In-vignette values: `crim` 0.38, `lstat` 1.12, `ptratio` 0.90. |

## Code fix: `plot.gg_vimp(relative)` (your choice (a), commit e0593e75)

`relative` was documented but never read, so `plot(x, relative = TRUE)` silently plotted raw VIMP. It now defaults to `FALSE`. With `TRUE`, each bar is divided by the largest VIMP in its `set` (per class for classification), so the top variable reads 1. There is a NEWS entry, and the `@param` is rewritten.

- **Why the plot computes the ratio instead of reading `rel_vimp`:** `gg_vimp()` never returns the `rel_vimp` column its code builds. The single-outcome branch adds `vars` at L225, which leaves 2 columns, so the frame always takes the pivot branch, and the `rel_vimp` branch at L310-321 never runs. Boston, PBC and iris (rfsrc) and Boston and iris (randomForest) all return `vars,set,vimp,positive`. You chose to compute in the plot and to flag the dead branch separately (a follow-up task is queued). The extractor's output is unchanged.
- **Test:** a new `test_that()` in `test_plot_layer_data.R` covers the default (raw) scale, the single-set rescale and the per-class rescale. It fails 3 expectations against the old method and passes against the new one.
- **Real fits:** the top bar reads 1 for Boston rfsrc (also with `nvar = 5`), for each iris class panel, for randomForest Boston, and through `autoplot()`.

## Questions for the maintainer (not changed)

1. ~~`plot.gg_vimp(relative)`~~ **Resolved:** implemented. See the code-fix section above.
2. `varpro.qmd` L508: "the design work for that is tracked but not yet landed". Is there an issue to link, or should the sentence go?
3. `varpro.qmd` L749: "established in v2.7.3.9012 (PR #98)". PR #98 is "varPro Phase 4c-classification: gg_beta_varpro for class family". Is that the right PR for the `cutoff` contract? The version string also carries a fourth digit.
4. The explainability numbers (9 of 11, median 0.6) now reproduce. Do you want the replication cited or scripted somewhere, or is the prose enough?
5. `gg_isopro.R` still says `"unsupv"` does better "when the anomalies follow a coherent direction". That followed from the old variance framing and has no source. Keep or cut?

## Not addressed here
- `plot.gg_brier.R` "ceiling" overlaps #280. `rhf.qmd` L297-299 needs a randomForestRHF answer. The remaining unsourced claims, the Minor grammar items and the voice items from #282 are left as they were.

## Verification
- `devtools::document()` regenerated 5 Rd files.
- `lintr::lint_package()` gives **0 lints**.
- `NOT_CRAN=true VDIFFR_RUN_TESTS=true devtools::test()` gives **FAIL 0 | SKIP 6 | PASS 2173** after the fix (2169 + 4 new expectations), with 58 warnings, the same baseline as before. The skips are the same 6 conditional skips as #282. `_snaps/snapshots` has 62 files before and after the run, and `git status` shows no snapshot changes.
- `R CMD check --as-cran` with the manual, from a `git archive` export, re-run on e0593e75: **Status: 1 NOTE**, which is only the incoming-feasibility "Number of updates in past 6 months: 8" (the same note as #282). The PDF manual builds OK. The vignette rebuild took 56 s, `--run-donttest` examples 46 s and tests 23 s. The earlier run on 97e4f768 was also 1 NOTE. The tarball is 3.8 MB and its only hidden file is `.Rinstignore`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
