### PR TITLE
ci(check-manual): drop the release trigger

### DIFF
--- a/.github/workflows/check-manual.yaml
+++ b/.github/workflows/check-manual.yaml
@@ -14,8 +14,10 @@ on:
     paths-ignore:
       - '.claude/**'
     branches: [main]
-  release:
-    types: [published]
+  # No `release:` trigger, deliberately. A release tags a commit already on
+  # main, and every push to main that can change the package has already run
+  # this check, so a release-triggered run only repeats it on the same code.
+  # The release gate is check-release.yaml, which builds the manual as well.
   workflow_dispatch:
 
 name: Check manual

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -16,12 +16,14 @@ on:
       - '.claude/**'
     branches: [main, dev]
   pull_request:
-  # No `release:` trigger, deliberately. A release here tags a commit that is
-  # already on main, and the push that merged it has already built and deployed
-  # it. A release-triggered run can only repeat that deploy or, when main has
-  # moved on, overwrite the site with an older commit: hvtiRlifetables v0.1.3
-  # (tagged at f024064) did that on 2026-09-11 and rolled the live help pages
-  # back past the ehrlinger/hvtiRlifetables#20 fix. The site documents main.
+  # No `release:` trigger, deliberately. A release of main tags a commit the
+  # merging push has already built and deployed, so a release-triggered run can
+  # only repeat that deploy or, when main has moved on, overwrite the site with
+  # an older commit: hvtiRlifetables v0.1.3 (tagged at f024064) did that on
+  # 2026-09-11 and rolled the live help pages back past the
+  # ehrlinger/hvtiRlifetables#20 fix. A release tagged on dev was worse: its
+  # ref is refs/tags/<tag>, not refs/heads/dev, so the deploy step below sent
+  # the dev docs to the root site. The site documents main.
   workflow_dispatch:
 
 name: pkgdown.yaml


### PR DESCRIPTION
Removes the `release: types: [published]` trigger from `check-manual.yaml`, the follow-up to the pkgdown change.

Unlike pkgdown, this workflow deploys nothing, so a release run could never roll anything back. It was only a repeat. A release tags a commit already on `main`, and every push to `main` that can change the package has already run this check on that code. A comment above `workflow_dispatch:` records why the trigger is absent.

**What does not change**
- `push` to `main` and `workflow_dispatch` are untouched. There is still no `pull_request` trigger, as before, so this is not a PR check and no required check is affected.
- No ruleset change.
- No NEWS entry or version bump: a CI-only change, following ehrlinger/hvtiR#65.
- The release gate here is `check-release.yaml`, which runs the full `--as-cran` check, manual included, on a published release. The comment says so.
- `pkgdown.yaml` comment, following Copilot's review of #292: it said every release tags a commit on `main`. It now says that of a release of `main`, and records the hazard a release tagged on `dev` carried: its ref is `refs/tags/<tag>`, not `refs/heads/dev`, so the deploy step would have sent the `dev` docs to the root site.

The `.claude/house-style.md` workflow table still lists `release` for this workflow and for pkgdown. That row is composed from the house-style standard, so it gets fixed there and arrives here with the next recompose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
