### PR TITLE
docs: fix the regression vignette's flat partial dependence surface

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -85,6 +85,14 @@ ggRandomForests v4.0.0 (development)
   dropped without a warning, so the facet strips rendered as bare "1" and "3"
   instead of the intended "1 Year" and "3 Years". Corrected; the figure now
   carries the labels its code always asked for.
+* The regression vignette's partial dependence surface was flat in `rm`. It
+  overwrote `newx$rm` and called `gg_partial_rfsrc()` once per `rm` value,
+  but `newx` only sets the evaluation grid and `partial.rfsrc()` always
+  averages over the training data, so all six curves were identical. It now
+  holds `rm` fixed through `xvar2.name`, and the prose describes what the
+  corrected figure shows: a modest interaction, not a strong one. The
+  `newx` and `xvar2.name` documentation now says what `newx` does and does
+  not control.
 * Development line opened after the v3.2.0 CRAN release (forward-merged the
   v3.2.0 RMST/varPro fixes onto the dev line).
 * Begin the v4.0.0 development line: a Random Hazard Forests (RHF)

--- a/R/gg_partial_rfsrc.R
+++ b/R/gg_partial_rfsrc.R
@@ -54,10 +54,21 @@
 #'   dependence should be computed. Must be a subset of \code{rf_model$xvar.names}.
 #' @param xvar2.name Optional single character name of a grouping variable in
 #'   \code{newx}. When supplied, partial dependence is computed separately for
-#'   each unique level of this variable and a \code{grp} column is appended.
-#' @param newx Optional \code{data.frame} of predictor values to evaluate
-#'   partial effects at. Defaults to the training data stored in
-#'   \code{rf_model$xvar}. All column names must match \code{rf_model$xvar.names}.
+#'   each unique value of this column in \code{newx}, with the variable held
+#'   at that value for every training observation, and a \code{grp} column is
+#'   appended. For a continuous variable, set \code{newx[[xvar2.name]]} to a
+#'   short grid first, since every distinct value costs one more
+#'   \code{partial.rfsrc()} call.
+#' @param newx Optional \code{data.frame} that sets the evaluation grid, not
+#'   the data being averaged over. Each of \code{xvar.names} is evaluated at
+#'   the quantile grid (or unique levels) of its column in \code{newx}, and
+#'   \code{xvar2.name} takes its values from the same place. The average is
+#'   always taken over the training data held in \code{rf_model} (see
+#'   \code{\link[randomForestSRC]{partial.rfsrc}}), so overwriting any other
+#'   column of \code{newx} has no effect on \code{yhat}; to hold a second
+#'   variable fixed, pass it as \code{xvar2.name}. Defaults to
+#'   \code{rf_model$xvar}. All column names must match
+#'   \code{rf_model$xvar.names}.
 #' @param partial.time Numeric vector of desired time points for survival
 #'   forests (ignored for regression/classification).  Values are automatically
 #'   snapped to the nearest entry in \code{rf_model$time.interest}; see the

--- a/R/gg_partial_rfsrc.R
+++ b/R/gg_partial_rfsrc.R
@@ -58,7 +58,7 @@
 #'   at that value for every training observation, and a \code{grp} column is
 #'   appended. For a continuous variable, set \code{newx[[xvar2.name]]} to a
 #'   short grid first, since every distinct value costs one more
-#'   \code{partial.rfsrc()} call.
+#'   \code{partial.rfsrc()} call for each variable in \code{xvar.names}.
 #' @param newx Optional \code{data.frame} that sets the evaluation grid, not
 #'   the data being averaged over. Each of \code{xvar.names} is evaluated at
 #'   the quantile grid (or unique levels) of its column in \code{newx}, and

--- a/man/gg_partial_rfsrc.Rd
+++ b/man/gg_partial_rfsrc.Rd
@@ -27,7 +27,7 @@ each unique value of this column in \code{newx}, with the variable held
 at that value for every training observation, and a \code{grp} column is
 appended. For a continuous variable, set \code{newx[[xvar2.name]]} to a
 short grid first, since every distinct value costs one more
-\code{partial.rfsrc()} call.}
+\code{partial.rfsrc()} call for each variable in \code{xvar.names}.}
 
 \item{newx}{Optional \code{data.frame} that sets the evaluation grid, not
 the data being averaged over. Each of \code{xvar.names} is evaluated at

--- a/man/gg_partial_rfsrc.Rd
+++ b/man/gg_partial_rfsrc.Rd
@@ -23,11 +23,22 @@ dependence should be computed. Must be a subset of \code{rf_model$xvar.names}.}
 
 \item{xvar2.name}{Optional single character name of a grouping variable in
 \code{newx}. When supplied, partial dependence is computed separately for
-each unique level of this variable and a \code{grp} column is appended.}
+each unique value of this column in \code{newx}, with the variable held
+at that value for every training observation, and a \code{grp} column is
+appended. For a continuous variable, set \code{newx[[xvar2.name]]} to a
+short grid first, since every distinct value costs one more
+\code{partial.rfsrc()} call.}
 
-\item{newx}{Optional \code{data.frame} of predictor values to evaluate
-partial effects at. Defaults to the training data stored in
-\code{rf_model$xvar}. All column names must match \code{rf_model$xvar.names}.}
+\item{newx}{Optional \code{data.frame} that sets the evaluation grid, not
+the data being averaged over. Each of \code{xvar.names} is evaluated at
+the quantile grid (or unique levels) of its column in \code{newx}, and
+\code{xvar2.name} takes its values from the same place. The average is
+always taken over the training data held in \code{rf_model} (see
+\code{\link[randomForestSRC]{partial.rfsrc}}), so overwriting any other
+column of \code{newx} has no effect on \code{yhat}; to hold a second
+variable fixed, pass it as \code{xvar2.name}. Defaults to
+\code{rf_model$xvar}. All column names must match
+\code{rf_model$xvar.names}.}
 
 \item{partial.time}{Numeric vector of desired time points for survival
 forests (ignored for regression/classification).  Values are automatically

--- a/tests/testthat/test_gg_partial_rfsrc.R
+++ b/tests/testthat/test_gg_partial_rfsrc.R
@@ -67,3 +67,29 @@ test_that("gg_partial_rfsrc rejects a non-rfsrc rf_model with a package error", 
   )
   expect_error(gg_partial_rfsrc(NULL), "expected an 'rfsrc' object")
 })
+
+test_that("gg_partial_rfsrc averages over the training data, not newx", {
+  # newx sets only the evaluation grid. Overwriting a non-target column must
+  # leave yhat unchanged; holding that column fixed through xvar2.name must
+  # move it. The regression vignette's surface once relied on the first and
+  # drew a flat figure.
+  set.seed(303)
+  n <- 200
+  d <- data.frame(x1 = runif(n), x2 = runif(n))
+  d$y <- 5 * d$x1 + 10 * (d$x2 > 0.5) + rnorm(n, sd = 0.1)
+  rf <- randomForestSRC::rfsrc(y ~ ., data = d, ntree = 50)
+
+  base <- gg_partial_rfsrc(rf, xvar.names = "x1", n_eval = 5)
+
+  newx <- rf$xvar
+  newx$x2 <- 0.9
+  ignored <- gg_partial_rfsrc(rf, xvar.names = "x1", newx = newx, n_eval = 5)
+  expect_equal(ignored$continuous$yhat, base$continuous$yhat)
+
+  newx$x2 <- rep_len(c(0.1, 0.9), nrow(newx))
+  grouped <- gg_partial_rfsrc(rf, xvar.names = "x1", xvar2.name = "x2",
+                              newx = newx, n_eval = 5)
+  cont <- grouped$continuous
+  expect_setequal(unique(cont$grp), c(0.1, 0.9))
+  expect_gt(mean(cont$yhat[cont$grp == 0.9] - cont$yhat[cont$grp == 0.1]), 5)
+})

--- a/vignettes/ggRandomForests-regression.qmd
+++ b/vignettes/ggRandomForests-regression.qmd
@@ -468,8 +468,8 @@ lines are close to parallel. Value falls by about 12 thousand dollars as
 
 So the interaction the forest itself carries between `lstat` and `rm` is
 modest: holding everything else as observed, moving from the smallest to the
-largest homes adds 10.4 thousand dollars in the highest-status tracts and
-8.1 in the lowest. The coplots above suggested something stronger, and the
+largest homes adds 10.4 thousand dollars at the low end of the `lstat` axis,
+2 percent, and 8.1 at the high end, 38 percent. The coplots above suggested something stronger, and the
 two views answer different questions. A coplot conditions on tracts that
 exist, and large homes in high-`lstat` tracts are rare, so each panel mixes
 the `rm` effect with everything else that differs between those tracts.

--- a/vignettes/ggRandomForests-regression.qmd
+++ b/vignettes/ggRandomForests-regression.qmd
@@ -432,33 +432,51 @@ To visualize the joint partial dependence of `medv` on `lstat` and `rm`, we
 compute partial dependence on a grid: 6 values of `rm`, each evaluated at 25
 points along `lstat`.
 
-```{r surface-data, cache=TRUE}
+```{r surface-data}
 rm_grid <- quantile_pts(rfsrc_Boston$xvar$rm, groups = 6)
 
-surface_list <- lapply(rm_grid, function(rm_val) {
-  newx <- rfsrc_Boston$xvar
-  newx$rm <- rm_val
-  pd_rm <- gg_partial_rfsrc(rfsrc_Boston, xvar.names = "lstat", newx = newx)
-  df <- pd_rm$continuous
-  df$rm <- rm_val
-  df
-})
+# newx only sets the evaluation grid: the lstat quantile points, and the
+# distinct rm values to condition on through xvar2.name. The average itself
+# always runs over the training data, so overwriting newx$rm alone would
+# change nothing.
+newx <- rfsrc_Boston$xvar
+newx$rm <- rep_len(rm_grid, nrow(newx))
 
-surface_df <- bind_rows(surface_list)
+pd_surface <- gg_partial_rfsrc(rfsrc_Boston, xvar.names = "lstat",
+                               xvar2.name = "rm", newx = newx)
+surface_df <- pd_surface$continuous
+surface_df$rm <- surface_df$grp
 ```
 
-```{r pd-surface, fig.cap="Partial dependence surface: median home value as a function of lstat and rm. Fill color is the predicted median value."}
-ggplot(surface_df, aes(x = x, y = rm, fill = yhat)) +
-  geom_tile() +
-  scale_fill_viridis_c(name = "Median Value\n($1000s)") +
-  labs(x = "Lower Status (%)", y = "Rooms per Dwelling") +
+```{r pd-surface, fig.cap="Partial dependence of median home value on lstat, one line for each of six rm values held fixed across all tracts."}
+ggplot(surface_df, aes(x = x, y = yhat, color = factor(round(rm, 2)))) +
+  geom_line(linewidth = 1) +
+  scale_color_viridis_d(name = "Rooms per\nDwelling") +
+  labs(x = st_labs["lstat"], y = st_labs["medv"]) +
   theme_bw()
 ```
 
-The surface confirms the strong interaction: home values are highest when `lstat`
-is low and `rm` is high (upper-left corner), dropping steeply along both axes.
-The non-planar curvature, particularly the sharp step near `rm` = 7, is the
-kind of non-linear structure that random forests capture naturally.
+Each line is one value of `rm`, held fixed for every tract while `lstat`
+sweeps its range. Two things stand out. The four lowest lines, `rm` from 3.6
+to 6.4 rooms, nearly coincide; the room effect only appears above that,
+averaging about 2 thousand dollars more at 6.75 rooms and another 5.5 at
+8.8, with the larger gaps at low `lstat`. That is the
+threshold the one-variable partial dependence curve for `rm` showed. And the
+lines are close to parallel. Value falls by about 12 thousand dollars as
+`lstat` climbs from 2 to 38 percent at every `rm` up to 6.75, and by 14.5 at
+8.8 rooms, with most of the drop coming before `lstat` reaches 15 percent.
+
+So the interaction the forest itself carries between `lstat` and `rm` is
+modest: holding everything else as observed, moving from the smallest to the
+largest homes adds 10.4 thousand dollars in the highest-status tracts and
+8.1 in the lowest. The coplots above suggested something stronger, and the
+two views answer different questions. A coplot conditions on tracts that
+exist, and large homes in high-`lstat` tracts are rare, so each panel mixes
+the `rm` effect with everything else that differs between those tracts.
+Partial dependence scores every tract at every (`lstat`, `rm`) pair, which
+isolates the forest's response to the two variables but also scores
+combinations the data never contain, such as nine-room homes in the poorest
+tracts.
 
 # Conclusion
 
@@ -473,8 +491,10 @@ We have walked a full random forest regression analysis with
   same shapes the raw-data EDA hinted at.
 - Partial dependence from `gg_partial_rfsrc()` gave the risk-adjusted version
   of those curves: steep then flat for `lstat`, threshold-like for `rm`.
-- Conditioning plots and the partial dependence surface pulled out the `lstat`--`rm`
-  interaction, with the room-size effect strongest in high-status tracts.
+- Conditioning plots suggested an `lstat`--`rm` interaction. The partial
+  dependence surface shows the forest's own version is modest: the two
+  effects are close to additive, with the room-size effect only slightly
+  larger in high-status tracts.
 
 Notice the pattern in all of this. Each `gg_*()` function returns a tidy
 object (often a data frame, sometimes a small list of data frames); the


### PR DESCRIPTION
**Stacked on `fix/regression-vignette-seed`**, which edits the same file and has no PR yet (it also carries #282's commits). Once that branch merges, GitHub retargets this one to `main`.

## The bug

The `surface-data` chunk overwrote `newx$rm` and called `gg_partial_rfsrc(..., xvar.names = "lstat", newx = newx)` once per `rm` value. `newx` only sets the evaluation grid (`make_eval_grid()`), and `partial.rfsrc()` always averages over the training data, so all six columns of the surface were identical. On the seeded fit, `yhat` ran from 31.3 at `lstat` 1.7 to 19.0 at 38 in every `rm` column. The tile plot was flat in `rm`. The prose ("sharp step near `rm` = 7", "dropping steeply along both axes") and the conclusion bullet described structure the figure did not have.

## Changes

- **Vignette chunk**: holds `rm` fixed through `xvar2.name = "rm"`, with `newx$rm <- rep_len(rm_grid, nrow(newx))`, and maps `grp` to `rm`. Drops `cache=TRUE`: knitr keys the cache on chunk code only, so the chunk would serve a stale surface after an upstream fit change, and it now takes 0.3 s.
- **Figure**: one line per `rm` value instead of `geom_tile`. The `lstat` grid is spaced by quantiles, and a plain `geom_tile` takes one width from the smallest gap, which leaves gaps between cells (the problem `plot.gg_ale_interaction` already works around). Parallel lines also make the actual finding easy to read.
- **Prose and conclusion**, rewritten against the corrected figure:
  - `rm` 3.6 to 6.4 nearly coincide, and the room effect appears above that.
  - The `lstat` drop is about 12 at every `rm` up to 6.75, and 14.5 at 8.8.
  - So the interaction is modest and the two effects are close to additive.
  - A short paragraph explains why the coplots suggested more: they condition on the tracts that exist, while partial dependence scores every (`lstat`, `rm`) pair.
- **`@param newx` / `@param xvar2.name`**: the old wording ("predictor values to evaluate partial effects at") invites exactly this pattern. Now says `newx` sets the evaluation grid, not the data being averaged over, and points to `xvar2.name` for holding a second variable fixed.
- **Test** (`test_gg_partial_rfsrc.R`): pins the contract. Overwriting a non-target `newx` column leaves `yhat` unchanged, and conditioning through `xvar2.name` moves it.
- NEWS bullet under 4.0.0. No version bump.

## Verification

- `devtools::document()`: only `man/gg_partial_rfsrc.Rd` changed.
- `lintr::lint_package()`: 0 lints.
- `NOT_CRAN=true VDIFFR_RUN_TESTS=true devtools::test()`: FAIL 0 | WARN 58 | SKIP 6 | PASS 2172.
  - No snapshot deletions (`git status` clean apart from the intended files).
  - All 6 skips are deliberate: dev-version NEWS, an opt-in slow test, 3 superseded tests, and 1 check-only test.
  - The warnings are existing ggplot `loess` messages.
- `R CMD check --as-cran` with the manual, from a `git archive` export: 0 errors, 0 warnings, 1 NOTE.
  - The NOTE is CRAN incoming's "Number of updates in past 6 months: 8", which is informational.
  - Vignette rebuild [54s/60s], tests [25s/30s], `--run-donttest` examples [37s/38s].
  - Tarball 3.99 MB; `tar tzf` shows only `.Rinstignore` as a hidden file.
- Standalone render of the regression vignette: 16.6 s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)