### PR TITLE
docs: version-qualify varPro NA and RMST-horizon notes in gg_partial_varpro

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,15 @@ Version: 4.0.0
 
 ggRandomForests v4.0.0 (development)
 ====================================
+* `?gg_partial_varpro` now separates varPro versions in its missing-data and
+  RMST-horizon notes. Before varPro 3.2.2, `varpro()` deletes incomplete cases
+  silently and drops unrecognised arguments such as `na.action`, and
+  `partialpro()` drops a horizon passed through `...`. From 3.2.2
+  (kogalur/varPro#7), `varpro()` warns with the omitted count and records it in
+  `model.info$observations`, and both functions stop with an error on an
+  argument they do not recognise. `partialpro()` still has no horizon
+  argument, so `scale = "rmst"` keeps supplying its own RMST(tau) learner.
+  Documentation only; no function changed.
 * `gg_vimp()` drops code that was meant to add a `rel_vimp` column but could
   never run: every fit, single-outcome included, takes the pivot branch, so no
   forest with stored importance ever returned it, and their output is

--- a/R/gg_partial_varpro.R
+++ b/R/gg_partial_varpro.R
@@ -229,8 +229,9 @@
 #' entries sort by importance rather than alphabetically.
 #'
 #' **Scale detection:** with \code{scale = "auto"} and an \code{object} in
-#' hand, the scale resolves to \code{"mortality"} for a survival forest and
-#' \code{"generic"} for a regression or classification forest.  We do not
+#' hand, the scale resolves to \code{"surv"} for a survival forest,
+#' \code{"prob"} for a classification forest and \code{"generic"} for a
+#' regression forest.  We do not
 #' read an RMST horizon \eqn{\tau} off the \code{varpro} object.  Before
 #' \pkg{varPro} 3.2.2 there is none to read; from 3.2.2 one is recorded only
 #' when \code{varpro} itself was fit with an \code{rmst} horizon.  So RMST

--- a/R/gg_partial_varpro.R
+++ b/R/gg_partial_varpro.R
@@ -168,19 +168,25 @@
 #' \code{randomForestSRC::rfsrc} to settle the family and hand back cleaned
 #' data, and that call takes \code{rfsrc}'s default \code{na.action =
 #' "na.omit"}.  Any case with a missing value, in a predictor or in the
-#' outcome, is deleted before the fit, with no warning and no message.
-#' Passing \code{na.action = "na.impute"} to \code{varPro::varpro} does not
-#' change this: it lands in \code{...}, never reaches the stump, and is
-#' discarded without remark (varPro 3.1.0).
+#' outcome, is deleted before the fit.  What you are told about it depends on
+#' the \pkg{varPro} version.  Before 3.2.2 the deletion is silent: no warning,
+#' no message, and \code{na.action = "na.impute"} passed to
+#' \code{varPro::varpro} lands in \code{...}, never reaches the stump, and is
+#' discarded without remark.  From 3.2.2, \code{varpro} warns with the input,
+#' omitted and retained counts, records them in
+#' \code{object$model.info$observations}, and stops with an error on
+#' \code{na.action} (or any other argument it does not recognise) instead of
+#' ignoring it.  The rows are deleted either way; 3.2.2 makes the deletion
+#' visible.
 #'
 #' The loss compounds across predictors rather than adding up.  At 5% missing
 #' per column, independently, retention is \eqn{0.95^p}: 60% of rows at 10
 #' predictors, 36% at 20, 8% at 50.  On a wide clinical frame a little
-#' missingness everywhere can delete most of the cohort.  Nothing in the fit
-#' records it: \code{object$rf$n} is the count \emph{after} deletion and no
-#' original is kept, so neither you nor this package can recover the number
-#' from the object.  Check before you fit: \code{nrow(dta)} against
-#' \code{sum(complete.cases(dta))}.
+#' missingness everywhere can delete most of the cohort.  Before 3.2.2 nothing
+#' in the fit records it: \code{object$rf$n} is the count \emph{after}
+#' deletion and no original is kept, so neither you nor this package can
+#' recover the number from the object.  On any version, check before you fit:
+#' \code{nrow(dta)} against \code{sum(complete.cases(dta))}.
 #'
 #' **Imputing first, without inventing outcomes:** \code{varPro::roughfix}
 #' does mean and modal fill, \code{randomForestSRC::impute} does the
@@ -224,16 +230,18 @@
 #'
 #' **Scale detection:** with \code{scale = "auto"} and an \code{object} in
 #' hand, the scale resolves to \code{"mortality"} for a survival forest and
-#' \code{"generic"} for a regression or classification forest.  The RMST
-#' horizon \eqn{\tau} is \emph{not} stored in the \code{varpro} object
-#' (varPro 3.1.0), so RMST output requires you to pass
-#' \code{scale = "rmst", time = tau} explicitly.
+#' \code{"generic"} for a regression or classification forest.  We do not
+#' read an RMST horizon \eqn{\tau} off the \code{varpro} object.  Before
+#' \pkg{varPro} 3.2.2 there is none to read; from 3.2.2 one is recorded only
+#' when \code{varpro} itself was fit with an \code{rmst} horizon.  So RMST
+#' output requires you to pass \code{scale = "rmst", time = tau} explicitly.
 #'
 #' **RMST partial dependence (scale = "rmst"):** \code{varPro::partialpro}
 #' has no time argument, so its default survival learner returns ensemble
-#' mortality at every horizon; passing a horizon through \code{...} is
-#' silently dropped, and multi-horizon plots built that way differ only by
-#' Monte-Carlo noise, not by \eqn{\tau}.  To get a genuine RMST(\eqn{\tau})
+#' mortality at every horizon.  Before \pkg{varPro} 3.2.2 a horizon passed
+#' through \code{...} is silently dropped, and multi-horizon plots built that
+#' way differ only by Monte-Carlo noise, not by \eqn{\tau}; from 3.2.2
+#' \code{partialpro} stops with an error instead.  To get a genuine RMST(\eqn{\tau})
 #' curve, \code{scale = "rmst"} supplies \code{partialpro} a \code{learner}
 #' that returns \eqn{\mathrm{RMST}(\tau)=\int_0^\tau S(t)\,dt} from the
 #' survival forest, so the curve actually depends on \eqn{\tau}.  This path

--- a/man/gg_partial_varpro.Rd
+++ b/man/gg_partial_varpro.Rd
@@ -155,19 +155,25 @@ entry point opens by growing a one-node stump through
 \code{randomForestSRC::rfsrc} to settle the family and hand back cleaned
 data, and that call takes \code{rfsrc}'s default \code{na.action =
 "na.omit"}.  Any case with a missing value, in a predictor or in the
-outcome, is deleted before the fit, with no warning and no message.
-Passing \code{na.action = "na.impute"} to \code{varPro::varpro} does not
-change this: it lands in \code{...}, never reaches the stump, and is
-discarded without remark (varPro 3.1.0).
+outcome, is deleted before the fit.  What you are told about it depends on
+the \pkg{varPro} version.  Before 3.2.2 the deletion is silent: no warning,
+no message, and \code{na.action = "na.impute"} passed to
+\code{varPro::varpro} lands in \code{...}, never reaches the stump, and is
+discarded without remark.  From 3.2.2, \code{varpro} warns with the input,
+omitted and retained counts, records them in
+\code{object$model.info$observations}, and stops with an error on
+\code{na.action} (or any other argument it does not recognise) instead of
+ignoring it.  The rows are deleted either way; 3.2.2 makes the deletion
+visible.
 
 The loss compounds across predictors rather than adding up.  At 5\% missing
 per column, independently, retention is \eqn{0.95^p}: 60\% of rows at 10
 predictors, 36\% at 20, 8\% at 50.  On a wide clinical frame a little
-missingness everywhere can delete most of the cohort.  Nothing in the fit
-records it: \code{object$rf$n} is the count \emph{after} deletion and no
-original is kept, so neither you nor this package can recover the number
-from the object.  Check before you fit: \code{nrow(dta)} against
-\code{sum(complete.cases(dta))}.
+missingness everywhere can delete most of the cohort.  Before 3.2.2 nothing
+in the fit records it: \code{object$rf$n} is the count \emph{after}
+deletion and no original is kept, so neither you nor this package can
+recover the number from the object.  On any version, check before you fit:
+\code{nrow(dta)} against \code{sum(complete.cases(dta))}.
 
 \strong{Imputing first, without inventing outcomes:} \code{varPro::roughfix}
 does mean and modal fill, \code{randomForestSRC::impute} does the
@@ -211,16 +217,18 @@ entries sort by importance rather than alphabetically.
 
 \strong{Scale detection:} with \code{scale = "auto"} and an \code{object} in
 hand, the scale resolves to \code{"mortality"} for a survival forest and
-\code{"generic"} for a regression or classification forest.  The RMST
-horizon \eqn{\tau} is \emph{not} stored in the \code{varpro} object
-(varPro 3.1.0), so RMST output requires you to pass
-\code{scale = "rmst", time = tau} explicitly.
+\code{"generic"} for a regression or classification forest.  We do not
+read an RMST horizon \eqn{\tau} off the \code{varpro} object.  Before
+\pkg{varPro} 3.2.2 there is none to read; from 3.2.2 one is recorded only
+when \code{varpro} itself was fit with an \code{rmst} horizon.  So RMST
+output requires you to pass \code{scale = "rmst", time = tau} explicitly.
 
 \strong{RMST partial dependence (scale = "rmst"):} \code{varPro::partialpro}
 has no time argument, so its default survival learner returns ensemble
-mortality at every horizon; passing a horizon through \code{...} is
-silently dropped, and multi-horizon plots built that way differ only by
-Monte-Carlo noise, not by \eqn{\tau}.  To get a genuine RMST(\eqn{\tau})
+mortality at every horizon.  Before \pkg{varPro} 3.2.2 a horizon passed
+through \code{...} is silently dropped, and multi-horizon plots built that
+way differ only by Monte-Carlo noise, not by \eqn{\tau}; from 3.2.2
+\code{partialpro} stops with an error instead.  To get a genuine RMST(\eqn{\tau})
 curve, \code{scale = "rmst"} supplies \code{partialpro} a \code{learner}
 that returns \eqn{\mathrm{RMST}(\tau)=\int_0^\tau S(t)\,dt} from the
 survival forest, so the curve actually depends on \eqn{\tau}.  This path

--- a/man/gg_partial_varpro.Rd
+++ b/man/gg_partial_varpro.Rd
@@ -216,8 +216,9 @@ order when no \code{object} was supplied), so facet panels and legend
 entries sort by importance rather than alphabetically.
 
 \strong{Scale detection:} with \code{scale = "auto"} and an \code{object} in
-hand, the scale resolves to \code{"mortality"} for a survival forest and
-\code{"generic"} for a regression or classification forest.  We do not
+hand, the scale resolves to \code{"surv"} for a survival forest,
+\code{"prob"} for a classification forest and \code{"generic"} for a
+regression forest.  We do not
 read an RMST horizon \eqn{\tau} off the \code{varpro} object.  Before
 \pkg{varPro} 3.2.2 there is none to read; from 3.2.2 one is recorded only
 when \code{varpro} itself was fit with an \code{rmst} horizon.  So RMST


### PR DESCRIPTION
## What

`?gg_partial_varpro` described varPro's missing-data and RMST-horizon behaviour as of varPro 3.1.0. varPro 3.2.2 (kogalur/varPro#7, posted to `develop` 2026-09-12, not yet on CRAN) changes that behaviour, so three Details passages now say which version does what. `Imports` stays at `varPro (>= 3.1.0)`, so the old behaviour is still true for some users and stays documented.

| Passage | Before 3.2.2 | From 3.2.2 |
|---|---|---|
| Which rows you actually get | incomplete cases deleted silently; `na.action` dropped | `varpro()` warns with input/omitted/retained counts, records them in `model.info$observations`, errors on `na.action` |
| Scale detection | no horizon stored on the fit | horizon recorded only when `varpro()` was fit with `rmst`; we still do not read it |
| RMST partial dependence | a horizon through `...` is silently dropped | `partialpro()` errors on it |

`partialpro()` still has no horizon argument, so `scale = "rmst"` keeps supplying its own RMST(tau) learner. One NEWS bullet under 4.0.0. Documentation only; no function, argument or returned object changed.

## Evidence

- Behaviour checked against both versions: CRAN 3.2.0 returns 111 of 153 `airquality` rows with no warning, has no `model.info`, and accepts `partialpro(..., RMST = 5)` silently; 3.2.2 warns `omitted 42 of 153 observations with missing values (111 retained)`, records the counts, and stops with `unrecognized argument(s): RMST`.
- ggRF's `.rmst_from_survival()` matches 3.2.2's left-endpoint `varPro:::get.rmst()` exactly (max abs diff 0 at tau = 500, 1500, 3000 on `pbc`).
- The varPro-related test files (456 blocks, vdiffr on) pass against varPro 3.2.2 with 0 failures, 0 errors.

## Checks on this branch

- `devtools::document()`: only `man/gg_partial_varpro.Rd` regenerated
- `lintr::lint_package()`: 0 lints
- `NOT_CRAN=true VDIFFR_RUN_TESTS=true devtools::test(filter = "gg_partial_varpro|news|version")`: 114 blocks, 0 fail, 0 error, 0 skip
- `tools::checkRd()` on the regenerated Rd: clean
- `R CMD check --as-cran` (with manual, from a `git archive` build): 0 errors, 0 warnings, 1 NOTE (CRAN incoming feasibility: days since last update / updates in past 6 months, not a package defect); PDF manual built; tarball carries no hidden files other than `.Rinstignore`

No version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
