### PR TITLE
ci(pkgdown): stop redeploying the site on a published release

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -16,8 +16,12 @@ on:
       - '.claude/**'
     branches: [main, dev]
   pull_request:
-  release:
-    types: [published]
+  # No `release:` trigger, deliberately. A release here tags a commit that is
+  # already on main, and the push that merged it has already built and deployed
+  # it. A release-triggered run can only repeat that deploy or, when main has
+  # moved on, overwrite the site with an older commit: hvtiRlifetables v0.1.3
+  # (tagged at f024064) did that on 2026-09-11 and rolled the live help pages
+  # back past the ehrlinger/hvtiRlifetables#20 fix. The site documents main.
   workflow_dispatch:
 
 name: pkgdown.yaml
@@ -55,7 +59,7 @@ jobs:
         shell: Rscript {0}
 
       # The deploy target follows the ref the run is on, NOT the event type:
-      #   - any non-dev ref (main push, release, or workflow_dispatch on main)
+      #   - any non-dev ref (a main push, or workflow_dispatch on main)
       #     -> gh-pages ROOT (the published v3.x site).
       #   - the dev ref (push or workflow_dispatch on dev) -> /dev/ (next step).
       # So a manual dispatch publishes root only when launched on a non-dev


### PR DESCRIPTION
Removes the `release: types: [published]` trigger from `pkgdown.yaml`, which redeployed the site on every published release.

A release tags a commit already on `main`, and the push that merged it has already built and deployed the site. A release-triggered run can only repeat that deploy or, once `main` has moved on, overwrite the site with an older commit. ehrlinger/hvtiRlifetables hit the second case on 2026-09-11: releasing v0.1.3 (tagged at f024064) rolled its live help pages back past the fix in ehrlinger/hvtiRlifetables#20. That repository dropped the trigger; this PR does the same here, with the same explanatory comment above `workflow_dispatch:`. The site documents `main`.

**What does not change**
- The `pull_request` trigger is untouched, so the pkgdown check still reports on every PR. No path or branch filter is added.
- `push` to `main` still deploys, and `workflow_dispatch` still allows a manual redeploy.
- No ruleset change.
- No NEWS entry or version bump: a CI-only change, following ehrlinger/hvtiR#65.
- The deploy-step comment listed `release` among the refs that publish to the gh-pages root; it no longer does.

There is a second hazard here that the release trigger carried. The root/`dev` split keys on `github.ref`, and a release run's ref is `refs/tags/<tag>`, never `refs/heads/dev`. A release tagged on `dev` would therefore have published the `dev` docs to the root site, over the v3.x reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
