### PR TITLE
fix: remove gg_vimp's unreachable rel_vimp branch; correct @return

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,7 +5,8 @@ ggRandomForests v4.0.0 (development)
 ====================================
 * `gg_vimp()` drops code that was meant to add a `rel_vimp` column but could
   never run: every fit, single-outcome included, takes the pivot branch, so no
-  fitted forest ever returned it. Output is unchanged for fitted forests. The
+  forest with stored importance ever returned it, and their output is
+  unchanged. The
   `@return` now lists the columns actually returned (`vars`, `set`, `vimp`,
   `positive`), and the `NA` placeholder for a `randomForest` fit without
   stored importance no longer carries an all-`NA` `rel_vimp` column.

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,12 @@ Version: 4.0.0
 
 ggRandomForests v4.0.0 (development)
 ====================================
+* `gg_vimp()` drops code that was meant to add a `rel_vimp` column but could
+  never run: every fit, single-outcome included, takes the pivot branch, so no
+  fitted forest ever returned it. Output is unchanged for fitted forests. The
+  `@return` now lists the columns actually returned (`vars`, `set`, `vimp`,
+  `positive`), and the `NA` placeholder for a `randomForest` fit without
+  stored importance no longer carries an all-`NA` `rel_vimp` column.
 * New `gg_ale_rfsrc()` computes Accumulated Local Effects (Apley and Zhu,
   2020) for regression and classification forests, as a counterpart to
   `gg_partial_rfsrc()`. Partial dependence averages the forest's prediction

--- a/R/gg_vimp.R
+++ b/R/gg_vimp.R
@@ -75,10 +75,12 @@
 #' \code{positive} column and colored differently by
 #' \code{\link{plot.gg_vimp}}.
 #'
-#' @return \code{gg_vimp} object. A \code{data.frame} of VIMP measures, in rank
-#'   order, optionally containing class-specific scores and a relative importance
-#'   column. When \code{randomForest} objects lack stored importance values a
-#'   warning is issued and \code{NA} placeholders are returned so plots remain
+#' @return \code{gg_vimp} object. A \code{data.frame} of VIMP measures in rank
+#'   order, with columns \code{vars}, \code{set} (the importance measure; for
+#'   classification, one set per class plus the overall measure), \code{vimp}
+#'   and \code{positive}. When \code{randomForest} objects lack stored
+#'   importance values a warning is issued and \code{NA} placeholders (columns
+#'   \code{vimp}, \code{vars} and \code{positive}) are returned so plots remain
 #'   reproducible.
 #'
 #' @seealso \code{\link{plot.gg_vimp}} \code{\link[randomForestSRC]{rfsrc}}
@@ -236,6 +238,8 @@ gg_vimp.rfsrc <- function(object, nvar, ...) {
 
   # Multi-class forests: $importance is a matrix (vars × classes).
   # Pivot to long form so each row is one (variable, class) combination.
+  # Single-outcome frames land here too: the `vars` column added above makes
+  # them two columns wide, and the pivot gives them set = "VIMP".
   if (ncol(gg_dta) > 1) {
     arg_set <- list(...)
 
@@ -307,17 +311,6 @@ gg_vimp.rfsrc <- function(object, nvar, ...) {
     )
     gg_dta <- gg_dta[order(gg_dta$vimp, decreasing = TRUE), ]
     gg_dta$vars <- factor(gg_dta$vars)
-  } else {
-    # Single-outcome: compute relative VIMP (each value as a fraction of the
-    # top-ranked variable's importance).
-    cnms <- colnames(gg_dta)
-    gg_dta <- cbind(gg_dta, gg_dta / gg_dta[1, 1])
-    colnames(gg_dta) <- c(cnms, "rel_vimp")
-    # Patch any NA entries in the vars column that slipped through.
-    gg_dta$vars[which(is.na(gg_dta$vars))] <-
-      rownames(gg_dta)[which(is.na(gg_dta$vars))]
-
-    gg_dta <- gg_dta[seq_len(nvar), ]
   }
 
   # Convert vars to an ordered factor (reversed so the most important variable
@@ -433,8 +426,7 @@ gg_vimp.randomForest <- function(object, nvar, ...) {
       )
       placeholder <- data.frame(
         vimp = rep(NA_real_, length(vars)),
-        vars = vars,
-        rel_vimp = NA_real_
+        vars = vars
       )
       placeholder$vars <- factor(placeholder$vars, levels = rev(unique(placeholder$vars)))
       placeholder$positive <- FALSE
@@ -543,10 +535,6 @@ gg_vimp.randomForest <- function(object, nvar, ...) {
     )
     gg_dta <- gg_dta[order(gg_dta$vimp, decreasing = TRUE), ]
     gg_dta$vars <- factor(gg_dta$vars)
-  } else {
-    gg_dta$vars[which(is.na(gg_dta$vars))] <-
-      rownames(gg_dta)[which(is.na(gg_dta$vars))]
-    gg_dta <- gg_dta[seq_len(nvar), ]
   }
 
   gg_dta$vars <-

--- a/R/gg_vimp.R
+++ b/R/gg_vimp.R
@@ -76,9 +76,12 @@
 #' \code{\link{plot.gg_vimp}}.
 #'
 #' @return \code{gg_vimp} object. A \code{data.frame} of VIMP measures in rank
-#'   order, with columns \code{vars}, \code{set} (the importance measure; for
-#'   classification, one set per class plus the overall measure), \code{vimp}
-#'   and \code{positive}. When \code{randomForest} objects lack stored
+#'   order, with columns \code{vars}, \code{set} (the importance measure),
+#'   \code{vimp} and \code{positive}. A classification forest with class-wise
+#'   permutation importance has one set per class plus the overall measure; a
+#'   \code{randomForest} classification fit grown with
+#'   \code{importance = FALSE} stores only node impurity, so it has a single
+#'   set. When \code{randomForest} objects lack stored
 #'   importance values a warning is issued and \code{NA} placeholders (columns
 #'   \code{vimp}, \code{vars} and \code{positive}) are returned so plots remain
 #'   reproducible.

--- a/man/gg_vimp.Rd
+++ b/man/gg_vimp.Rd
@@ -22,9 +22,12 @@ importance information.}
 }
 \value{
 \code{gg_vimp} object. A \code{data.frame} of VIMP measures in rank
-order, with columns \code{vars}, \code{set} (the importance measure; for
-classification, one set per class plus the overall measure), \code{vimp}
-and \code{positive}. When \code{randomForest} objects lack stored
+order, with columns \code{vars}, \code{set} (the importance measure),
+\code{vimp} and \code{positive}. A classification forest with class-wise
+permutation importance has one set per class plus the overall measure; a
+\code{randomForest} classification fit grown with
+\code{importance = FALSE} stores only node impurity, so it has a single
+set. When \code{randomForest} objects lack stored
 importance values a warning is issued and \code{NA} placeholders (columns
 \code{vimp}, \code{vars} and \code{positive}) are returned so plots remain
 reproducible.

--- a/man/gg_vimp.Rd
+++ b/man/gg_vimp.Rd
@@ -21,10 +21,12 @@ function if the \code{\link[randomForestSRC]{rfsrc}} object does not contain
 importance information.}
 }
 \value{
-\code{gg_vimp} object. A \code{data.frame} of VIMP measures, in rank
-order, optionally containing class-specific scores and a relative importance
-column. When \code{randomForest} objects lack stored importance values a
-warning is issued and \code{NA} placeholders are returned so plots remain
+\code{gg_vimp} object. A \code{data.frame} of VIMP measures in rank
+order, with columns \code{vars}, \code{set} (the importance measure; for
+classification, one set per class plus the overall measure), \code{vimp}
+and \code{positive}. When \code{randomForest} objects lack stored
+importance values a warning is issued and \code{NA} placeholders (columns
+\code{vimp}, \code{vars} and \code{positive}) are returned so plots remain
 reproducible.
 }
 \description{

--- a/tests/testthat/test_extractor_contracts.R
+++ b/tests/testthat/test_extractor_contracts.R
@@ -58,6 +58,24 @@ test_that("gg_vimp uses %IncMSE for randomForest, not IncNodePurity", {
   expect_equal(gg$vimp, unname(rf$importance[as.character(gg$vars), "%IncMSE"]))
 })
 
+test_that("gg_vimp returns vars/set/vimp/positive for every fit type", {
+  # Catches: a column documented in @return that no code path returns (the old
+  # rel_vimp), or a fit type whose frame drifts from the shared shape that
+  # plot.gg_vimp reads.
+  skip_if_not_installed("randomForestSRC")
+  skip_if_not_installed("randomForest")
+  set.seed(20260911L)
+  fits <- list(
+    randomForestSRC::rfsrc(mpg ~ ., mtcars, ntree = 20, importance = TRUE),
+    randomForestSRC::rfsrc(Species ~ ., iris, ntree = 20, importance = TRUE),
+    randomForest::randomForest(mpg ~ ., mtcars, ntree = 20, importance = TRUE),
+    randomForest::randomForest(Species ~ ., iris, ntree = 20, importance = TRUE)
+  )
+  for (rf in fits) {
+    expect_setequal(colnames(gg_vimp(rf)), c("vars", "set", "vimp", "positive"))
+  }
+})
+
 ## ---- gg_error --------------------------------------------------------------
 
 test_that("gg_error drops rfsrc's NA error rows and keeps the tree index", {

--- a/tests/testthat/test_randomForest_helpers.R
+++ b/tests/testthat/test_randomForest_helpers.R
@@ -79,5 +79,5 @@ test_that("gg_vimp falls back to placeholder when importance is unavailable", {
   rf_noimp$importance <- NULL
   expect_warning(gg_na <- gg_vimp(rf_noimp), "Returning NA values")
   expect_true(all(is.na(gg_na$vimp)))
-  expect_true(all(is.na(gg_na$rel_vimp)))
+  expect_setequal(colnames(gg_na), c("vimp", "vars", "positive"))
 })


### PR DESCRIPTION
`gg_vimp()` has code that was meant to add a `rel_vimp` column, but it can never run. This PR takes option (a) from the maintainer's decision: delete that code and correct the documentation. Nothing changes for fitted forests.

## Why the branch was dead
- **`gg_vimp.rfsrc()`:** for a single-outcome forest, the code at L221-227 renames the one importance column to `VIMP` and then adds `vars`. The frame is then two columns wide, so the `if (ncol(gg_dta) > 1)` pivot always runs, and the `else` branch that built `rel_vimp` (old L310-321) was unreachable.
- **`gg_vimp.randomForest()`:** has the same structure. The `ncol < 3` block leaves `c("vimp", "vars")`, and a wider frame is already more than one column, so its `else` (old L546-550) was unreachable too.
- **Before this change:** fits on Boston, PBC and iris (rfsrc) and on Boston and iris (randomForest) all returned `vars,set,vimp,positive`. The only `rel_vimp` anywhere was the all-`NA` one on the no-importance randomForest placeholder, and the `@return` still promised "a relative importance column".

## Changes
- `R/gg_vimp.R`: both dead `else` branches are removed. A two-line comment now says that single-outcome frames also go through the pivot and get `set = "VIMP"`.
- **Placeholder:** the randomForest NA placeholder drops `rel_vimp` and keeps `vimp`, `vars` and `positive`. This is the only change to any returned object.
- **`@return`:** now lists the columns actually returned (`vars`, `set`, `vimp`, `positive`) and the placeholder's columns.
- **Tests:** `test_randomForest_helpers.R` now asserts the placeholder's columns instead of `all(is.na(rel_vimp))`. A new test in `test_extractor_contracts.R` pins `vars/set/vimp/positive` for rfsrc regression and classification and for randomForest regression and classification.
- **NEWS:** a new entry under 4.0.0.

## Evidence that output is unchanged
I sourced `origin/main`'s `R/gg_vimp.R` next to the new code and compared the two with `identical()` on every combination:

| Fit | default | `nvar = 5` | `which.outcome = 1` |
|---|---|---|---|
| rfsrc Boston (regression) | TRUE | TRUE | n/a |
| rfsrc PBC (survival) | TRUE | TRUE | n/a |
| rfsrc iris (classification) | TRUE | TRUE | TRUE |
| randomForest Boston, `importance = TRUE` | TRUE | TRUE | n/a |
| randomForest Boston, impurity only | TRUE | TRUE | n/a |
| randomForest iris | TRUE | TRUE | TRUE |

For the NA placeholder, the old columns were `vimp vars rel_vimp positive` and the new ones are `vimp vars positive`. The two frames are `identical()` once `rel_vimp` is dropped.

**Reverse dependencies:** `tools::package_dependencies("ggRandomForests", reverse = TRUE, which = "all")` against the CRAN db returns none.

## Relation to #285
#285, now merged, makes `plot.gg_vimp(relative = TRUE)` compute relative VIMP in the plot, so nothing reads a `rel_vimp` column from `gg_vimp()`. The `rel_vimp` references left in `test_plot_layer_data.R` are synthetic input frames, and the plot overwrites that column. I merged `origin/main` (#285 and #288) into this branch as a real merge commit (`903d5097`) with no conflicts.

## Verification
- `devtools::document()` regenerated `man/gg_vimp.Rd`, and `lintr::lint_package()` gives **0 lints**.
- `NOT_CRAN=true VDIFFR_RUN_TESTS=true devtools::test()` on the merged tree (`903d5097`) gives **FAIL 0 | WARN 58 | SKIP 6 | PASS 2189**. The pre-merge branch gave 2173; the difference is the tests that came in with #285 and #288. There are 62 snapshot files before and after the run, and `git status` shows no snapshot changes.
- `R CMD check --as-cran` with the manual, from a `git archive` export of `903d5097`: **Status: 1 NOTE**. The NOTE is only CRAN incoming feasibility: "Days since last update: 0" and "Number of updates in past 6 months: 9". Both describe the CRAN submission history, not this change. The PDF manual builds OK. The vignette rebuild took 60 s, `--run-donttest` examples 43 s and tests 22 s. The tarball's only hidden file is `.Rinstignore`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
